### PR TITLE
[Artifact Display] Fixed the issue with artifact location filtering

### DIFF
--- a/src/Artifact/ArtifactDisplay.js
+++ b/src/Artifact/ArtifactDisplay.js
@@ -110,9 +110,10 @@ export default class ArtifactDisplay extends React.Component {
     else locationDisplay = <b>{Character.getName(filterLocation)}</b>
     let artifacts = Object.values(artifactDB).filter(art => {
       if (filterLocation) {
-        if (filterLocation === "Inventory" && art.location) return false;
-        else if (filterLocation === "Equipped" && !art.location) return false;
-        else if (filterLocation !== art.location) return false;
+        if (filterLocation === "Inventory" && !art.location) {}
+        else if (filterLocation === "Equipped" && art.location) {}
+        else if (filterLocation === art.location) {}
+        else return false;
       }
       if (filterArtSetKey && filterArtSetKey !== art.setKey) return false;
       if (filterSlotKey && filterSlotKey !== art.slotKey) return false


### PR DESCRIPTION
Artifact display filtering logic followed "reject if meets unwanted condition", which is hard for mental management. It was also bugged after mentioned fix in patch [4.6.1](https://discord.com/channels/785153694478893126/785976604584050758/821775866211598346) (discord link) - "equipped" and per character select displayed no results

This commit reversed the logic - now if it meets criteria, it just skips the else branch and eventually ending up at last `else` rejecting the entry.

Video showing the fix (this commit):
https://streamable.com/m0tbvr