### PR TITLE
Fix Venti C4 giving the wrong damage buff.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://frzyc.github.io/genshin-optimizer/",
   "name": "genshin-optimizer",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/src/Data/Characters/Venti/index.js
+++ b/src/Data/Characters/Venti/index.js
@@ -252,7 +252,7 @@ const char = {
           sourceKey: "venti",
           maxStack: 1,
           stats: {
-            anemo_dmg_: 15,
+            anemo_dmg_: 25,
           },
           fields: [{
             text: "Duration",


### PR DESCRIPTION
The text reads:

> When Venti picks up an Elemental Orb or Particle, he receives a 25% Anemo DMG Bonus for 10s.

But the value provided was actually 15%.