### PR TITLE
[Sucrose] Added talents page along with constellations and basic calculations

### DIFF
--- a/src/Data/Characters/Sucrose/data.js
+++ b/src/Data/Characters/Sucrose/data.js
@@ -1,0 +1,52 @@
+import { basicDMGFormula } from "../../../Util/FormulaUtil";
+
+export const data = {
+  baseStat: {
+    characterHP: [775, 1991, 2570, 3850, 4261, 4901, 5450, 6090, 6501, 7141, 7552, 8192, 8604, 9244],
+    characterATK: [14, 37, 47, 71, 78, 90, 100, 112, 120, 131, 139, 151, 158, 170],
+    characterDEF: [59, 151, 195, 293, 324, 373, 414, 463, 494, 543, 574, 623, 654, 703]
+  },
+  specializeStat: {
+    key: "anemo_dmg_",
+    value: [0, 0, 0, 0, 6, 6, 12, 12, 12, 12, 18, 18, 24, 24]
+  },
+  normal: {
+    hitArr: [
+      [33.46, 35.97, 38.48, 41.83, 44.34, 46.85, 50.2, 53.54, 56.89, 60.24, 63.58, 66.93, 71.11, 75.29, 79.48], // 1
+      [30.62, 32.91, 35.21, 38.27, 40.57, 42.86, 45.92, 48.99, 52.05, 55.11, 58.17, 61.23, 65.06, 68.89, 72.71], // 2
+      [38.45, 41.33, 44.22, 48.06, 50.94, 53.83, 57.67, 61.52, 65.36, 69.21, 73.05, 76.9, 81.7, 86.51, 91.31], // 3
+      [47.92, 51.51, 55.11, 59.9, 63.49, 67.08, 71.88, 76.67, 81.46, 86.25, 91.04, 95.84, 101.82, 107.81, 113.8], // 4
+    ]
+  },
+  charged: {
+    hit: [120.16, 129.17, 138.18, 150.2, 159.21, 168.22, 180.24, 192.26, 204.27, 216.29, 228.3, 240.32, 255.34, 270.36, 285.38],
+  },
+  plunging: {
+    dmg: [56.83, 61.45, 66.08, 72.69, 77.31, 82.6, 89.87, 97.14, 104.41, 112.34, 120.27, 128.2, 136.12, 144.05, 151.98],
+    low: [122.88, 132.13, 145.35, 154.59, 165.17, 179.7, 194.23, 208.77, 224.62, 240.48, 256.34, 272.19, 288.05, 303.9],
+    high: [153.49, 165.04, 181.54, 193.1, 206.3, 224.45, 242.61, 260.76, 280.57, 300.37, 320.18, 339.98, 359.79, 379.59],
+  },
+  skill: {
+    press: [211.2, 227.04, 242.88, 264, 279.84, 295.68, 316.8, 337.92, 359.04, 380.16, 401.28, 422.4, 448.8, 475.2, 501.6],
+  },
+  burst: {
+    dot: [148, 159.1, 170.2, 185, 196.1, 207.2, 222, 236.8, 251.6, 266.4, 281.2, 296, 314.5, 333, 351.5],
+    additionalElementalDMG: [44, 47.3, 50.6, 55, 58.3, 61.6, 66, 70.4, 74.8, 79.2, 83.6, 88, 93.5, 99, 104.5],
+  }
+}
+const formula = {
+  normal: Object.fromEntries(data.normal.hitArr.map((arr, i) =>
+    [i, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "normal")])),
+  charged: {
+    hit: (tlvl, stats) => basicDMGFormula(data.charged.hit[tlvl], stats, "charged"),
+  },
+  plunging: Object.fromEntries(Object.entries(data.plunging).map(([name, arr]) =>
+    [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "plunging")])),
+  skill: Object.fromEntries(Object.entries(data.skill).map(([name, arr]) =>
+    [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "skill")])),
+  burst: Object.fromEntries([
+    ...Object.entries(data.burst).map(([name, arr]) =>
+      [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "burst")]),
+  ]),
+}
+export default formula

--- a/src/Data/Characters/Sucrose/index.js
+++ b/src/Data/Characters/Sucrose/index.js
@@ -1,17 +1,21 @@
 import card from './Character_Sucrose_Card.jpg'
 import thumb from './Character_Sucrose_Thumb.png'
-// import c1 from './Constellation_Clustered_Vacuum_Field.png'
-// import c2 from './Constellation_Beth_Unbound_Form.png'
-// import c3 from './Constellation_Flawless_Alchemistress.png'
-// import c4 from './Constellation_Alchemania.png'
-// import c5 from './Constellation_Caution_Standard_Flask.png'
-// import c6 from './Constellation_Chaotic_Entropy.png'
-// import normal from './Talent_Wind_Spirit_Creation.png'
-// import skill from './Talent_Astable_Anemohypostasis_Creation_-_6308.png'
-// import burst from './Talent_Forbidden_Creation_-_Isomer_75_Type_II.png'
-// import passive1 from './Talent_Catalyst_Conversion.png'
-// import passive2 from './Talent_Mollis_Favonius.png'
-// import passive3 from './Talent_Astable_Invention.png'
+import c1 from './Constellation_Clustered_Vacuum_Field.png'
+import c2 from './Constellation_Beth_Unbound_Form.png'
+import c3 from './Constellation_Flawless_Alchemistress.png'
+import c4 from './Constellation_Alchemania.png'
+import c5 from './Constellation_Caution_Standard_Flask.png'
+import c6 from './Constellation_Chaotic_Entropy.png'
+import normal from './Talent_Wind_Spirit_Creation.png'
+import skill from './Talent_Astable_Anemohypostasis_Creation_-_6308.png'
+import burst from './Talent_Forbidden_Creation_-_Isomer_75_Type_II.png'
+import passive1 from './Talent_Catalyst_Conversion.png'
+import passive2 from './Talent_Mollis_Favonius.png'
+import passive3 from './Talent_Astable_Invention.png'
+import ElementalData from '../../ElementalData'
+import Stat from '../../../Stat'
+import formula, { data } from './data'
+import { getTalentStatKey, getTalentStatKeyVariant } from "../../../Build/Build"
 
 const char = {
   name: "Sucrose",
@@ -23,14 +27,166 @@ const char = {
   gender: "F",
   constellationName: "Ampulla",
   titles: ["Harmless Sweetie", "Knights of Favonius Alchemist"],
-  baseStat: {
-    characterHP: [775, 1991, 2570, 3850, 4261, 4901, 5450, 6090, 6501, 7141, 7552, 8192, 8603, 9244],
-    characterATK: [14, 37, 47, 71, 78, 90, 100, 112, 120, 131, 139, 151, 159, 170],
-    characterDEF: [59, 151, 195, 293, 324, 373, 414, 463, 494, 543, 574, 623, 654, 703]
-  },
-  specializeStat: {
-    key: "anemo_dmg_",
-    value: [0, 0, 0, 0, 6, 6, 12, 12, 12, 12, 18, 18, 24, 24]
-  },
+  baseStat: data.baseStat,
+  specializeStat: data.specializeStat,
+  formula,
+  talent: {
+    auto: {
+      name: "Wind Spirit Creation",
+      img: normal,
+      infusable: false,
+      document: [{
+        text: <span><strong>Normal Attack</strong> Performs up to 4 attacks using Wind Spirits, dealing <span className="text-anemo">Anemo DMG</span>.</span>,
+        fields: data.normal.hitArr.map((percentArr, i) =>
+        ({
+          text: `${i + 1}-Hit DMG`,
+          formulaText: (tlvl, stats) => <span>{percentArr[tlvl]}% {Stat.printStat(getTalentStatKey("normal", stats), stats)}</span>,
+          formula: formula.normal[i],
+          variant: (tlvl, stats) => getTalentStatKeyVariant("normal", stats),
+        }))
+      }, {
+        text: <span><strong>Charged Attack</strong> Consumes a certain amount of Stamina and deals <span className="text-anemo">AoE Anemo DMG</span> after a short casting time.</span>,
+        fields: [{
+          text: "Charged Attack DMG",
+          formulaText: (tlvl, stats) => <span>{data.charged.hit[tlvl]}% {Stat.printStat(getTalentStatKey("charged", stats), stats)}</span>,
+          formula: formula.charged.hit,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("charged", stats),
+        }, {
+          text: "Stamina Cost",
+          value: "50"
+        }]
+      }, {
+        text: <span><strong>Plunging Attack</strong> Calling upon the power of her Wind Spirits, Sucrose plunges towards the ground from mid-air, damaging all opponents in her path. Deals <span className="text-anemo">AoE Anemo DMG</span> upon impact with the ground.</span>,
+        fields: [{
+          text: "Plunge DMG",
+          formulaText: (tlvl, stats) => <span>{data.plunging.dmg[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.dmg,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }, {
+          text: "Low Plunge DMG",
+          formulaText: (tlvl, stats) => <span>{data.plunging.low[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.low,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }, {
+          text: "High Plunge DMG",
+          formulaText: (tlvl, stats) => <span>{data.plunging.high[tlvl]}% {Stat.printStat(getTalentStatKey("plunging", stats), stats)}</span>,
+          formula: formula.plunging.high,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("plunging", stats),
+        }]
+      }],
+    },
+    skill: {
+      name: "Astable Anemohypostasis Creation - 6308",
+      img: skill,
+      document: [{
+        text: <span>
+          Creates a small Wind Spirit that pulls opponents and objects towards its location, launches opponents within its AoE, and deals Anemo DMG.
+        </span>,
+        fields: [{
+          text: "Skill DMG",
+          formulaText: (tlvl, stats) => <span>{data.skill.press[tlvl]}% {Stat.printStat(getTalentStatKey("skill", stats), stats)}</span>,
+          formula: formula.skill.press,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("skill", stats),
+        }, {
+          text: "CD",
+          value: "15s"
+        }]
+      }]
+    },
+    burst: {
+      name: "Forbidden Creation - Isomer 75 / Type II",
+      img: burst,
+      document: [{
+        text: <span>
+          <p className="mb-2">
+            Sucrose hurls an unstable concoction that creates a Large Wind Spirit.<br />
+            While it persists, the Large Wind Spirit will continuously pull in surrounding opponents and objects, launch nearby opponents, and deal <span className="text-anemo">Anemo DMG</span>.
+          </p>
+          <p className="mb-2">
+            If the Wind Spirit comes into contact with{' '}
+              <span className="text-pyro">Hydro</span>/
+              <span className="text-pyro">Pyro</span>/
+              <span className="text-cryo">Cryo</span>/
+              <span className="text-electro">Electro</span>
+              {' '}energy, it will deal additional elemental DMG of that type.<br />
+            Elemental Absorption may only occur once per use.
+          </p>
+        </span>,
+        fields: [{
+          text: "DoT",
+          formulaText: (tlvl, stats) => <span>{data.burst.dot[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
+          formula: formula.burst.dot,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+        }, {
+          text: "Additional Elemental DMG",
+          formulaText: (tlvl, stats) => <span>{data.burst.additionalElementalDMG[tlvl]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
+          formula: formula.burst.additionalElementalDMG,
+          variant: (tlvl, stats) => getTalentStatKeyVariant("burst", stats),
+        }, {
+          text: "Duration",
+          value: "6s"
+        }, {
+          text: "CD",
+          value: "20s"
+        }, {
+          text: "Energy Cost",
+          value: "80"
+        }]
+      }]
+    },
+    passive1: {
+      name: "Astable Invention",
+      img: passive1,
+      document: [{ text: <span>When Sucrose crafts Character and Weapon Enhancement Materials, she has a 10% to obtain double the product.</span> }],
+    },
+    passive2: {
+      name: "Catalyst Conversion",
+      img: passive2,
+      document: [{ text: <span>When Sucrose triggers a Swirl reaction, all characters in the party with the matching element (excluding Sucrose) have their Elemental Mastery increased by 50 for 8s.</span> }],
+    },
+    passive3: {
+      name: "Mollis Favonius",
+      img: passive3,
+      document: [{ text: <span>When Astable Anemohypostasis Creation - 6308 or Forbidden Creation - Isomer 75 / Type II hits an opponent, increases all party members' (excluding Sucrose) Elemental Mastery by an amount equal to 20% of Sucrose's Elemental Mastery for 8s.</span> }],
+    },
+    constellation1: {
+      name: "Clustered Vacuum Field",
+      img: c1,
+      document: [{ text: <span>Astable Anemohypostasis Creation - 6308 gains 1 additional charge.</span> }],
+    },
+    constellation2: {
+      name: "Beth: Unbound Form",
+      img: c2,
+      document: [{ text: <span>The duration of Forbidden Creation - Isomer 75 / Type II is increased by 2s.</span> }],
+    },
+    constellation3: {
+      name: "Flawless Alchemistress",
+      img: c3,
+      talentBoost: { skill: 3 },
+      document: [{ text: <span>
+        Increases the Level of Astable Anemohypostasis Creation - 6308 by 3.<br />
+        Maximum upgrade level is 15.
+      </span> }],
+    },
+    constellation4: {
+      name: "Alchemania",
+      img: c4,
+      document: [{ text: <span>Every 7 Normal and Charged Attacks, Sucrose will reduce the CD of Astable Anemohypostasis Creation - 6308 by 1-7s.</span> }],
+    },
+    constellation5: {
+      name: "Caution: Standard Flask",
+      img: c5,
+      talentBoost: { skill: 5 },
+      document: [{ text: <span>
+        Increases the Level of Forbidden Creation - Isomer 75 / Type II by 3.<br />
+        Maximum upgrade level is 15.
+      </span> }],
+    },
+    constellation6: {
+      name: "Chaotic Entropy",
+      img: c6,
+      document: [{ text: <span>If Forbidden Creation - Isomer 75 / Type II triggers an Elemental Absorption, all party members gain a 20% Elemental DMG Bonus for the corresponding absorbed element during its duration.</span> }],
+    }
+  }
 };
 export default char;

--- a/src/Data/Characters/Sucrose/index.js
+++ b/src/Data/Characters/Sucrose/index.js
@@ -176,7 +176,7 @@ const char = {
     constellation5: {
       name: "Caution: Standard Flask",
       img: c5,
-      talentBoost: { skill: 5 },
+      talentBoost: { burst: 3 },
       document: [{ text: <span>
         Increases the Level of Forbidden Creation - Isomer 75 / Type II by 3.<br />
         Maximum upgrade level is 15.

--- a/src/Data/Characters/formula.js
+++ b/src/Data/Characters/formula.js
@@ -19,7 +19,7 @@ import ningguang from './Ningguang/data'
 import noelle from './Noelle/data'
 // import qiqi from './Qiqi/data'
 // import razor from './Razor/data'
-// import sucrose from './Sucrose/data'
+import sucrose from './Sucrose/data'
 // import tartaglia from './Tartaglia/data'
 // import traveler_anemo from './Traveler Anemo/data'
 // import traveler_geo from './Traveler Geo/data'
@@ -51,7 +51,7 @@ const formula = {
   noelle,
   // qiqi,
   // razor,
-  // sucrose,
+  sucrose,
   // tartaglia,
   // traveler_anemo,
   // traveler_geo,


### PR DESCRIPTION
I don't think there's anything 'extra' required with this PR other than one thing regarding swirl reactions mentioned below

Data was taken from https://genshin.honeyhunterworld.com/db/char/sucrose/
***
Since I based it off of `Data/Characters/Venti/data.js`, I removed extra entry next to burst because I have no idea how are you going to evaluate `additionalElementalDMG` into swirl calculations

Talking about this part (excerpt from Sucrose file)
```
  burst: Object.fromEntries([
    ...Object.entries(data.burst).map(([name, arr]) =>
      [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "burst")]),
  ]),
  ```

while on Venti's page, it displays all swirl elements + some formula that I have no idea about
  ```
    burst: Object.fromEntries([
    ...Object.entries(data.burst).map(([name, arr]) =>
      [name, (tlvl, stats) => basicDMGFormula(arr[tlvl], stats, "burst")]),
    ...Object.entries(data.burst).flatMap(([name, arr]) =>
      (["hydro", "pyro", "cryo", "electro"]).map((ele) =>
        [`${ele}_${name}`, (tlvl, stats) => [s=>(arr[tlvl] / 2 / 100) * stats[`${ele}_burst_${stats.hitMode}`], [`${ele}_burst_${stats.hitMode}`]]])),//not optimizationTarget, dont need to precompute
  ]),
  ```
  
I guess it would be better for you to adjust it somehow to your needs.