### PR TITLE
Added Full Elemental Burst Damage section and optim. targets to Razor.

### DIFF
--- a/public/locales/en/char_razor.json
+++ b/public/locales/en/char_razor.json
@@ -1,0 +1,5 @@
+{
+  "fullBurstDMG": {
+    "text": "<0><0><0>Full Elemental Burst DMG</0></0><1>This calculates the combined damage from Razor's normal attacks during his Elemental Burst. It simply sums the Companion X-Hit DMG with the corresponding X-Hit DMG of the normal attack which triggers it.</1></0>"
+  }
+}

--- a/src/Data/Characters/razor/data.ts
+++ b/src/Data/Characters/razor/data.ts
@@ -1,4 +1,5 @@
-import { IFormulaSheet } from "../../../Types/character"
+import { FormulaItem, IFormulaSheet } from "../../../Types/character"
+import { BasicStats } from "../../../Types/stats"
 import { basicDMGFormula } from "../../../Util/FormulaUtil"
 
 const data = {
@@ -48,6 +49,23 @@ const formula: IFormulaSheet = {
   constellation6: {
     dmg: stats => basicDMGFormula(100, stats, "elemental"),
   }
+}
+
+formula.burstCombo = {
+  ...Object.fromEntries([0, 1, 2, 3].map((i) => {
+    const comboFormula = (stats: BasicStats): FormulaItem => {
+      const normalFormula = formula.normal[i](stats);
+      const burstFormula = formula.burst[i](stats);
+      
+      // Just add 'em together!
+      return [
+        (s) => (normalFormula[0](s) + burstFormula[0](s)),
+        [...normalFormula[1], ...burstFormula[1]]
+      ]
+    };
+
+    return [i, comboFormula];
+  }))
 }
 
 export default formula

--- a/src/Data/Characters/razor/data2.test.ts
+++ b/src/Data/Characters/razor/data2.test.ts
@@ -1,0 +1,57 @@
+import { applyArtifacts, computeAllStats, createProxiedStats, parseTestFlexObject } from "../TestUtils"
+import formula from "./data"
+
+const string = "https://frzyc.github.io/genshin-optimizer/#/flex?v=2&d=545k01049p14W03z0a4245k03147x0aJ19t14n195g0424a423P08W02F1g5k0c349J12W0aS08E295k04446912629e15G0k203003L8007553mphysical_enemyImmunity3NaNaenemyLevel277iphysical_enemyRes_270fPrototypeAminus3L800101000"
+const { artifacts } = parseTestFlexObject(string)
+
+let setupStats
+describe("Testing Steel + Lightning (by EliteMasterEric#3723)", () => {
+  beforeEach(() => {
+    setupStats = createProxiedStats({
+      characterHP: 10602, characterATK: 704 - 497, characterDEF: 665,
+      characterEle: "electro", characterLevel: 80,
+      weaponType: "claymore", weaponATK: 497,
+      atk_: 25.1,//prototype Archiac R1
+      physical_dmg_: 22.5,//specialized
+
+      enemyLevel: 77, physical_enemyRes_: 70, // Ruin Guard
+      dmg_: 10,//C1
+      tlvl: Object.freeze({ auto: 8 - 1, skill: 6 - 1, burst: 9 - 1 }),
+    })
+  })
+
+  describe("with artifacts", () => {
+    beforeEach(() => applyArtifacts(setupStats, [
+      ...artifacts,
+      { physical_dmg_: 25, atk_: 18 }, // 2 piece bloodstained 2 piece gladiator
+    ]))
+
+    describe("no crit", () => {
+      beforeEach(() => setupStats.hitMode = "hit")
+
+      test("hit", () => {
+        const stats = computeAllStats(setupStats)
+
+        // Calculate combined damage of normal attack and burst.
+        expect(formula.burstCombo[0](stats)[0](stats)).toApproximate(1041 + 650)
+        expect(formula.burstCombo[1](stats)[0](stats)).toApproximate(897 + 560)
+        expect(formula.burstCombo[2](stats)[0](stats)).toApproximate(1122 + 700)
+        expect(formula.burstCombo[3](stats)[0](stats)).toApproximate(1477 + 922)
+      })
+
+    })
+    describe("crit", () => {
+      beforeEach(() => setupStats.hitMode = "critHit")
+
+      test("hit", () => {
+        const stats = computeAllStats(setupStats)
+
+        // Calculate combined damage of normal attack and burst.
+        expect(formula.burstCombo[0](stats)[0](stats)).toApproximate(2008 + 1252)
+        expect(formula.burstCombo[1](stats)[0](stats)).toApproximate(1730 + 1079)
+        expect(formula.burstCombo[2](stats)[0](stats)).toApproximate(2163 + 1349)
+        expect(formula.burstCombo[3](stats)[0](stats)).toApproximate(2848 + 1777)
+      })
+    })
+  })
+})

--- a/src/Data/Characters/razor/index.tsx
+++ b/src/Data/Characters/razor/index.tsx
@@ -18,7 +18,7 @@ import data_gen from './data_gen.json'
 import { getTalentStatKey, getTalentStatKeyVariant, } from "../../../Build/Build"
 import { IConditionals } from '../../../Types/IConditional'
 import { ICharacterSheet } from '../../../Types/character'
-import { Translate } from '../../../Components/Translate'
+import { Translate, TransWrapper } from '../../../Components/Translate'
 import { claymoreChargedDocSection, normalDocSection, plungeDocSection, talentTemplate } from '../SheetUtil'
 const tr = (strKey: string) => <Translate ns="char_razor_gen" key18={strKey} />
 const conditionals: IConditionals = {
@@ -142,7 +142,8 @@ const char: ICharacterSheet = {
             formulaText: stats => <span>{data.burst.dmg[stats.tlvl.burst]}% * {percentArr[stats.tlvl.auto]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
             formula: formula.burst[i],
             variant: stats => getTalentStatKeyVariant("burst", stats),
-          })), {
+          })),
+          {
             text: "Duration",
             value: "15s",
           }, {
@@ -152,7 +153,21 @@ const char: ICharacterSheet = {
             text: "Energy Cost",
             value: 80,
           }],
-          conditional: conditionals.q
+        }, {
+          text: (
+            <TransWrapper ns="char_razor" key18="fullBurstDMG.text"><span>
+              <h6><strong>Full Elemental Burst DMG</strong></h6>
+              <p className="mb-2">This calculates the combined damage from Razor's normal attacks during his Elemental Burst.
+              It simply sums the Companion X-Hit DMG with the corresponding X-Hit DMG of the normal attack which triggers it.</p>
+            </span></TransWrapper>
+          ),
+          fields: data.normal.hitArr.map((percentArr, i) => ({
+              text: `Steel + Lightning ${i + 1}-Hit DMG`,
+              formulaText: stats => <span>
+                {percentArr[stats.tlvl.auto]}% {Stat.printStat(getTalentStatKey("normal", stats), stats)}
+                + {data.burst.dmg[stats.tlvl.burst]}% * {percentArr[stats.tlvl.auto]}% {Stat.printStat(getTalentStatKey("burst", stats), stats)}</span>,
+              formula: formula.burstCombo[i],
+            })),
         }],
       },
       passive1: talentTemplate("passive1", tr, passive1),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4635334/128626780-b7734e9b-f3b7-4b5f-b8cc-e4618c251135.png)

This PR adds four additional fields to Razor's elemental burst:

* Steel + Lightning 1-Hit DMG
* Steel + Lightning 2-Hit DMG
* Steel + Lightning 3-Hit DMG
* Steel + Lightning 4-Hit DMG

These sum up the damage dealt by Steel Fang hits with their corresponding Lightning Fang hits. By targeting these values when generating builds, Razor mains can provide better optimizations for hybrid builds, placing higher emphasis on Crit Rate and Crit DMG (which provide bonuses to both normal attack and burst) while preventing Phys DMG from either being ignored entirely or overinvested in.

Tasks done include:

- [x] Add new field and optimization targets for Razor.
- [x] Add formatted translation key for the explanation of these values.
- [x] Add additional unit tests to calculate and compare these values to known ones.