### PR TITLE
Fixed issue with Raiden Shogun's Talent names and icons not displaying properly

### DIFF
--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -11,9 +11,9 @@ import c6 from './Constellation_Wishbearer.png'
 import normal from './Talent_Origin.png'
 import skill from './Talent_Transcendence_Baleful_Omen.png'
 import burst from './Talent_Secret_Art_Musou_Shinsetsu.png'
-import passive1 from './Talent_Enlightened_One.png'
-import passive2 from './Talent_All-Preserver.png'
-import passive3 from './Talent_Wishes_Unnumbered.png'
+import passive1 from './Talent_Wishes_Unnumbered.png'
+import passive2 from './Talent_Enlightened_One.png'
+import passive3 from './Talent_All-Preserver.png'
 import Stat from '../../../Stat'
 import formula, { data, energyCosts, getResolve, resolveStacks } from './data'
 import data_gen from './data_gen.json'
@@ -242,7 +242,7 @@ const char: ICharacterSheet = {
       },
       passive1: talentTemplate("passive1", tr, passive1),
       passive2: {
-        name: tr("passive1.name"),
+        name: tr("passive2.name"),
         img: passive2,
         sections: [{
           text: tr("passive2.description"),


### PR DESCRIPTION
Before:
![unknown](https://user-images.githubusercontent.com/44659572/138524854-ab51186e-e1e2-4ca9-8ffa-455f976c94ad.png)

After:
![Capture](https://user-images.githubusercontent.com/44659572/138524934-82d3f2bd-fc7c-482a-9787-50c56e0a0b15.PNG)

