### PR TITLE
Implement reactionChance to specify how likely an elemental reaction is to happen

### DIFF
--- a/src/Build/BuildDisplay.tsx
+++ b/src/Build/BuildDisplay.tsx
@@ -151,7 +151,7 @@ export default function BuildDisplay({ location: { characterKey: propCharacterKe
     else isMounted.current = true
   }, [characterKey, maxBuildsToShow])
 
-  //validate optimizationTarget 
+  //validate optimizationTarget
   useEffect(() => {
     if (!statsDisplayKeys) return
     if (!Array.isArray(optimizationTarget)) return
@@ -630,7 +630,7 @@ function StatFilterItem({ statKey, statKeys = [], min, max, close, setFilter }: 
 
 function HitModeCard({ characterSheet, character, build, className }: { characterSheet: CharacterSheet, character: ICharacter, build: ICalculatedStats, className: string }) {
   const setHitmode = useCallback(({ hitMode }) => CharacterDatabase.update({ ...character, hitMode }), [character])
-  const setReactionMode = useCallback(({ reactionMode }) => CharacterDatabase.update({ ...character, reactionMode }), [character])
+  const setReactionMode = useCallback(({ reactionMode, reactionChance }) => CharacterDatabase.update({ ...character, reactionMode, reactionChance }), [character])
   const setInfusionAura = useCallback(({ infusionAura }) => CharacterDatabase.update({ ...character, infusionAura }), [character])
   if (!character) return null
   return <Card bg="lightcontent" text={"lightfont" as any} className={className}>

--- a/src/Character/Character.ts
+++ b/src/Character/Character.ts
@@ -151,7 +151,7 @@ export default class Character {
 
   static createInitialStats = (character: ICharacter, characterSheet: CharacterSheet, weaponSheet: WeaponSheet): ICalculatedStats => {
     character = deepClone(character)
-    const { characterKey, elementKey, levelKey, hitMode, infusionAura, reactionMode, talentLevelKeys, constellation, equippedArtifacts, conditionalValues = {}, weapon = { key: "", refineIndex: 0 } } = character
+    const { characterKey, elementKey, levelKey, hitMode, infusionAura, reactionMode, reactionChance, talentLevelKeys, constellation, equippedArtifacts, conditionalValues = {}, weapon = { key: "", refineIndex: 0 } } = character
     const ascension = Character.getAscension(levelKey)
 
     //generate the initalStats obj with data from Character & overrides
@@ -162,6 +162,7 @@ export default class Character {
     initialStats.hitMode = hitMode;
     initialStats.infusionAura = infusionAura
     initialStats.reactionMode = reactionMode;
+    initialStats.reactionChance = reactionChance;
     initialStats.conditionalValues = conditionalValues
     initialStats.weaponType = characterSheet.weaponTypeKey
     initialStats.tlvl = talentLevelKeys;

--- a/src/Character/CharacterDisplay/DamageOptionsAndCalculation.tsx
+++ b/src/Character/CharacterDisplay/DamageOptionsAndCalculation.tsx
@@ -43,12 +43,12 @@ type ReactionToggleProps = {
   characterDispatch: (any) => void,
   className: string
 }
-export function ReactionToggle({ character: { reactionMode = "none", infusionAura }, build, characterDispatch, className }: ReactionToggleProps) {
+export function ReactionToggle({ character: { reactionMode = "none", infusionAura, reactionChance = 100 }, build, characterDispatch, className }: ReactionToggleProps) {
   if (reactionMode === null) reactionMode = "none"
   const charEleKey = build.characterEle
   if (!["pyro", "hydro", "cryo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusionAura)) return null
-  return <ToggleButtonGroup className={className} type="radio" name="reactionMode" value={reactionMode} onChange={val => characterDispatch({ reactionMode: val === "none" ? null : val })}>
-    <ToggleButton value={"none"} variant={reactionMode === "none" ? "success" : "primary"}>No Reactions</ToggleButton >
+  return <Dropdown as={ToggleButtonGroup} className={className} type="radio" name="reactionMode" value={reactionMode} onChange={val => characterDispatch({ reactionMode: val === "none" ? null : val, reactionChance })}>
+    <ToggleButton value={"none"} variant={reactionMode === "none" ? "success" : "primary"}>No Reaction</ToggleButton >
     {(charEleKey === "pyro" || infusionAura === "pyro") && <ToggleButton value={"pyro_vaporize"} variant={reactionMode === "pyro_vaporize" ? "success" : "primary"}>
       <span className="text-vaporize">Vaporize(Pyro) <Image src={Assets.elements.hydro} className="inline-icon" />+<Image src={Assets.elements.pyro} className="inline-icon" /></span>
     </ToggleButton >}
@@ -61,7 +61,15 @@ export function ReactionToggle({ character: { reactionMode = "none", infusionAur
     {(charEleKey === "cryo" || infusionAura === "cryo") && <ToggleButton value={"cryo_melt"} variant={reactionMode === "cryo_melt" ? "success" : "primary"}>
       <span className="text-melt">Melt(Cryo) <Image src={Assets.elements.pyro} className="inline-icon" />+<Image src={Assets.elements.cryo} className="inline-icon" /></span>
     </ToggleButton >}
-  </ToggleButtonGroup>
+    <Dropdown.Toggle split variant="primary" />
+    <Dropdown.Menu onSelect={e => console.log(e)} >
+      <Dropdown.Header className="text-reactionChance">Reaction Chance</Dropdown.Header>
+      {Array.from({length: 10}, (_, i) => 10 + i * 10).map(i =>
+        <Dropdown.Item active={reactionChance === i} onSelect={() => characterDispatch({ reactionMode, reactionChance: i })}>
+          {i} %
+        </Dropdown.Item>)}
+    </Dropdown.Menu>
+  </Dropdown>
 }
 export function HitModeToggle({ hitMode, characterDispatch, className }) {
   return <ToggleButtonGroup type="radio" value={hitMode} name="hitOptions" onChange={m => characterDispatch({ hitMode: m })} className={className}>

--- a/src/Character/CharacterDisplayCard.tsx
+++ b/src/Character/CharacterDisplayCard.tsx
@@ -46,6 +46,7 @@ const initialCharacter = (characterKey): ICharacter => ({
   levelKey: "L1",//combination of level and ascension
   hitMode: "avgHit",
   reactionMode: null,
+  reactionChance: 100,
   equippedArtifacts: Object.fromEntries(allSlotKeys.map(sKey => [sKey, ""])),
   conditionalValues: {},
   baseStatOverrides: {},//overriding the baseStat
@@ -172,8 +173,9 @@ export default function CharacterDisplayCard({ characterKey: propCharacterKey, c
     const newBuild = propNewBuild && deepClone(propNewBuild);
     newBuild.hitMode = character.hitMode;
     newBuild.reactionMode = character.reactionMode;
+    newBuild.reactionChance = character.reactionChance;
     return newBuild
-  }, [propNewBuild, character.hitMode, character.reactionMode])
+  }, [propNewBuild, character.hitMode, character.reactionMode, character.reactionChance])
 
   const { levelKey, artifacts: flexArts } = character
 

--- a/src/Data/Characters/Bennett/data.test.ts
+++ b/src/Data/Characters/Bennett/data.test.ts
@@ -66,6 +66,7 @@ describe("Testing Bennett's Formulas (Mabmab#6492)", () => {
       beforeEach(() => {
         setupStats.hitMode = "hit"
         setupStats.reactionMode = "pyro_vaporize"
+        setupStats.reactionChance = 100
       })
 
       test("hit", () => {
@@ -115,10 +116,19 @@ describe("Testing Bennett's Formulas (Mabmab#6492)", () => {
         setupStats.hitMode = "critHit"
         setupStats.reactionMode = "pyro_vaporize"
       })
-
-      test("hit", () => {
-        const stats = computeAllStats(setupStats)
-        expect(formula.skill.press(stats)[0](stats)).toApproximate(9203)
+      describe("with 100% reactionChance", () => {
+        beforeEach(() => setupStats.reactionChance = 100)
+        test("hit", () => {
+          const stats = computeAllStats(setupStats)
+          expect(formula.skill.press(stats)[0](stats)).toApproximate(9203)
+        })
+      })
+      describe("with 50% reactionChance", () => {
+        beforeEach(() => setupStats.reactionChance = 50)
+        test("hit", () => {
+          const stats = computeAllStats(setupStats)
+          expect(formula.skill.press(stats)[0](stats)).toApproximate(6920)
+        })
       })
     })
   })

--- a/src/Data/Characters/Diona/data1.test.ts
+++ b/src/Data/Characters/Diona/data1.test.ts
@@ -60,6 +60,7 @@ describe("Testing Diona's Formulas (⛧ Sin ⛧#0663)", () => {
       })
       test('melt', () => {
         setupStats.reactionMode = "cryo_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.charged.fullAimedShot(stats)[0](stats)).toApproximate(1694)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(825)

--- a/src/Data/Characters/Kaeya/data.test.ts
+++ b/src/Data/Characters/Kaeya/data.test.ts
@@ -49,6 +49,7 @@ describe("Testing Kaeya's Formulas (Derpy#2132)", () => {
       });
       test('melt', () => {
         setupStats.reactionMode = "cryo_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(1711)
       })
@@ -78,6 +79,7 @@ describe("Testing Kaeya's Formulas (Derpy#2132)", () => {
       });
       test('melt', () => {
         setupStats.reactionMode = "cryo_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(3925)
       })

--- a/src/Data/Characters/Klee/data.test.ts
+++ b/src/Data/Characters/Klee/data.test.ts
@@ -64,21 +64,45 @@ describe("Testing Klee's Formulas", () => {
       describe("with vaporize", () => {
         beforeEach(() => setupStats.reactionMode = "pyro_vaporize")
 
-        test("hits", () => {
-          const stats = computeAllStats(setupStats)
-          expect(formula.normal[0](stats)[0](stats)).toApproximate(1444)
-          expect(formula.charged.dmg(stats)[0](stats)).toApproximate(3149)
-          expect(formula.skill.jumpyDmg(stats)[0](stats)).toApproximate(1905)
-          expect(formula.burst.dmg(stats)[0](stats)).toApproximate(853)
+        describe("with 100% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 100)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1444)
+            expect(formula.charged.dmg(stats)[0](stats)).toApproximate(3149)
+            expect(formula.skill.jumpyDmg(stats)[0](stats)).toApproximate(1905)
+            expect(formula.burst.dmg(stats)[0](stats)).toApproximate(853)
+          })
+        })
+        describe("with 50% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 50)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1039)
+            expect(formula.charged.dmg(stats)[0](stats)).toApproximate(2267)
+            expect(formula.skill.jumpyDmg(stats)[0](stats)).toApproximate(1371)
+            expect(formula.burst.dmg(stats)[0](stats)).toApproximate(614)
+          })
         })
       })
       describe("with melt", () => {
         beforeEach(() => setupStats.reactionMode = "pyro_melt")
 
-        test("hits", () => {
-          const stats = computeAllStats(setupStats)
-          expect(formula.normal[0](stats)[0](stats)).toApproximate(1925)
-          expect(formula.charged.dmg(stats)[0](stats)).toApproximate(4199)
+        describe("with 100% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 100)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1925)
+            expect(formula.charged.dmg(stats)[0](stats)).toApproximate(4199)
+          })
+        })
+        describe("with 50% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 50)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1280)
+            expect(formula.charged.dmg(stats)[0](stats)).toApproximate(2792)
+          })
         })
       })
     })

--- a/src/Data/Characters/Mona/data.test.ts
+++ b/src/Data/Characters/Mona/data.test.ts
@@ -54,10 +54,21 @@ describe("Testing Mona's Formulas", () => {
       describe("vaporize", () => {
         beforeEach(() => setupStats.reactionMode = "hydro_vaporize")
 
-        test("hits", () => {
-          const stats = computeAllStats(setupStats)
-          expect(formula.normal[0](stats)[0](stats)).toApproximate(1155)
-          expect(formula.charged.hit(stats)[0](stats)).toApproximate(4599)
+        describe("with 100% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 100)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1155)
+            expect(formula.charged.hit(stats)[0](stats)).toApproximate(4599)
+          })
+        })
+        describe("with 100% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 50)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(820)
+            expect(formula.charged.hit(stats)[0](stats)).toApproximate(3265)
+          })
         })
       })
     })
@@ -72,10 +83,21 @@ describe("Testing Mona's Formulas", () => {
       describe("vaporize", () => {
         beforeEach(() => setupStats.reactionMode = "hydro_vaporize")
 
-        test("hits", () => {
-          const stats = computeAllStats(setupStats)
-          expect(formula.normal[0](stats)[0](stats)).toApproximate(2398)
-          expect(formula.charged.hit(stats)[0](stats)).toApproximate(9552)
+        describe("with 100% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 100)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(2398)
+            expect(formula.charged.hit(stats)[0](stats)).toApproximate(9552)
+          })
+        })
+        describe("with 50% reactionChance", () => {
+          beforeEach(() => setupStats.reactionChance = 50)
+          test("hits", () => {
+            const stats = computeAllStats(setupStats)
+            expect(formula.normal[0](stats)[0](stats)).toApproximate(1703)
+            expect(formula.charged.hit(stats)[0](stats)).toApproximate(6782)
+          })
         })
       })
     })

--- a/src/Data/Characters/Rosaria/data.test.ts
+++ b/src/Data/Characters/Rosaria/data.test.ts
@@ -54,6 +54,7 @@ describe("Testing Tartaglia's Formulas (Derpy#2132)", () => {
         })
         test("cryo_melt", () => {
           setupStats.reactionMode = "cryo_melt"
+          setupStats.reactionChance = 100
           const stats = computeAllStats(setupStats)
           expect(formula.skill.hit1(stats)[0](stats)).toApproximate(1295)
           expect(formula.skill.hit2(stats)[0](stats)).toApproximate(3016)
@@ -113,6 +114,7 @@ describe("Testing Tartaglia's Formulas (Derpy#2132)", () => {
         })
         test("cryo_melt", () => {
           setupStats.reactionMode = "cryo_melt"
+          setupStats.reactionChance = 100
           const stats = computeAllStats(setupStats)
           expect(formula.skill.hit1(stats)[0](stats)).toApproximate(2355)
           expect(formula.skill.hit2(stats)[0](stats)).toApproximate(5486)

--- a/src/Data/Characters/Xinyan/data1.test.ts
+++ b/src/Data/Characters/Xinyan/data1.test.ts
@@ -49,11 +49,13 @@ describe("Testing Xinyan's Formulas (Stain#9093)", () => {
 
       test("vaorize", () => {
         setupStats.reactionMode = "pyro_vaporize"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(5098)
       })
       test("melt", () => {
         setupStats.reactionMode = "pyro_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(6798)
       })

--- a/src/Data/Characters/Yanfei/data.test.ts
+++ b/src/Data/Characters/Yanfei/data.test.ts
@@ -46,12 +46,14 @@ describe("Testing Yanfei's Formulas (Stain#9093)", () => {
       });
       test('vaporize', () => {
         setupStats.reactionMode = "pyro_vaporize"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(5729);
         expect(formula.burst.dmg(stats)[0](stats)).toApproximate(6161);
       })
       test('melt', () => {
         setupStats.reactionMode = "pyro_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(7639);
         expect(formula.burst.dmg(stats)[0](stats)).toApproximate(8215);
@@ -111,12 +113,14 @@ describe("Testing Yanfei's Formulas (Stain#9093)", () => {
       });
       test('vaporize', () => {
         setupStats.reactionMode = "pyro_vaporize"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(13759);
         expect(formula.burst.dmg(stats)[0](stats)).toApproximate(14798);
       })
       test('melt', () => {
         setupStats.reactionMode = "pyro_melt"
+        setupStats.reactionChance = 100
         const stats = computeAllStats(setupStats)
         expect(formula.skill.dmg(stats)[0](stats)).toApproximate(18346);
         expect(formula.burst.dmg(stats)[0](stats)).toApproximate(19731);

--- a/src/Stat.tsx
+++ b/src/Stat.tsx
@@ -129,7 +129,7 @@ Object.entries(amplifyingReactions).forEach(([reaction, { variants }]) => {
     Object.entries(hitTypes).forEach(([type, typeName]) => {
       Object.entries(hitMoves).forEach(([move, moveName]) => {
         FormulaText[`${ele}_${reaction}_${move}_${type}_multi`] = (o) => <span>{f(o, `${ele}_${move}_${type}_multi`)} * {f(o, `${ele}_${reaction}_multi`)}</span>
-        FormulaText[`${ele}_${reaction}_${move}_${type}`] = (o) => <span>{f(o, "finalATK")} * {f(o, `${ele}_${reaction}_${move}_${type}_multi`)}</span>
+        FormulaText[`${ele}_${reaction}_${move}_${type}`] = (o) => <span>{f(o, "finalATK")} * {f(o, `${ele}_${reaction}_${move}_${type}_multi`)} * {f(o, "reactionChance")} + {f(o, "finalATK")} * {f(o, `${ele}_${move}_${type}_multi`)} * (1 - {f(o, "reactionChance")})</span>
       })
     })
   })

--- a/src/StatData.ts
+++ b/src/StatData.ts
@@ -62,6 +62,7 @@ const StatData: { [stat: string]: StatItem } = {
   heal_multi: { name: "Heal multiplier", unit: "multi" },
 
   // Reaction
+  reactionChance: { name: "Reaction Chance", unit: "%", const: true },
   transformative_level_multi: { name: "Reaction Level Multiplier", unit: "multi", const: true },
   amplificative_dmg_: { name: "Amplificative Reaction DMG Bonus", unit: "%" },
   transformative_dmg_: { name: "Transformative Reaction DMG Bonus", unit: "%" },
@@ -203,7 +204,7 @@ Object.entries(amplifyingReactions).forEach(([reaction, { name, variants }]) => 
         StatData[`${ele}_${reaction}_${move}_${type}`] = { name: `${name} ${moveName} ${typeName}`, ...opt }
 
         Formulas[`${ele}_${reaction}_${move}_${type}_multi`] = (s) => s[`${ele}_${move}_${type}_multi`] * s[`${ele}_${reaction}_multi`]
-        Formulas[`${ele}_${reaction}_${move}_${type}`] = (s) => s.finalATK * s[`${ele}_${reaction}_${move}_${type}_multi`]
+        Formulas[`${ele}_${reaction}_${move}_${type}`] = (s, c) => s.finalATK * s[`${ele}_${reaction}_${move}_${type}_multi`] * c.reactionChance/100 + s.finalATK * s[`${ele}_${move}_${type}_multi`] * (1 - c.reactionChance/100)
       })
     })
   })

--- a/src/Types/ICalculatedStats.d.ts
+++ b/src/Types/ICalculatedStats.d.ts
@@ -21,6 +21,7 @@ export default interface ICalculatedStats {
   weaponType: string
   hitMode: HitModeKey
   reactionMode: reactionModeKey | null
+  reactionChance: number
   infusionAura: ElementKey | ""
   finalHP: number
 }

--- a/src/Types/character.d.ts
+++ b/src/Types/character.d.ts
@@ -39,6 +39,7 @@ export interface ICharacter {
   hitMode: HitModeKey
   elementKey?: ElementKey
   reactionMode: reactionModeKey | null
+  reactionChance: number
   equippedArtifacts: StrictDict<SlotKey, string>,
   conditionalValues: any,
   baseStatOverrides: {},//overriding the baseStat


### PR DESCRIPTION
Hey!

First of all, great work, I really like your optimizer.

But what's always been bugging me is the available choices for elemental reactions.
Either you have no reaction which makes EM useless, or you have a 100% chance of melt/vaporize which makes the optimizer choose EM over all other stats.

<https://genshinimpactcalculator.com/genshinCalc> goes around this problem by allowing you to specify how likely an elemental reaction is to happen.

This PR is just a rough idea of how to implement it and I'd like to hear your thoughts on how it could be improved.

![image](https://user-images.githubusercontent.com/11648852/123496119-e68c7c80-d626-11eb-93c0-56d31879eb90.png)

![image](https://user-images.githubusercontent.com/11648852/123496230-48e57d00-d627-11eb-80b1-2d107daa432a.png)

It should default to 100% reaction chance, so unless the reaction chance is changed it should continue to function like before.
