### PR TITLE
Refine 3 Broken pines using incorrect atk value

### DIFF
--- a/src/Data/Weapons/Claymore/SongOfBrokenPines/index.tsx
+++ b/src/Data/Weapons/Claymore/SongOfBrokenPines/index.tsx
@@ -4,7 +4,7 @@ import { IConditionals } from '../../../../Types/IConditional'
 import { IWeaponSheet } from '../../../../Types/weapon'
 import data_gen from './data_gen.json'
 import img from './Weapon_Song_of_Broken_Pines.png'
-const atk_ = [16, 20, 34, 28, 32]
+const atk_ = [16, 20, 24, 28, 32]
 const atkSPD_ = [12, 15, 18, 21, 24]
 const condAtk_ = [20, 25, 30, 35, 40]
 const conditionals: IConditionals = {


### PR DESCRIPTION
Refinement 3 of Broken Pines shows an incorrect bonus attack stat, despite having the correct description