### PR TITLE
WIP: Added full talent data for Razor.

### DIFF
--- a/src/Data/Characters/Razor/data.js
+++ b/src/Data/Characters/Razor/data.js
@@ -81,7 +81,10 @@ const formula = {
   },
   c6: {
     dmg: () => {
-      const f = (stats) => stats.characterATK * data.c6.dmg / 100;
+      const f = (stats) => {
+        const multi = (1 + (stats.dmg_ + stats.electro_dmg_) / 100);
+        return stats.characterATK * (data.c6.dmg / 100) * multi;
+      };
       const d = ['characterATK'];
       return [f, d];
     }

--- a/src/Data/Characters/Razor/data.js
+++ b/src/Data/Characters/Razor/data.js
@@ -30,21 +30,11 @@ const data = {
   skill: {
     press: [199.2, 214.14, 229.08, 249, 263.94, 278.88, 298.8, 318.72, 338.64, 358.56, 378.48, 398.4, 423.3, 448.2, 473.1],
     hold: [295.2, 317.34, 339.48, 369, 391.14, 413.28, 442.8, 472.32, 501.84, 531.36, 560.88, 590.4, 627.3, 664.2, 701.1],
-    cd: {
-      a1: 0.82, // 100% - 18%
-      press: 6,
-      hold: 10,
-    }
   },
   burst: {
     summon: [160, 172, 184, 200, 212, 224, 240, 256, 272, 288, 304, 320, 340, 360, 380],
     dmg: [24, 25.8, 27.6, 30, 31.8, 33.6, 36, 38.4, 40.8, 43.2, 45.6, 48, 51, 54, 57],
     atkspd: [26, 28, 30, 32, 34, 36, 37, 38, 39, 40, 40, 40, 40, 40, 40],
-  },
-  c6: {
-    dmg: 100,
-    cd: 10,
-    sigils: 1,
   }
 }
 
@@ -53,41 +43,17 @@ const formula = {
     basicDMGFormula(percentArr[tlvl], stats, "normal")])),
   charged: Object.fromEntries(Object.entries(data.charged).map(([name, arr]) =>
     [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "charged")])),
-  plunging: {
-    dmg: (tlvl, stats) => basicDMGFormula(data.plunging.dmg[tlvl], stats, "plunging"),
-    low: (tlvl, stats) => basicDMGFormula(data.plunging.low[tlvl], stats, "plunging"),
-    high: (tlvl, stats) => basicDMGFormula(data.plunging.high[tlvl], stats, "plunging"),
-  },
+  plunging: Object.fromEntries(Object.entries(data.plunging).map(([key, arr]) => [key, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "plunging")])),
   skill: {
     press: (tlvl, stats) => basicDMGFormula(data.skill.press[tlvl], stats, "skill"),
     hold: (tlvl, stats) => basicDMGFormula(data.skill.hold[tlvl], stats, "skill"),
-    cd: {
-      press: () => {
-        const f = (stats) => data.skill.cd.press * (stats.ascension >= 1 ? data.skill.cd.a1 : 1);
-        const d = ['ascension'];
-        return [f, d];
-      },
-      hold: () => {
-        const f = (stats) => data.skill.cd.hold * (stats.ascension >= 1 ? data.skill.cd.a1 : 1);
-        const d = ['ascension'];
-        return [f, d];
-      }
-    }
   },
   burst: {
     summon: (tlvl, stats) => basicDMGFormula(data.burst.summon[tlvl], stats, "burst"),
     dmg: (tlvl, stats) => basicDMGFormula(data.burst.dmg[tlvl], stats, "burst"),
-    atkspd: (tlvl, stats) => [() => data.burst.atkspd[tlvl], [""]],
   },
-  c6: {
-    dmg: () => {
-      const f = (stats) => {
-        const multi = (1 + (stats.dmg_ + stats.electro_dmg_) / 100);
-        return stats.characterATK * (data.c6.dmg / 100) * multi;
-      };
-      const d = ['characterATK'];
-      return [f, d];
-    }
+  constellation6: {
+    dmg: (tlvl, stats) => basicDMGFormula(data.burst.summon[tlvl], stats, "burst"),
   }
 }
 

--- a/src/Data/Characters/Razor/data.js
+++ b/src/Data/Characters/Razor/data.js
@@ -1,0 +1,94 @@
+import { basicDMGFormula } from "../../../Util/FormulaUtil"
+
+const data = {
+  baseStat: {
+    characterHP: [1003, 2577, 3326, 4982, 5514, 6343, 7052, 7881, 8413, 9241, 9773, 10602, 11134, 11962],
+    characterATK: [20, 50, 65, 97, 108, 124, 138, 154, 164, 180, 191, 207, 217, 234],
+    characterDEF: [61, 158, 211, 315, 352, 405, 455, 509, 546, 600, 637, 692, 729, 784]
+  },
+  specializeStat: {
+    key: "physical_dmg_",
+    value: [0, 0, 0, 0, 7.5, 7.5, 15, 15, 15, 15, 22.5, 22.5, 30, 30]
+  },
+  normal: {
+    hitArr: [
+      [95.92, 102.46, 109, 117.72, 124.26, 131.89, 141.7, 151.51, 161.32, 171.13, 180.94, 190.75, 200.56, 210.37, 220.18],
+      [82.63, 88.27, 93.9, 101.41, 107.05, 113.62, 122.07, 130.52, 138.97, 147.42, 155.87, 164.33, 172.78, 181.23, 189.68],
+      [103.31, 110.36, 117.4, 126.79, 133.84, 142.05, 152.62, 163.19, 173.75, 184.32, 194.88, 205.45, 216.02, 226.58, 237.15],
+      [136.05, 145.32, 154.6, 166.97, 176.24, 187.07, 200.98, 214.89, 228.81, 242.72, 256.64, 270.55, 284.46, 298.38, 312.29],
+    ]
+  },
+  charged: {
+    spinning: [62.54, 67.63, 72.72, 79.99, 85.08, 90.9, 98.9, 106.9, 114.9, 123.62, 132.35, 141.08, 149.8, 158.53, 167.26],
+    final: [113.09, 122.3, 131.5, 144.65, 153.86, 164.38, 178.84, 193.31, 207.77, 223.55, 239.33, 255.11, 270.89, 286.67, 302.45]
+  },
+  plunging: {
+    dmg: [82.05, 88.72, 95.4, 104.94, 111.62, 119.25, 129.75, 140.24, 150.74, 162.19, 173.63, 185.08, 196.53, 207.98, 219.43],
+    low: [164.06, 177.41, 190.77, 209.84, 223.2, 238.46, 259.44, 280.43, 301.41, 324.3, 347.19, 370.09, 392.98, 415.87, 438.76],
+    high: [204.92, 221.6, 238.28, 262.1, 278.78, 297.85, 324.06, 350.27, 376.48, 405.07, 433.66, 462.26, 490.85, 519.44, 548.04]
+  },
+  skill: {
+    press: [199.2, 214.14, 229.08, 249, 263.94, 278.88, 298.8, 318.72, 338.64, 358.56, 378.48, 398.4, 423.3, 448.2, 473.1],
+    hold: [295.2, 317.34, 339.48, 369, 391.14, 413.28, 442.8, 472.32, 501.84, 531.36, 560.88, 590.4, 627.3, 664.2, 701.1],
+    cd: {
+      a1: 0.82, // 100% - 18%
+      press: 6,
+      hold: 10,
+    }
+  },
+  burst: {
+    summon: [160, 172, 184, 200, 212, 224, 240, 256, 272, 288, 304, 320, 340, 360, 380],
+    dmg: [24, 25.8, 27.6, 30, 31.8, 33.6, 36, 38.4, 40.8, 43.2, 45.6, 48, 51, 54, 57],
+    atkspd: [26, 28, 30, 32, 34, 36, 37, 38, 39, 40, 40, 40, 40, 40, 40],
+  },
+  c6: {
+    dmg: 100,
+    cd: 10,
+    sigils: 1,
+  }
+}
+
+const formula = {
+  normal: Object.fromEntries(data.normal.hitArr.map((percentArr, i) => [i, (tlvl, stats) =>
+    basicDMGFormula(percentArr[tlvl], stats, "normal")])),
+  charged: Object.fromEntries(Object.entries(data.charged).map(([name, arr]) =>
+    [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "charged")])),
+  plunging: {
+    dmg: (tlvl, stats) => basicDMGFormula(data.plunging.dmg[tlvl], stats, "plunging"),
+    low: (tlvl, stats) => basicDMGFormula(data.plunging.low[tlvl], stats, "plunging"),
+    high: (tlvl, stats) => basicDMGFormula(data.plunging.high[tlvl], stats, "plunging"),
+  },
+  skill: {
+    press: (tlvl, stats) => basicDMGFormula(data.skill.press[tlvl], stats, "skill"),
+    hold: (tlvl, stats) => basicDMGFormula(data.skill.hold[tlvl], stats, "skill"),
+    cd: {
+      press: () => {
+        const f = (stats) => data.skill.cd.press * (stats.ascension >= 1 ? data.skill.cd.a1 : 1);
+        const d = ['ascension'];
+        return [f, d];
+      },
+      hold: () => {
+        const f = (stats) => data.skill.cd.hold * (stats.ascension >= 1 ? data.skill.cd.a1 : 1);
+        const d = ['ascension'];
+        return [f, d];
+      }
+    }
+  },
+  burst: {
+    summon: (tlvl, stats) => basicDMGFormula(data.burst.summon[tlvl], stats, "burst"),
+    dmg: (tlvl, stats) => basicDMGFormula(data.burst.dmg[tlvl], stats, "burst"),
+    atkspd: (tlvl, stats) => [() => data.burst.atkspd[tlvl], [""]],
+  },
+  c6: {
+    dmg: () => {
+      const f = (stats) => stats.characterATK * data.c6.dmg / 100;
+      const d = ['characterATK'];
+      return [f, d];
+    }
+  }
+}
+
+export default formula
+export {
+  data
+}

--- a/src/Data/Characters/Razor/index.js
+++ b/src/Data/Characters/Razor/index.js
@@ -365,7 +365,7 @@ const char = {
             c >= 1 && {
               type: "character",
               conditionalKey: "WolfsInstinct",
-              condition: "Wolf's Instinct",
+              condition: "Pickup Elemental Particle",
               sourceKey: "razor",
               maxStack: 1,
               stats: {
@@ -499,6 +499,7 @@ const char = {
                   text: "Lupus Fulguris DMG",
                   formulaText: (<span>{data.c6.dmg}% of Razor's ATK</span>),
                   formula: formula.c6.dmg,
+                  variant: 'electro',
                 },
                 {
                   text: "Cooldown",

--- a/src/Data/Characters/Razor/index.js
+++ b/src/Data/Characters/Razor/index.js
@@ -41,16 +41,14 @@ const char = {
         {
           text: (
             <span>
-              <strong>Normal Attack</strong> Perform up to 4 consecutive
-              strikes.
+              <strong>Normal Attack</strong> Perform up to 4 consecutive strikes.
             </span>
           ),
           fields: data.normal.hitArr.map((percentArr, i) => ({
             text: `${i + 1}-Hit DMG`,
             formulaText: (tlvl, stats) => (
               <span>
-                {percentArr[tlvl]}%{" "}
-                {Stat.printStat(getTalentStatKey("normal", stats), stats)}
+                {percentArr[tlvl]}% {Stat.printStat(getTalentStatKey("normal", stats), stats)}
               </span>
             ),
             formula: formula.normal[i],
@@ -62,7 +60,7 @@ const char = {
             <span>
               <strong>Charged Attack</strong> Drains Stamina over time to
               perform continuous spinning attacks against all nearby opponents.
-              At end of the sequence, perform a more powerful slash.{" "}
+              At end of the sequence, perform a more powerful slash.
             </span>
           ),
           fields: [
@@ -70,8 +68,7 @@ const char = {
               text: `Spinning DMG`,
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.charged.spinning[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("charged", stats), stats)}
+                  {data.charged.spinning[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}
                 </span>
               ),
               formula: formula.charged.spinning,
@@ -82,8 +79,7 @@ const char = {
               text: `Spinning Final DMG`,
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.charged.final[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("charged", stats), stats)}
+                  {data.charged.final[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}
                 </span>
               ),
               formula: formula.charged.final,
@@ -113,8 +109,7 @@ const char = {
               text: `Plunge DMG`,
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.plunging.dmg[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                  {data.plunging.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
                 </span>
               ),
               formula: formula.plunging.dmg,
@@ -125,8 +120,7 @@ const char = {
               text: `Low Plunge DMG`,
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.plunging.low[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                  {data.plunging.low[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
                 </span>
               ),
               formula: formula.plunging.low,
@@ -137,8 +131,7 @@ const char = {
               text: `High Plunge DMG`,
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.plunging.high[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                  {data.plunging.high[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
                 </span>
               ),
               formula: formula.plunging.high,
@@ -181,8 +174,7 @@ const char = {
               text: "Press DMG",
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.skill.press[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("skill", stats), stats)}
+                  {data.skill.press[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}
                 </span>
               ),
               formula: formula.skill.press,
@@ -196,8 +188,7 @@ const char = {
               text: "Hold DMG",
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.skill.hold[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("skill", stats), stats)}
+                  {data.skill.hold[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}
                 </span>
               ),
               formula: formula.skill.hold,
@@ -250,8 +241,7 @@ const char = {
               text: "Elemental Burst DMG",
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.burst.summon[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("burst", stats), stats)}
+                  {data.burst.summon[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}
                 </span>
               ),
               formula: formula.burst.summon,
@@ -261,8 +251,7 @@ const char = {
               text: "Wolf Within Electro DMG",
               formulaText: (tlvl, stats) => (
                 <span>
-                  {data.burst.dmg[tlvl]}%{" "}
-                  {Stat.printStat(getTalentStatKey("burst", stats), stats)}
+                  {data.burst.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}
                 </span>
               ),
               formula: formula.burst.dmg,

--- a/src/Data/Characters/Razor/index.js
+++ b/src/Data/Characters/Razor/index.js
@@ -14,10 +14,7 @@ import passive2 from './Talent_Hunger.png'
 import passive3 from './Talent_Wolvensprint.png'
 import Stat from '../../../Stat'
 import formula, { data } from './data'
-import {
-  getTalentStatKey,
-  getTalentStatKeyVariant,
-} from "../../../Build/Build"
+import { getTalentStatKey, getTalentStatKeyVariant, } from "../../../Build/Build"
 
 const char = {
   name: "Razor",
@@ -36,472 +33,272 @@ const char = {
     auto: {
       name: "Steel Fang",
       img: normal,
-      infusable: true,
-      document: [
-        {
-          text: (
-            <span>
-              <strong>Normal Attack</strong> Perform up to 4 consecutive strikes.
-            </span>
-          ),
-          fields: data.normal.hitArr.map((percentArr, i) => ({
-            text: `${i + 1}-Hit DMG`,
-            formulaText: (tlvl, stats) => (
-              <span>
-                {percentArr[tlvl]}% {Stat.printStat(getTalentStatKey("normal", stats), stats)}
-              </span>
-            ),
-            formula: formula.normal[i],
-            variant: (tlvl, stats) => getTalentStatKeyVariant("normal", stats),
-          })),
-        },
-        {
-          text: (
-            <span>
-              <strong>Charged Attack</strong> Drains Stamina over time to
-              perform continuous spinning attacks against all nearby opponents.
-              At end of the sequence, perform a more powerful slash.
-            </span>
-          ),
-          fields: [
-            {
-              text: `Spinning DMG`,
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.charged.spinning[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}
-                </span>
-              ),
-              formula: formula.charged.spinning,
-              variant: (tlvl, stats) =>
-                getTalentStatKeyVariant("charged", stats),
-            },
-            {
-              text: `Spinning Final DMG`,
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.charged.final[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}
-                </span>
-              ),
-              formula: formula.charged.final,
-              variant: (tlvl, stats) =>
-                getTalentStatKeyVariant("charged", stats),
-            },
-            (c, a) => ({
-              text: `Stamina Cost`,
-              value: "40/s",
-            }),
-            (c, a) => ({
-              text: `Max Duration`,
-              value: "5s",
-            }),
-          ],
-        },
-        {
-          text: (
-            <span>
-              <strong>Plunging Attack</strong> Plunges from mid-air to strike
-              the ground, damaging enemies along the path and dealing AoE DMG
-              upon impact.
-            </span>
-          ),
-          fields: [
-            {
-              text: `Plunge DMG`,
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.plunging.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
-                </span>
-              ),
-              formula: formula.plunging.dmg,
-              variant: (tlvl, stats) =>
-                getTalentStatKeyVariant("plunging", stats),
-            },
-            {
-              text: `Low Plunge DMG`,
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.plunging.low[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
-                </span>
-              ),
-              formula: formula.plunging.low,
-              variant: (tlvl, stats) =>
-                getTalentStatKeyVariant("plunging", stats),
-            },
-            {
-              text: `High Plunge DMG`,
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.plunging.high[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
-                </span>
-              ),
-              formula: formula.plunging.high,
-              variant: (tlvl, stats) =>
-                getTalentStatKeyVariant("plunging", stats),
-            },
-          ],
-        },
-      ],
+      infusable: false,
+      document: [{
+        text: <span><strong>Normal Attack</strong> Perform up to 4 consecutive strikes.</span>,
+        fields: data.normal.hitArr.map((percentArr, i) => ({
+          text: `${i + 1}-Hit DMG`,
+          formulaText: (tlvl, stats) => <span>{percentArr[tlvl]}% {Stat.printStat(getTalentStatKey("normal", stats), stats)}</span>,
+          formula: formula.normal[i],
+          variant: (tlvl, stats) => getTalentStatKeyVariant("normal", stats),
+        })),
+      }, {
+        text: <span><strong>Charged Attack</strong> Drains Stamina over time to perform continuous spinning attacks against all nearby opponents. At end of the sequence, perform a more powerful slash.</span>,
+        fields: [{
+          text: `Spinning DMG`,
+          formulaText: (tlvl, stats) => <span>{data.charged.spinning[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}</span>,
+          formula: formula.charged.spinning,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("charged", stats),
+        }, {
+          text: `Spinning Final DMG`,
+          formulaText: (tlvl, stats) => <span>{data.charged.final[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}</span>,
+          formula: formula.charged.final,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("charged", stats),
+        }, {
+          text: `Stamina Cost`,
+          value: "40/s",
+        }, {
+          text: `Max Duration`,
+          value: "5s",
+        }],
+      }, {
+        text: <span><strong>Plunging Attack</strong> Plunges from mid-air to strike the ground, damaging enemies along the path and dealing AoE DMG upon impact.</span>,
+        fields: [{
+          text: `Plunge DMG`,
+          formulaText: (tlvl, stats) => <span>{data.plunging.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.dmg,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }, {
+          text: `Low Plunge DMG`,
+          formulaText: (tlvl, stats) => <span>{data.plunging.low[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.low,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }, {
+          text: `High Plunge DMG`,
+          formulaText: (tlvl, stats) => <span>{data.plunging.high[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.high,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }],
+      }],
     },
     skill: {
       name: "Claw and Thunder",
       img: skill,
-      document: [
-        {
-          text: (
-            <span>
-              <p className="mb-2">
-                Hunts his prey using the techniques taught to him by his master
-                and his Lupical.
-              </p>
-              <p className="mb-2">
-                <strong>Press:</strong> Swings the Thunder Wolf Claw, dealing
-                Electro DMG to opponents in front of Razor. Upon striking an
-                opponent, Razor will gain an Electro Sigil, which increases his
-                Energy Recharge rate. Razor can have up to 3 Electro Sigils
-                simultaneously, and gaining a new Electro Sigil refreshes their
-                duration.
-              </p>
-              <p className="mb-2">
-                <strong>Hold:</strong> Gathers Electro energy to unleash a
-                lightning storm over a small AoE, causing massive Electro DMG,
-                and clears all of Razor's Electro Sigils. Each Electro Sigil
-                cleared in this manner will be converted into Energy for Razor.
-              </p>
-            </span>
-          ),
-          fields: [
-            {
-              text: "Press DMG",
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.skill.press[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}
-                </span>
-              ),
-              formula: formula.skill.press,
-              variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
-            },
-            {
-              text: "Press CD (sec)",
-              formula: formula.skill.cd.press,
-            },
-            {
-              text: "Hold DMG",
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.skill.hold[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}
-                </span>
-              ),
-              formula: formula.skill.hold,
-              variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
-            },
-            {
-              text: "Hold CD (sec)",
-              formula: formula.skill.cd.hold,
-            },
-            {
-              text: "Energy Recharge Bonus",
-              value: "20% per Electro Sigil",
-            },
-            {
-              text: "Hold Energy Generated",
-              value: "5 per Electro Sigil Absorbed",
-            },
-            {
-              text: "Electro Sigil Duration",
-              value: "18s",
-            },
-          ],
-        },
-      ],
+      document: [{
+        text: <span>
+          <p className="mb-2">Hunts his prey using the techniques taught to him by his master and his Lupical.</p>
+          <p className="mb-2"><strong>Press:</strong> Swings the Thunder Wolf Claw, dealing <span className="text-electro">Electro DMG</span> to opponents in front of Razor. Upon striking an opponent, Razor will gain an Electro Sigil, which increases his Energy Recharge rate. Razor can have up to 3 Electro Sigils simultaneously, and gaining a new Electro Sigil refreshes their duration.</p>
+          <p className="mb-2"><strong>Hold:</strong> Gathers Electro energy to unleash a lightning storm over a small AoE, causing massive <span className="text-electro">Electro DMG</span>, and clears all of Razor's Electro Sigils. Each Electro Sigil cleared in this manner will be converted into Energy for Razor. </p>
+        </span>,
+        fields: [{
+          text: "Press DMG",
+          formulaText: (tlvl, stats) => <span>{data.skill.press[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}</span>,
+          formula: formula.skill.press,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
+        }, (con, a) => ({
+          text: "Press CD",
+          value: 6 * (a >= 1 ? 0.82 : 1) + "s",
+        }), {
+          text: "Hold DMG",
+          formulaText: (tlvl, stats) => <span>{data.skill.hold[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}</span>,
+          formula: formula.skill.hold,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
+        }, (con, a) => ({
+          text: "Hold CD",
+          value: 10 * (a >= 1 ? 0.82 : 1) + "s",
+        }), {
+          text: "Energy Recharge Bonus",
+          value: "20% per Electro Sigil",
+        }, {
+          text: "Hold Energy Generated",
+          value: "5 per Electro Sigil Absorbed",
+        }, {
+          text: "Electro Sigil Duration",
+          value: "18s",
+        }],
+        conditional: (tlvl, c) => c >= 6 && {
+          type: "character",
+          conditionalKey: "ElectroSigil",
+          condition: "Electro Sigil",
+          sourceKey: "razor",
+          maxStack: 3,
+          stats: {
+            enerRech_: 20,
+          },
+        }
+      }],
     },
     burst: {
       name: "Lightning Fang",
       img: burst,
-      document: [
-        {
-          text: (
-            <span>
-              Summons the Wolf Within which deals Electro DMG to all nearby
-              opponents. This clears all of Razor's Electro Sigils, which will
-              be converted into elemental energy for him. The Wolf Within will
-              fight alongside Razor for the skill's duration.
-              <h6>The Wolf Within</h6>
-              <ul className="mb-2">
-                <li>Strikes alongside Razor's normal attacks, dealing Electro DMG.</li>
-                <li>Raises Razor's ATK SPD and Electro RES.</li>
-                <li>Causes Razor to be immune to DMG inflicted by the Electro-Charged status.</li>
-                <li>Disables Razor's Charged Attacks.</li>
-                <li>Increases Razor's resistance to interruption.</li>
-              </ul>
-              These effects end when Razor leaves the battlefield. When Razor leaves the field, a maximum of 10 Energy will be returned to him based off the duration remaining on this skill.
-            </span>
-          ),
-          fields: [
-            {
-              text: "Elemental Burst DMG",
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.burst.summon[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}
-                </span>
-              ),
-              formula: formula.burst.summon,
-              variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
-            },
-            {
-              text: "Wolf Within Electro DMG",
-              formulaText: (tlvl, stats) => (
-                <span>
-                  {data.burst.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}
-                </span>
-              ),
-              formula: formula.burst.dmg,
-              variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
-            },
-            {
-              text: "ATK Speed Bonus",
-              formula: formula.burst.atkspd,
-            },
-            {
-              text: "Electro RES Bonus",
-              value: "80%",
-            },
-            {
-              text: "Duration",
-              value: "15s",
-            },
-            {
-              text: "CD",
-              value: "20s",
-            },
-            {
-              text: "Energy Cost",
-              value: 80,
-            },
-          ],
-        },
-      ],
+      document: [{
+        text: (
+          <span>
+            <p className="mb-2">Summons the Wolf Within which deals <span className="text-electro">Electro DMG</span> to all nearby opponents. This clears all of Razor's Electro Sigils, which will be converted into elemental energy for him. The Wolf Within will fight alongside Razor for the skill's duration.</p>
+            <h6>The Wolf Within</h6>
+            <ul className="mb-2">
+              <li>Strikes alongside Razor's normal attacks, dealing <span className="text-electro">Electro DMG</span>.</li>
+              <li>Raises Razor's ATK SPD and <span className="text-electro">Electro RES</span>.</li>
+              <li>Causes Razor to be immune to DMG inflicted by the Electro-Charged status.</li>
+              <li>Disables Razor's Charged Attacks.</li>
+              <li>Increases Razor's resistance to interruption.</li>
+            </ul>
+            <p className="mb-2">These effects end when Razor leaves the battlefield. When Razor leaves the field, a maximum of 10 Energy will be returned to him based off the duration remaining on this skill.</p>
+          </span>
+        ),
+        fields: [{
+          text: "Elemental Burst DMG",
+          formulaText: (tlvl, stats) => <span>{data.burst.summon[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
+          formula: formula.burst.summon,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+        }, {
+          text: "Soul Companion DMG",
+          formulaText: (tlvl, stats) => <span>{data.burst.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
+          formula: formula.burst.dmg,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+        }, {
+          text: "Duration",
+          value: "15s",
+        }, {
+          text: "CD",
+          value: "20s",
+        }, {
+          text: "Energy Cost",
+          value: 80,
+        }],
+        conditional: (tlvl, c) => c >= 6 && {
+          type: "character",
+          conditionalKey: "LightningFang",
+          condition: "Lightning Fang",
+          sourceKey: "razor",
+          maxStack: 1,
+          stats: {
+            electro_res_: 80,
+            atkSPD_: data.burst.atkspd[tlvl],
+          },
+          fields: [{
+            text: "Increases resistance to interruption"
+          }]
+        }
+      }],
+
     },
     passive1: {
       name: "Awakening",
       img: passive1,
-      document: [
-        {
-          text: (
-            <span>
-              Decreases Claw and Thunder's CD by 18%. Using Lightning Fang
-              resets the CD of Claw and Thunder.
-            </span>
-          ),
-        },
-      ],
+      document: [{ text: <span>Decreases <b>Claw and Thunder</b>'s CD by 18%. Using <b>Lightning Fang</b> resets the CD of <b>Claw and Thunder</b>.</span>, }],
     },
     passive2: {
       name: "Hunger",
       img: passive2,
-      document: [
-        {
-          text: (
-            <span>
-              When Razor's Energy is below 50%, increases Energy Recharge by
-              30%.
-            </span>
-          ),
+      document: [{
+        text: <span>When Razor's Energy is below 50%, increases Energy Recharge by 30%.</span>,
+        conditional: (tlvl, c, a) => a >= 4 && {
+          type: "character",
+          conditionalKey: "Hunger",
+          condition: "Energy < 50%",
+          sourceKey: "razor",
+          maxStack: 1,
+          stats: {
+            enerRech_: 30,
+          },
         },
-        {
-          conditional: (tlvl, c, a) =>
-            a >= 4 && {
-              type: "character",
-              conditionalKey: "Hunger",
-              condition: "Energy < 30%",
-              sourceKey: "razor",
-              maxStack: 1,
-              stats: {
-                enerRech_: 15,
-              },
-            },
-        },
-      ],
+      }],
     },
     passive3: {
       name: "Wolvensprint",
       img: passive3,
-      document: [
-        {
-          text: (
-            <span>
-              Decreases sprinting Stamina consumption for your own party members
-              by 20%. Not stackable with Passive Talents that provide the exact
-              same effects.
-            </span>
-          ),
-        },
-      ],
+      document: [{ text: <span>Decreases sprinting Stamina consumption for your own party members by 20%. Not stackable with Passive Talents that provide the exact same effects.</span>, }],//TODO: team buff
     },
     constellation1: {
       name: "Wolf's Instinct",
       img: c1,
-      document: [
-        {
-          text: (
-            <span>
-              Picking up an Elemental Orb or Particle increases Razor's DMG by
-              10% for 8s.
-            </span>
-          ),
+      document: [{
+        text: <span>Picking up an Elemental Orb or Particle increases Razor's DMG by 10% for 8s.</span>,
+        conditional: (tlvl, c, a) => c >= 1 && {
+          type: "character",
+          conditionalKey: "WolfsInstinct",
+          condition: "Pickup Elemental Particle",
+          sourceKey: "razor",
+          maxStack: 1,
+          stats: {
+            dmg_: 10,
+          },
+          fields: [{
+            text: "Duration",
+            value: "8s",
+          }],
         },
-        {
-          conditional: (tlvl, c, a) =>
-            c >= 1 && {
-              type: "character",
-              conditionalKey: "WolfsInstinct",
-              condition: "Pickup Elemental Particle",
-              sourceKey: "razor",
-              maxStack: 1,
-              stats: {
-                dmg_: 10,
-              },
-              fields: [
-                {
-                  text: "Duration",
-                  value: "8s",
-                },
-              ],
-            },
-        },
-      ],
+      }],
     },
     constellation2: {
       name: "Suppression",
       img: c2,
-      document: [
-        {
-          text: (
-            <span>
-              Increases CRIT Rate against opponents with less than 30% HP by
-              10%.
-            </span>
-          ),
+      document: [{
+        text: <span>Increases CRIT Rate against opponents with less than 30% HP by 10%.</span>,
+        conditional: (tlvl, c, a) => c >= 1 && {
+          type: "character",
+          conditionalKey: "Enemy30",
+          condition: "Enemy with <30% HP",
+          sourceKey: "razor",
+          maxStack: 1,
+          stats: {
+            critRate_: 10,
+          },
         },
-        {
-          conditional: (tlvl, c, a) =>
-            c >= 1 && {
-              type: "character",
-              conditionalKey: "Enemy30",
-              condition: "Enemy with <30% HP",
-              sourceKey: "razor",
-              maxStack: 1,
-              stats: {
-                critRate_: 10,
-              },
-            },
-        },
-      ],
+      }],
     },
     constellation3: {
       name: "Soul Companion",
       img: c3,
-      document: [
-        {
-          text: (
-            <span>
-              Increases <b>Lightning Fang</b>'s skill level by 3. Maximum
-              upgrade level is 15.
-            </span>
-          ),
-        },
-      ],
+      document: [{ text: <span>Increases <b>Lightning Fang</b>'s skill level by 3. Maximum upgrade level is 15.</span>, }],
       talentBoost: { burst: 3 },
     },
     constellation4: {
       name: "Bite",
       img: c4,
-      document: [
-        {
-          text: (
-            <span>
-              When casting Claw and Thunder (Press), opponents hit will have
-              their DEF decreased by 15% for 7s.
-            </span>
-          ),
+      document: [{
+        text: <span>When casting <b>Claw and Thunder</b> (Press), opponents hit will have their DEF decreased by 15% for 7s.</span>,
+        conditional: (tlvl, c, a) => c >= 4 && {
+          type: "character",
+          conditionalKey: "Bite",
+          condition: "Bite",
+          sourceKey: "razor",
+          maxStack: 1,
+          stats: {
+            enemyDEFRed_: 15,
+          },
+          fields: [{
+            text: "Duration",
+            value: "7s",
+          }],
         },
-        {
-          conditional: (tlvl, c, a) =>
-            c >= 1 && {
-              type: "character",
-              conditionalKey: "Bite",
-              condition: "Bite",
-              sourceKey: "razor",
-              maxStack: 1,
-              stats: {
-                enemyDEFRed_: 15,
-              },
-              fields: [
-                {
-                  text: "Duration",
-                  value: "7s",
-                },
-              ],
-            },
-        },
-      ],
+      }],
     },
     constellation5: {
       name: "Sharpened Claws",
       img: c5,
-      document: [
-        {
-          text: (
-            <span>
-              Increases <b>Claw and Thunder</b>'s skill level by 3. Maximum
-              upgrade level is 15.
-            </span>
-          ),
-        },
-      ],
+      document: [{ text: <span>Increases <b>Claw and Thunder</b>'s skill level by 3. Maximum upgrade level is 15.</span> }],
       talentBoost: { skill: 3 },
     },
     constellation6: {
       name: "Lupus Fulguris",
       img: c6,
-      document: [
-        {
-          text: (
-            <span>
-              Every 10s, Razor's sword charges up, causing the next Normal
-              Attack to release lightning that deals 100% of Razor's ATK as
-              Electro DMG. When Razor is not using Lightning Fang, a lightning
-              strike on an opponent will grant Razor an Electro Sigil for Claw
-              and Thunder.
-            </span>
-          ),
-        },
-        {
-          conditional: (tlvl, c, a) =>
-            c >= 6 && {
-              type: "character",
-              conditionalKey: "LupusFulguris",
-              condition: "Lupus Fulguris",
-              sourceKey: "razor",
-              maxStack: 1,
-              fields: [
-                {
-                  text: "Lupus Fulguris DMG",
-                  formulaText: (<span>{data.c6.dmg}% of Razor's ATK</span>),
-                  formula: formula.c6.dmg,
-                  variant: 'electro',
-                },
-                {
-                  text: "Cooldown",
-                  value: `${data.c6.cd}s`,
-                },
-                {
-                  text: "Electro Sigils Granted",
-                  value: data.c6.sigils,
-                },
-              ],
-            },
-        },
-      ],
+      document: [{
+        text: <span>Every 10s, Razor's sword charges up, causing the next Normal Attack to release lightning that deals 100% of Razor's ATK as <span className="text-electro">Electro DMG</span>. When Razor is not using <b>Lightning Fang</b>, a lightning strike on an opponent will grant Razor an Electro Sigil for <b>Claw and Thunder</b>.</span>,
+        fields: [(con) => con >= 6 && {
+          text: "Lupus Fulguris DMG",
+          formulaText: (tlvl, stats) => <span>10% {Stat.printStat(getTalentStatKey("electro", stats), stats)}</span>,
+          formula: formula.constellation6.dmg,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("electro", stats),
+        }, (con) => con >= 6 && {
+          text: "Electro Sigils per proc",
+          value: 1,
+        }, (con) => con >= 6 && {
+          text: "Cooldown",
+          value: `10s`,
+        }],
+      }],
     },
   },
 };

--- a/src/Data/Characters/Razor/index.js
+++ b/src/Data/Characters/Razor/index.js
@@ -1,17 +1,23 @@
 import card from './Character_Razor_Card.jpg'
 import thumb from './Character_Razor_Thumb.png'
-// import c1 from './Constellation_Wolf\'s_Instinct.png'
-// import c2 from './Constellation_Suppression.png'
-// import c3 from './Constellation_Soul_Companion.png'
-// import c4 from './Constellation_Bite.png'
-// import c5 from './Constellation_Sharpened_Claws.png'
-// import c6 from './Constellation_Lupus_Fulguris.png'
-// import normal from './Talent_Steel_Fang.png'
-// import skill from './Talent_Claw_and_Thunder.png'
-// import burst from './Talent_Lightning_Fang.png'
-// import passive1 from './Talent_Awakening.png'
-// import passive2 from './Talent_Hunger.png'
-// import passive3 from './Talent_Wolvensprint.png'
+import c1 from './Constellation_Wolf\'s_Instinct.png'
+import c2 from './Constellation_Suppression.png'
+import c3 from './Constellation_Soul_Companion.png'
+import c4 from './Constellation_Bite.png'
+import c5 from './Constellation_Sharpened_Claws.png'
+import c6 from './Constellation_Lupus_Fulguris.png'
+import normal from './Talent_Steel_Fang.png'
+import skill from './Talent_Claw_and_Thunder.png'
+import burst from './Talent_Lightning_Fang.png'
+import passive1 from './Talent_Awakening.png'
+import passive2 from './Talent_Hunger.png'
+import passive3 from './Talent_Wolvensprint.png'
+import Stat from '../../../Stat'
+import formula, { data } from './data'
+import {
+  getTalentStatKey,
+  getTalentStatKeyVariant,
+} from "../../../Build/Build"
 
 const char = {
   name: "Razor",
@@ -23,14 +29,490 @@ const char = {
   gender: "M",
   constellationName: "Lupus Minor",
   titles: ["Legend of Wolvendom", "Wolf Boy"],
-  baseStat: {
-    characterHP: [1003, 2577, 3326, 4982, 5514, 6343, 7052, 7881, 8413, 9241, 9773, 10602, 11134, 11962],
-    characterATK: [20, 50, 65, 97, 108, 124, 138, 154, 164, 180, 191, 207, 217, 234],
-    characterDEF: [63, 162, 209, 313, 346, 398, 443, 495, 528, 580, 613, 665, 699, 751]
-  },
-  specializeStat: {
-    key: "physical_dmg_",
-    value: [0, 0, 0, 0, 7.5, 7.5, 15, 15, 15, 15, 22.5, 22.5, 30, 30]
+  baseStat: data.baseStat,
+  specializeStat: data.specializeStat,
+  formula,
+  talent: {
+    auto: {
+      name: "Steel Fang",
+      img: normal,
+      infusable: true,
+      document: [
+        {
+          text: (
+            <span>
+              <strong>Normal Attack</strong> Perform up to 4 consecutive
+              strikes.
+            </span>
+          ),
+          fields: data.normal.hitArr.map((percentArr, i) => ({
+            text: `${i + 1}-Hit DMG`,
+            formulaText: (tlvl, stats) => (
+              <span>
+                {percentArr[tlvl]}%{" "}
+                {Stat.printStat(getTalentStatKey("normal", stats), stats)}
+              </span>
+            ),
+            formula: formula.normal[i],
+            variant: (tlvl, stats) => getTalentStatKeyVariant("normal", stats),
+          })),
+        },
+        {
+          text: (
+            <span>
+              <strong>Charged Attack</strong> Drains Stamina over time to
+              perform continuous spinning attacks against all nearby opponents.
+              At end of the sequence, perform a more powerful slash.{" "}
+            </span>
+          ),
+          fields: [
+            {
+              text: `Spinning DMG`,
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.charged.spinning[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("charged", stats), stats)}
+                </span>
+              ),
+              formula: formula.charged.spinning,
+              variant: (tlvl, stats) =>
+                getTalentStatKeyVariant("charged", stats),
+            },
+            {
+              text: `Spinning Final DMG`,
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.charged.final[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("charged", stats), stats)}
+                </span>
+              ),
+              formula: formula.charged.final,
+              variant: (tlvl, stats) =>
+                getTalentStatKeyVariant("charged", stats),
+            },
+            (c, a) => ({
+              text: `Stamina Cost`,
+              value: "40/s",
+            }),
+            (c, a) => ({
+              text: `Max Duration`,
+              value: "5s",
+            }),
+          ],
+        },
+        {
+          text: (
+            <span>
+              <strong>Plunging Attack</strong> Plunges from mid-air to strike
+              the ground, damaging enemies along the path and dealing AoE DMG
+              upon impact.
+            </span>
+          ),
+          fields: [
+            {
+              text: `Plunge DMG`,
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.plunging.dmg[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                </span>
+              ),
+              formula: formula.plunging.dmg,
+              variant: (tlvl, stats) =>
+                getTalentStatKeyVariant("plunging", stats),
+            },
+            {
+              text: `Low Plunge DMG`,
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.plunging.low[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                </span>
+              ),
+              formula: formula.plunging.low,
+              variant: (tlvl, stats) =>
+                getTalentStatKeyVariant("plunging", stats),
+            },
+            {
+              text: `High Plunge DMG`,
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.plunging.high[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("plunging", stats), stats)}
+                </span>
+              ),
+              formula: formula.plunging.high,
+              variant: (tlvl, stats) =>
+                getTalentStatKeyVariant("plunging", stats),
+            },
+          ],
+        },
+      ],
+    },
+    skill: {
+      name: "Claw and Thunder",
+      img: skill,
+      document: [
+        {
+          text: (
+            <span>
+              <p className="mb-2">
+                Hunts his prey using the techniques taught to him by his master
+                and his Lupical.
+              </p>
+              <p className="mb-2">
+                <strong>Press:</strong> Swings the Thunder Wolf Claw, dealing
+                Electro DMG to opponents in front of Razor. Upon striking an
+                opponent, Razor will gain an Electro Sigil, which increases his
+                Energy Recharge rate. Razor can have up to 3 Electro Sigils
+                simultaneously, and gaining a new Electro Sigil refreshes their
+                duration.
+              </p>
+              <p className="mb-2">
+                <strong>Hold:</strong> Gathers Electro energy to unleash a
+                lightning storm over a small AoE, causing massive Electro DMG,
+                and clears all of Razor's Electro Sigils. Each Electro Sigil
+                cleared in this manner will be converted into Energy for Razor.
+              </p>
+            </span>
+          ),
+          fields: [
+            {
+              text: "Press DMG",
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.skill.press[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("skill", stats), stats)}
+                </span>
+              ),
+              formula: formula.skill.press,
+              variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
+            },
+            {
+              text: "Press CD (sec)",
+              formula: formula.skill.cd.press,
+            },
+            {
+              text: "Hold DMG",
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.skill.hold[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("skill", stats), stats)}
+                </span>
+              ),
+              formula: formula.skill.hold,
+              variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
+            },
+            {
+              text: "Hold CD (sec)",
+              formula: formula.skill.cd.hold,
+            },
+            {
+              text: "Energy Recharge Bonus",
+              value: "20% per Electro Sigil",
+            },
+            {
+              text: "Hold Energy Generated",
+              value: "5 per Electro Sigil Absorbed",
+            },
+            {
+              text: "Electro Sigil Duration",
+              value: "18s",
+            },
+          ],
+        },
+      ],
+    },
+    burst: {
+      name: "Lightning Fang",
+      img: burst,
+      document: [
+        {
+          text: (
+            <span>
+              Summons the Wolf Within which deals Electro DMG to all nearby
+              opponents. This clears all of Razor's Electro Sigils, which will
+              be converted into elemental energy for him. The Wolf Within will
+              fight alongside Razor for the skill's duration.
+              <h6>The Wolf Within</h6>
+              <ul className="mb-2">
+                <li>Strikes alongside Razor's normal attacks, dealing Electro DMG.</li>
+                <li>Raises Razor's ATK SPD and Electro RES.</li>
+                <li>Causes Razor to be immune to DMG inflicted by the Electro-Charged status.</li>
+                <li>Disables Razor's Charged Attacks.</li>
+                <li>Increases Razor's resistance to interruption.</li>
+              </ul>
+              These effects end when Razor leaves the battlefield. When Razor leaves the field, a maximum of 10 Energy will be returned to him based off the duration remaining on this skill.
+            </span>
+          ),
+          fields: [
+            {
+              text: "Elemental Burst DMG",
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.burst.summon[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("burst", stats), stats)}
+                </span>
+              ),
+              formula: formula.burst.summon,
+              variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+            },
+            {
+              text: "Wolf Within Electro DMG",
+              formulaText: (tlvl, stats) => (
+                <span>
+                  {data.burst.dmg[tlvl]}%{" "}
+                  {Stat.printStat(getTalentStatKey("burst", stats), stats)}
+                </span>
+              ),
+              formula: formula.burst.dmg,
+              variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+            },
+            {
+              text: "ATK Speed Bonus",
+              formula: formula.burst.atkspd,
+            },
+            {
+              text: "Electro RES Bonus",
+              value: "80%",
+            },
+            {
+              text: "Duration",
+              value: "15s",
+            },
+            {
+              text: "CD",
+              value: "20s",
+            },
+            {
+              text: "Energy Cost",
+              value: 80,
+            },
+          ],
+        },
+      ],
+    },
+    passive1: {
+      name: "Awakening",
+      img: passive1,
+      document: [
+        {
+          text: (
+            <span>
+              Decreases Claw and Thunder's CD by 18%. Using Lightning Fang
+              resets the CD of Claw and Thunder.
+            </span>
+          ),
+        },
+      ],
+    },
+    passive2: {
+      name: "Hunger",
+      img: passive2,
+      document: [
+        {
+          text: (
+            <span>
+              When Razor's Energy is below 50%, increases Energy Recharge by
+              30%.
+            </span>
+          ),
+        },
+        {
+          conditional: (tlvl, c, a) =>
+            a >= 4 && {
+              type: "character",
+              conditionalKey: "Hunger",
+              condition: "Energy < 30%",
+              sourceKey: "razor",
+              maxStack: 1,
+              stats: {
+                enerRech_: 15,
+              },
+            },
+        },
+      ],
+    },
+    passive3: {
+      name: "Wolvensprint",
+      img: passive3,
+      document: [
+        {
+          text: (
+            <span>
+              Decreases sprinting Stamina consumption for your own party members
+              by 20%. Not stackable with Passive Talents that provide the exact
+              same effects.
+            </span>
+          ),
+        },
+      ],
+    },
+    constellation1: {
+      name: "Wolf's Instinct",
+      img: c1,
+      document: [
+        {
+          text: (
+            <span>
+              Picking up an Elemental Orb or Particle increases Razor's DMG by
+              10% for 8s.
+            </span>
+          ),
+        },
+        {
+          conditional: (tlvl, c, a) =>
+            c >= 1 && {
+              type: "character",
+              conditionalKey: "WolfsInstinct",
+              condition: "Wolf's Instinct",
+              sourceKey: "razor",
+              maxStack: 1,
+              stats: {
+                dmg_: 10,
+              },
+              fields: [
+                {
+                  text: "Duration",
+                  value: "8s",
+                },
+              ],
+            },
+        },
+      ],
+    },
+    constellation2: {
+      name: "Suppression",
+      img: c2,
+      document: [
+        {
+          text: (
+            <span>
+              Increases CRIT Rate against opponents with less than 30% HP by
+              10%.
+            </span>
+          ),
+        },
+        {
+          conditional: (tlvl, c, a) =>
+            c >= 1 && {
+              type: "character",
+              conditionalKey: "Enemy30",
+              condition: "Enemy with <30% HP",
+              sourceKey: "razor",
+              maxStack: 1,
+              stats: {
+                critRate_: 10,
+              },
+            },
+        },
+      ],
+    },
+    constellation3: {
+      name: "Soul Companion",
+      img: c3,
+      document: [
+        {
+          text: (
+            <span>
+              Increases <b>Lightning Fang</b>'s skill level by 3. Maximum
+              upgrade level is 15.
+            </span>
+          ),
+        },
+      ],
+      talentBoost: { burst: 3 },
+    },
+    constellation4: {
+      name: "Bite",
+      img: c4,
+      document: [
+        {
+          text: (
+            <span>
+              When casting Claw and Thunder (Press), opponents hit will have
+              their DEF decreased by 15% for 7s.
+            </span>
+          ),
+        },
+        {
+          conditional: (tlvl, c, a) =>
+            c >= 1 && {
+              type: "character",
+              conditionalKey: "Bite",
+              condition: "Bite",
+              sourceKey: "razor",
+              maxStack: 1,
+              stats: {
+                enemyDEFRed_: 15,
+              },
+              fields: [
+                {
+                  text: "Duration",
+                  value: "7s",
+                },
+              ],
+            },
+        },
+      ],
+    },
+    constellation5: {
+      name: "Sharpened Claws",
+      img: c5,
+      document: [
+        {
+          text: (
+            <span>
+              Increases <b>Claw and Thunder</b>'s skill level by 3. Maximum
+              upgrade level is 15.
+            </span>
+          ),
+        },
+      ],
+      talentBoost: { skill: 3 },
+    },
+    constellation6: {
+      name: "Lupus Fulguris",
+      img: c6,
+      document: [
+        {
+          text: (
+            <span>
+              Every 10s, Razor's sword charges up, causing the next Normal
+              Attack to release lightning that deals 100% of Razor's ATK as
+              Electro DMG. When Razor is not using Lightning Fang, a lightning
+              strike on an opponent will grant Razor an Electro Sigil for Claw
+              and Thunder.
+            </span>
+          ),
+        },
+        {
+          conditional: (tlvl, c, a) =>
+            c >= 6 && {
+              type: "character",
+              conditionalKey: "LupusFulguris",
+              condition: "Lupus Fulguris",
+              sourceKey: "razor",
+              maxStack: 1,
+              fields: [
+                {
+                  text: "Lupus Fulguris DMG",
+                  formulaText: (<span>{data.c6.dmg}% of Razor's ATK</span>),
+                  formula: formula.c6.dmg,
+                },
+                {
+                  text: "Cooldown",
+                  value: `${data.c6.cd}s`,
+                },
+                {
+                  text: "Electro Sigils Granted",
+                  value: data.c6.sigils,
+                },
+              ],
+            },
+        },
+      ],
+    },
   },
 };
 export default char;

--- a/src/Data/Characters/formula.js
+++ b/src/Data/Characters/formula.js
@@ -18,7 +18,7 @@ import mona from './Mona/data'
 import ningguang from './Ningguang/data'
 import noelle from './Noelle/data'
 // import qiqi from './Qiqi/data'
-// import razor from './Razor/data'
+import razor from './Razor/data'
 // import sucrose from './Sucrose/data'
 // import tartaglia from './Tartaglia/data'
 // import traveler_anemo from './Traveler Anemo/data'
@@ -50,7 +50,7 @@ const formula = {
   ningguang,
   noelle,
   // qiqi,
-  // razor,
+  razor,
   // sucrose,
   // tartaglia,
   // traveler_anemo,


### PR DESCRIPTION
I feel I was quite thorough with this. It includes the following:

* Stat scaling for all talents, sourced from HHW.
* Descriptions for all talents, sourced from HHW.
* Automatic Claw and Thunder cooldown reduction at A1.
* Conditional toggle for A4 bonus Energy Recharge.
* Conditional toggle for C1 bonus DMG.
* Conditional toggle for C2 bonus CRate.
* Conditional toggle for C4 bonus DEF Reduction.
* Conditional toggle to display Electro Damage dealt by C6 Lupus Fulgiris.

To-Do Items:
[ ] Clean up cooldown fields after "Add unit property to fields" is implemented.
[ ] Get code review on C6 formula. Is it missing any factors?