### PR TITLE
Added filter option for artifacts: 'Currently Equipped', showing all currently equipped artifacts while ignoring the ones from inventory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://frzyc.github.io/genshin-optimizer/",
   "name": "genshin-optimizer",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/src/Artifact/ArtifactDisplay.js
+++ b/src/Artifact/ArtifactDisplay.js
@@ -106,11 +106,12 @@ export default class ArtifactDisplay extends React.Component {
     let locationDisplay
     if (!filterLocation) locationDisplay = <span>Location: Any</span>
     else if (filterLocation === "Inventory") locationDisplay = <span>Location: Inventory</span>
+    else if (filterLocation === "Equipped") locationDisplay = <span>Location: Equipped</span>
     else locationDisplay = <b>{Character.getName(filterLocation)}</b>
     let artifacts = Object.values(artifactDB).filter(art => {
       if (filterLocation) {
         if (filterLocation === "Inventory" && art.location) return false;
-        else if (filterLocation !== "Inventory" && filterLocation !== art.location) return false;
+        else if (filterLocation === "Equipped" && !art.location) return false;
       }
       if (filterArtSetKey && filterArtSetKey !== art.setKey) return false;
       if (filterSlotKey && filterSlotKey !== art.slotKey) return false
@@ -290,6 +291,7 @@ export default class ArtifactDisplay extends React.Component {
                   <Dropdown.Menu>
                     <Dropdown.Item onClick={() => this.setState({ filterLocation: "" })}>Unselect</Dropdown.Item>
                     <Dropdown.Item onClick={() => this.setState({ filterLocation: "Inventory" })}>Inventory</Dropdown.Item>
+                    <Dropdown.Item onClick={() => this.setState({ filterLocation: "Equipped" })}>Currently Equipped</Dropdown.Item>
                     <Dropdown.Divider />
                     <CharacterSelectionDropdownList onSelect={cid => this.setState({ filterLocation: cid })} />
                   </Dropdown.Menu>


### PR DESCRIPTION
Simple filter in artifacts view - added:
- `Equipped` option for `filterLocation` key
- `Currently Equipped` in dropdown view
- Logic showing only artifacts that are currently equipped by any character

Discord message:
https://discord.com/channels/785153694478893126/785176576110231583/821616085349695498

Image showing the implemented feature
![image](https://user-images.githubusercontent.com/76654426/111421977-32f22300-86ee-11eb-9be7-b83981af05b9.png)