### PR TITLE
Add conditionalHeader, description to talentTemplate, standardize sheets and bug fixes

### DIFF
--- a/public/locales/en/char_KaedeharaKazuha.json
+++ b/public/locales/en/char_KaedeharaKazuha.json
@@ -6,8 +6,8 @@
     "name_cryo": "Upon triggering a <cryo>Cryo</cryo> Swirl reaction"
   },
   "c1": "Using <strong>Kazuha Slash</strong> resets CD",
-  "c2": "In Autumn Whilelwind field",
-  "c2p": "Character within Autumn Whilelwind field",
+  "c2": "In Autumn Whirlwind field",
+  "c2p": "Character in Autumn Whirlwind field",
   "c6": {
     "after": "After using <strong>Chihayaburu</strong> or <strong>Kazuha Slash</strong>",
     "bonus": "Normal, Charged and Plunging DMG Bonus"

--- a/src/Data/Characters/CharacterSheet.tsx
+++ b/src/Data/Characters/CharacterSheet.tsx
@@ -75,7 +75,9 @@ export const talentTemplate = (talentKey: TalentSheetElementKey, tr: (string) =>
   sections: [{
     text: tr(`${talentKey}.description`),
     fields,
-    conditional,
+    conditional: conditional 
+      ? { ...conditional, header: conditionalHeader(talentKey, tr, img), description: tr(`${talentKey}.description`) }
+      : undefined,
   }],
 })
 

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -287,9 +287,7 @@ const sheet: ICharacterSheet = {
           },
         }, {
           conditional: { // C2 Party
-            // TODO: uncomment after `target` bug is fixed
-            // canShow: c2PEleMas,
-            canShow: greaterEq(input.constellation, 2, 1),
+            canShow: greaterEq(input.constellation, 2, unequal(target.charKey, key, 1)),
             value: condC2P,
             path: condC2PPath,
             teamBuff: true,

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -236,7 +236,7 @@ const sheet: ICharacterSheet = {
           }]
         }],
       },
-      burst: {
+      burst: { // Cannot use talentTemplate because this has multiple conditionals
         name: tr("burst.name"),
         img: burst,
         sections: [{
@@ -262,6 +262,7 @@ const sheet: ICharacterSheet = {
             value: condBurstAbsorption,
             path: condBurstAbsorptionPath,
             name: st("eleAbsor"),
+            header: conditionalHeader("burst", tr, burst),
             states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
               name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
               fields: [{
@@ -271,10 +272,11 @@ const sheet: ICharacterSheet = {
           },
         }, {
           conditional: { // C2
-            canShow: greaterEq(input.constellation, 2, 1,),
+            canShow: greaterEq(input.constellation, 2, 1),
             value: condC2,
             path: condC2Path,
             name: trm("c2"),
+            header: conditionalHeader("constellation2", tr, c2),
             states: {
               c2: {
                 fields: [{
@@ -285,13 +287,15 @@ const sheet: ICharacterSheet = {
           },
         }, {
           conditional: { // C2 Party
-            canShow: c2PEleMas,
+            // TODO: uncomment after `target` bug is fixed
+            // canShow: c2PEleMas,
+            canShow: greaterEq(input.constellation, 2, 1),
             value: condC2P,
             path: condC2PPath,
             teamBuff: true,
-            header: conditionalHeader("constellation2", tr, c2),
             description: tr("constellation2.description"),
             name: trm("c2p"),
+            header: conditionalHeader("constellation2", tr, c2),
             states: {
               c2p: {
                 fields: [{
@@ -302,25 +306,20 @@ const sheet: ICharacterSheet = {
           },
         }],
       },
-      passive1: {
-        name: tr("passive1.name"),
-        img: passive1,
-        sections: [{
-          text: tr("passive1.description"),
-          conditional: { // Skill Absorption
-            value: condSkillAbsorption,
-            path: condSkillAbsorptionPath,
-            name: st("eleAbsor"),
-            states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
-              name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
-              fields: [{
-                node: infoMut(dmgFormulas.passive1[eleKey], { key: `sheet_gen:addEleDMG` }),
-              }]
-            }]))
-          },
-        }],
-      },
-      passive2: {
+      passive1: talentTemplate("passive1", tr, passive1, undefined, {
+        // Skill Absorption
+        value: condSkillAbsorption,
+        path: condSkillAbsorptionPath,
+        name: st("eleAbsor"),
+        canShow: greaterEq(input.asc, 1, 1),
+        states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
+          name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
+          fields: [{
+            node: infoMut(dmgFormulas.passive1[eleKey], { key: `sheet_gen:addEleDMG` }),
+          }]
+        }]))
+      }),
+      passive2: { // Cannot use talentTemplate because this has multiple conditionals
         name: tr("passive2.name"),
         img: passive2,
         sections: [{
@@ -330,9 +329,11 @@ const sheet: ICharacterSheet = {
             value: condSwirls[eleKey],
             path: condSwirlPaths[eleKey],
             teamBuff: true,
-            header: conditionalHeader("passive2", tr, passive2),
-            description: tr("passive2.description"),
+            // Only show the description once
+            description: eleKey === "hydro" ? tr("passive2.description"): "",
             name: trm(`a4.name_${eleKey}`),
+            header: conditionalHeader("passive2", tr, passive2),
+            canShow: greaterEq(input.asc, 4, 1),
             states: {
               swirl: {
                 fields: [{
@@ -347,18 +348,11 @@ const sheet: ICharacterSheet = {
           },
         }))],
       },
-      passive3: {
-        name: tr("passive3.name"),
-        img: passive3,
-        sections: [{
-          text: tr("passive3.description"),
-          fields: [{ //TODO: put into subsection since this is teambuff
-            //   header: conditionalHeader("passive3", tr, passive3),
-            //   description: tr("passive3.description"),
-            node: passive
-          }]
-        }],
-      },
+      passive3: talentTemplate("passive3", tr, passive3, [{
+        //TODO: put into subsection since this is teambuff
+        //   description: tr("passive3.description"),
+        node: passive
+      }]),
       constellation1: talentTemplate("constellation1", tr, c1),
       constellation2: talentTemplate("constellation2", tr, c2),
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
@@ -369,7 +363,7 @@ const sheet: ICharacterSheet = {
         img: c6,
         sections: [{
           text: tr("constellation6.description"),
-          conditional: {//Crimson Momiji
+          conditional: { //Crimson Momiji
             value: condC6,
             path: condC6Path,
             name: trm("c6.after"),

--- a/src/Data/Characters/KamisatoAyaka/index.tsx
+++ b/src/Data/Characters/KamisatoAyaka/index.tsx
@@ -273,6 +273,7 @@ const sheet: ICharacterSheet = {
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
       constellation4: talentTemplate("constellation4", tr, c4, undefined, {
         // Hit by burst
+        teamBuff: true,
         canShow: greaterEq(input.constellation, 4, 1),
         value: condAfterBurst,
         path: condAfterBurstPath,

--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -114,7 +114,7 @@ function burstResolve(atkType: number[], initial = false) {
   })
 }
 
-const passive2ElecDmgBonus = greaterEq(input.asc, 4, prod(sum(input.total.enerRech_, percent(-1)), (datamine.passive2.electroDmg_bonus * 100)))
+const passive2ElecDmgBonus = greaterEq(input.asc, 4, prod(sum(input.premod.enerRech_, percent(-1)), (datamine.passive2.electroDmg_bonus * 100)))
 
 const [condC4Path, condC4] = cond(key, "c4")
 const c4AtkBonus_ = greaterEq(input.constellation, 4,
@@ -214,7 +214,7 @@ const sheet: ICharacterSheet = {
           }
         ],
       },
-      skill: {
+      skill: { // Cannot use talentTemplate because this has multiple sections.
         name: tr("skill.name"),
         img: skill,
         sections: [{
@@ -234,6 +234,7 @@ const sheet: ICharacterSheet = {
             value: condSkillEye,
             path: condSkillEyePath,
             name: trm("skill.eye"),
+            header: conditionalHeader("skill", tr, skill),
             states: {
               skillEye: {
                 fields: [{
@@ -246,11 +247,11 @@ const sheet: ICharacterSheet = {
           conditional: {
             value: condSkillEyeTeam,
             path: condSkillEyeTeamPath,
-            header: conditionalHeader("skill", tr, skill),
             description: tr("skill.description"),
             teamBuff: true,
             canShow: unequal(input.activeCharKey, input.charKey, 1),
             name: trm("skill.partyCost"),
+            header: conditionalHeader("skill", tr, skill),
             states: Object.fromEntries(energyCosts.map(c => [c, {
               name: `${c}`,
               fields: [{
@@ -260,114 +261,90 @@ const sheet: ICharacterSheet = {
           }
         }]
       },
-      burst: {
-        name: tr("burst.name"),
-        img: burst,
-        sections: [{
-          text: tr("burst.description"),
-          fields: [{
-            node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.hit1, { key: `char_${key}_gen:burst.skillParams.3` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.hit2, { key: `char_${key}_gen:burst.skillParams.4` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.hit3, { key: `char_${key}_gen:burst.skillParams.5` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.hit41, { key: `char_${key}_gen:burst.skillParams.6` }),
-            textSuffix: "(1)"
-          }, {
-            node: infoMut(dmgFormulas.burst.hit42, { key: `char_${key}_gen:burst.skillParams.6` }),
-            textSuffix: "(2)"
-          }, {
-            node: infoMut(dmgFormulas.burst.hit5, { key: `char_${key}_gen:burst.skillParams.7` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.charged1, { key: `char_${key}_gen:burst.skillParams.8` }),
-            textSuffix: "(1)"
-          }, {
-            node: infoMut(dmgFormulas.burst.charged2, { key: `char_${key}_gen:burst.skillParams.8` }),
-            textSuffix: "(2)"
-          }, {
-            text: tr("burst.skillParams.9"),
-            value: `${datamine.burst.stam}`,
-          }, {
-            node: infoMut(dmgFormulas.burst.plunge, { key: `char_${key}_gen:burst.skillParams.10` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.plungeLow, { key: `char_${key}_gen:burst.skillParams.11` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.plungeHigh, { key: `char_${key}_gen:burst.skillParams.11` }),
-          }, {
-            text: tr("burst.skillParams.12"),
-            value: (data) => `${datamine.burst.enerGen[data.get(input.total.burstIndex).value]}`,
-          }, {
-            text: tr("burst.skillParams.13"),
-            value: `${datamine.burst.duration}s`,
-          }, {
-            text: tr("burst.skillParams.14"),
-            value: `${datamine.burst.cd}s`,
-          }, {
-            text: tr("burst.skillParams.15"),
-            value: `${datamine.burst.enerCost}`,
-          }],
-          conditional: {
-            value: condResolveStack,
-            path: condResolveStackPath,
-            name: trm("burst.resolves"),
-            states: Object.fromEntries(resolveStacks.map(c => [c, {
-              name: `${c}`,
-              fields: []
-            }]))
-          }
-        }],
-      },
+      burst: talentTemplate("burst", tr, burst, [{
+        node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.hit1, { key: `char_${key}_gen:burst.skillParams.3` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.hit2, { key: `char_${key}_gen:burst.skillParams.4` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.hit3, { key: `char_${key}_gen:burst.skillParams.5` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.hit41, { key: `char_${key}_gen:burst.skillParams.6` }),
+        textSuffix: "(1)"
+      }, {
+        node: infoMut(dmgFormulas.burst.hit42, { key: `char_${key}_gen:burst.skillParams.6` }),
+        textSuffix: "(2)"
+      }, {
+        node: infoMut(dmgFormulas.burst.hit5, { key: `char_${key}_gen:burst.skillParams.7` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.charged1, { key: `char_${key}_gen:burst.skillParams.8` }),
+        textSuffix: "(1)"
+      }, {
+        node: infoMut(dmgFormulas.burst.charged2, { key: `char_${key}_gen:burst.skillParams.8` }),
+        textSuffix: "(2)"
+      }, {
+        text: tr("burst.skillParams.9"),
+        value: `${datamine.burst.stam}`,
+      }, {
+        node: infoMut(dmgFormulas.burst.plunge, { key: `char_${key}_gen:burst.skillParams.10` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.plungeLow, { key: `char_${key}_gen:burst.skillParams.11` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.plungeHigh, { key: `char_${key}_gen:burst.skillParams.11` }),
+      }, {
+        text: tr("burst.skillParams.12"),
+        value: (data) => `${datamine.burst.enerGen[data.get(input.total.burstIndex).value]}`,
+      }, {
+        text: tr("burst.skillParams.13"),
+        value: `${datamine.burst.duration}s`,
+      }, {
+        text: tr("burst.skillParams.14"),
+        value: `${datamine.burst.cd}s`,
+      }, {
+        text: tr("burst.skillParams.15"),
+        value: `${datamine.burst.enerCost}`,
+      }], {
+        value: condResolveStack,
+        path: condResolveStackPath,
+        name: trm("burst.resolves"),
+        states: Object.fromEntries(resolveStacks.map(c => [c, {
+          name: `${c}`,
+          fields: []
+        }]))
+      }),
       passive1: talentTemplate("passive1", tr, passive1),
-      passive2: {
-        name: tr("passive2.name"),
-        img: passive2,
-        sections: [{
-          text: tr("passive2.description"),
-          fields: [{
-            canShow: data => data.get(input.asc).value >= 4,
-            text: trm("a4.enerRest"),
-            value: (data) => {
-              return (data.get(input.total.enerRech_).value * 100 - 100) * (datamine.passive2.energyGen * 100)
-            },
-            unit: "%"
-          }, {
-            node: passive2ElecDmgBonus,
-          }]
-        }]
-      },
+      passive2: talentTemplate("passive2", tr, passive2, [{
+        canShow: data => data.get(input.asc).value >= 4,
+        text: trm("a4.enerRest"),
+        value: (data) => {
+          return (data.get(input.total.enerRech_).value * 100 - 100) * (datamine.passive2.energyGen * 100)
+        },
+        unit: "%"
+      }, {
+          node: passive2ElecDmgBonus,
+      }]),
       passive3: talentTemplate("passive3", tr, passive3),
       constellation1: talentTemplate("constellation1", tr, c1),
       constellation2: talentTemplate("constellation2", tr, c2),
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
-      constellation4: {
-        name: tr("constellation4.name"),
-        img: c4,
-        sections: [{
-          text: tr("constellation4.description"),
-          conditional: {
-            value: condC4,
-            path: condC4Path,
-            teamBuff: true,
-            canShow: greaterEq(input.constellation, 4, unequal(input.activeCharKey, input.charKey, 1)),
-            header: conditionalHeader("constellation4", tr, c4),
-            description: tr("constellation4.description"),
-            name: trm("c4.expires"),
-            states: {
-              c4: {
-                fields: [{
-                  node: c4AtkBonus_,
-                }, {
-                  text: tr("skill.skillParams.2"),
-                  value: `${datamine.constellation4.duration}s`
-                }]
-              }
-            }
+      constellation4: talentTemplate("constellation4", tr, c4, undefined, {
+        value: condC4,
+        path: condC4Path,
+        teamBuff: true,
+        canShow: greaterEq(input.constellation, 4, unequal(input.activeCharKey, input.charKey, 1)),
+        name: trm("c4.expires"),
+        states: {
+          c4: {
+            fields: [{
+              node: c4AtkBonus_,
+            }, {
+              text: tr("skill.skillParams.2"),
+              value: `${datamine.constellation4.duration}s`
+            }]
           }
-        }],
-      },
+        }
+      }),
       constellation5: talentTemplate("constellation5", tr, c5, [{ node: nodeC5 }]),
       constellation6: talentTemplate("constellation6", tr, c6),
     },

--- a/src/Data/Characters/Shenhe/index.tsx
+++ b/src/Data/Characters/Shenhe/index.tsx
@@ -212,7 +212,7 @@ const sheet: ICharacterSheet = {
           }]
         }],
       },
-      skill: {
+      skill: { // Cannot use talentTemplate because this has multiple sections.
         name: tr("skill.name"),
         img: skill,
         sections: [{
@@ -299,7 +299,7 @@ const sheet: ICharacterSheet = {
           }
         }],
       },
-      burst: {
+      burst: { // Cannot use talentTemplate because this has multiple sections
         name: tr("burst.name"),
         img: burst,
         sections: [{
@@ -326,6 +326,8 @@ const sheet: ICharacterSheet = {
             value: condBurst,
             path: condBurstPath,
             name: tr("burst.name"),
+            header: conditionalHeader("burst", tr, burst),
+            description: tr("burst.description"),
             states: {
               burst: {
                 fields: [{

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -69,9 +69,10 @@ const [condSwirlReactionPath, condSwirlReaction] = cond(characterKey, "swirl")
 const [condSkillHitOpponentPath, condSkillHitOpponent] = cond(characterKey, "skillHit")
 
 // Conditional Output
-const asc1 = greaterEq(input.asc, 1,
+const asc1Condition = greaterEq(input.asc, 1,
   unequal(target.charKey, characterKey,
-    equal(target.charEle, condSwirlReaction, datamine.passive1.eleMas)))
+    equal(target.charEle, condSwirlReaction, 1)))
+const asc1 = equal(asc1Condition, 1, datamine.passive1.eleMas)
 const asc4 = equal("hit", condSkillHitOpponent,
   unequal(target.charKey, characterKey,
     greaterEq(input.asc, 4,
@@ -132,7 +133,7 @@ const sheet: ICharacterSheet = {
         sections: [
           {
             text: tr(`auto.fields.normal`),
-            fields: datamine.normal.hitArr.map((percentArr, i) => ({
+            fields: datamine.normal.hitArr.map((_, i) => ({
               node: infoMut(dmgFormulas.normal[i], { key: `char_${characterKey}_gen:auto.skillParams.${i}` }),
             }))
           },
@@ -197,6 +198,7 @@ const sheet: ICharacterSheet = {
             value: condAbsorption,
             path: condAbsorptionPath,
             name: st("eleAbsor"),
+            header: conditionalHeader("burst", tr, burst),
             states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
               name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
               fields: [{
@@ -211,6 +213,8 @@ const sheet: ICharacterSheet = {
             header: conditionalHeader("constellation6", tr, c6),
             description: tr("constellation6.description"),
             name: st("eleAbsor"),
+            teamBuff: true,
+            canShow: greaterEq(input.constellation, 6, 1),
             states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
               name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
               fields: [{
@@ -220,55 +224,45 @@ const sheet: ICharacterSheet = {
           },
         }]
       },
-      passive1: {
-        name: tr("passive1.name"),
-        img: passive1,
-        sections: [{
-          text: tr("passive1.description"),
-          conditional: { // Swirl Element
-            value: condSwirlReaction,
-            path: condSwirlReactionPath,
-            header: conditionalHeader("passive1", tr, passive1),
-            description: tr("passive1.description"),
-            name: st("eleSwirled"),
-            states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
-              name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
-              fields: [{
-                node: asc1,
-              }, {
-                text: sgt("duration"),
-                value: datamine.passive1.duration,
-                unit: "s"
-              }],
-            }]))
-          },
-        }]
-      },
-      passive2: {
-        name: tr("passive2.name"),
-        img: passive2,
-        sections: [{
-          text: tr("passive2.description"),
-          conditional: { // Swirl Element
-            value: condSkillHitOpponent,
-            path: condSkillHitOpponentPath,
-            header: conditionalHeader("passive1", tr, passive1),
-            description: tr("passive1.description"),
-            name: trm("asc4"),
-            states: {
-              hit: {
-                fields: [{
-                  node: asc4,
-                }, {
-                  text: sgt("duration"),
-                  value: datamine.passive2.duration,
-                  unit: "s"
-                }],
-              }
-            }
-          },
-        }]
-      },
+      passive1: talentTemplate("passive1", tr, passive1, undefined, {
+        // Swirl Element
+        teamBuff: true,
+        value: condSwirlReaction,
+        path: condSwirlReactionPath,
+        name: st("eleSwirled"),
+        canShow: greaterEq(input.asc, 1, unequal(target.charKey, characterKey, 1)),
+        states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
+          name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
+          fields: [{
+            node: asc1,
+          }, {
+            // TODO: uncomment after `target` bug is fixed
+            // canShow: data => data.get(asc1Condition).value,
+            text: sgt("duration"),
+            value: datamine.passive1.duration,
+            unit: "s",
+          }],
+        }]))
+      }),
+      passive2: talentTemplate("passive2", tr, passive2, undefined, {
+        // Swirl element
+        teamBuff: true,
+        value: condSkillHitOpponent,
+        path: condSkillHitOpponentPath,
+        name: trm("asc4"),
+        canShow: greaterEq(input.asc, 4, unequal(target.charKey, characterKey, 1)),
+        states: {
+          hit: {
+            fields: [{
+              node: asc4,
+            }, {
+              text: sgt("duration"),
+              value: datamine.passive2.duration,
+              unit: "s"
+            }],
+          }
+        }
+      }),
       passive3: talentTemplate("passive3", tr, passive3),
       constellation1: talentTemplate("constellation1", tr, c1),
       constellation2: talentTemplate("constellation2", tr, c2),

--- a/src/Data/Characters/Xiangling/index.tsx
+++ b/src/Data/Characters/Xiangling/index.tsx
@@ -197,6 +197,7 @@ const sheet: ICharacterSheet = {
         value: condAfterChili,
         path: condAfterChiliPath,
         name: trm("afterChili"),
+        teamBuff: true,
         states: {
           afterChili: {
             fields: [{
@@ -215,6 +216,7 @@ const sheet: ICharacterSheet = {
         value: condAfterGuobaHit,
         path: condAfterGuobaHitPath,
         name: trm("afterGuobaHit"),
+        teamBuff: true,
         states: {
           afterGuobaHit: {
             fields: [{
@@ -240,6 +242,7 @@ const sheet: ICharacterSheet = {
         value: condDuringPyronado,
         path: condDuringPyronadoPath,
         name: trm("duringPyronado"),
+        teamBuff: true,
         states: {
           duringPyronado: {
             fields: [{

--- a/src/Data/Characters/Xingqiu/index.tsx
+++ b/src/Data/Characters/Xingqiu/index.tsx
@@ -164,78 +164,60 @@ const sheet: ICharacterSheet = {
           }]
         }],
       },
-      skill: {
-        name: tr("skill.name"),
-        img: skill,
-        sections: [{
-          text: tr("skill.description"),
-          fields: [{
-            node: infoMut(dmgFormulas.skill.press1, { key: `char_${key}_gen:skill.skillParams.0` }),
-            textSuffix: "(1)"
-          }, {
-            node: infoMut(dmgFormulas.skill.press2, { key: `char_${key}_gen:skill.skillParams.0` }),
-            textSuffix: "(2)"
-          }, {
-            text: tr("skill.skillParams.2"),
-            value: data => data.get(input.constellation).value >= 2
-              ? `${datamine.skill.duration}s + ${datamine.constellation2.skill_duration}`
-              : `${datamine.skill.duration}`,
-            unit: "s"
-          }, {
-            text: tr("skill.skillParams.3"),
-            value: datamine.skill.cd,
-            unit: "s"
-          }],
-          conditional: {
-            teamBuff: true,
-            value: condSkill,
-            path: condSkillPath,
-            header: conditionalHeader("skill", tr, skill),
-            description: tr("skill.description"),
-            name: trm("skillCond"),
-            states: {
-              on: {
-                fields: [{
-                  node: dmgFormulas.skill.dmgRed_,
-                }]
-              }
-            }
+      skill: talentTemplate("skill", tr, skill, [{
+        node: infoMut(dmgFormulas.skill.press1, { key: `char_${key}_gen:skill.skillParams.0` }),
+        textSuffix: "(1)"
+      }, {
+        node: infoMut(dmgFormulas.skill.press2, { key: `char_${key}_gen:skill.skillParams.0` }),
+        textSuffix: "(2)"
+      }, {
+        text: tr("skill.skillParams.2"),
+        value: data => data.get(input.constellation).value >= 2
+          ? `${datamine.skill.duration}s + ${datamine.constellation2.skill_duration}`
+          : `${datamine.skill.duration}`,
+        unit: "s"
+      }, {
+        text: tr("skill.skillParams.3"),
+        value: datamine.skill.cd,
+        unit: "s"
+      }], {
+        teamBuff: true,
+        value: condSkill,
+        path: condSkillPath,
+        name: trm("skillCond"),
+        states: {
+          on: {
+            fields: [{
+              node: dmgFormulas.skill.dmgRed_,
+            }]
           }
-        }]
-      },
-      burst: {
-        name: tr("burst.name"),
-        img: burst,
-        sections: [{
-          text: tr("burst.description"),
-          fields: [{
-            text: tr("burst.skillParams.2"),
-            value: datamine.burst.cd,
-            unit: "s"
-          }, {
-            text: tr("burst.skillParams.3"),
-            value: datamine.burst.cost,
-          }],
-          conditional: {
-            value: condBurst,
-            path: condBurstPath,
-            name: trm("burstCond"),
-            states: {
-              on: {
-                fields: [{
-                  node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
-                }, {
-                  text: tr("burst.skillParams.1"),
-                  value: datamine.burst.duration,
-                  unit: "s"
-                }, {
-                  node: nodeC4
-                }]
-              }
-            }
-          },
-        }]
-      },
+        }
+      }),
+      burst: talentTemplate("burst", tr, burst, [{
+        text: tr("burst.skillParams.2"),
+        value: datamine.burst.cd,
+        unit: "s"
+      }, {
+          text: tr("burst.skillParams.3"),
+          value: datamine.burst.cost,
+        }], {
+        value: condBurst,
+        path: condBurstPath,
+        name: trm("burstCond"),
+        states: {
+          on: {
+            fields: [{
+              node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
+            }, {
+              text: tr("burst.skillParams.1"),
+              value: datamine.burst.duration,
+              unit: "s"
+            }, {
+              node: nodeC4
+            }]
+          }
+        }
+      }),
       passive1: talentTemplate("passive1", tr, passive1, [{
         node: infoMut(dmgFormulas.passive1.healing, { key: `sheet_gen:healing`, variant: "success" }),
       },]),
@@ -250,8 +232,6 @@ const sheet: ICharacterSheet = {
         path: condC2Path,
         teamBuff: true,
         name: trm("c2Cond"),
-        header: conditionalHeader("constellation2", tr, c2),
-        description: tr("constellation2.description"),
         states: {
           on: {
             fields: [{

--- a/src/Data/Characters/YaeMiko/index.tsx
+++ b/src/Data/Characters/YaeMiko/index.tsx
@@ -144,77 +144,54 @@ const sheet: ICharacterSheet = {
           }]
         }],
       },
-      skill: {
-        name: tr("skill.name"),
-        img: skill,
-        sections: [{
-          text: tr("skill.description"),
-          fields: [{
-            node: infoMut(dmgFormulas.skill.dmg1, { key: `char_${key}_gen:skill.skillParams.0` }),
-          }, {
-            node: infoMut(dmgFormulas.skill.dmg2, { key: `char_${key}_gen:skill.skillParams.1` }),
-          }, {
-            node: infoMut(dmgFormulas.skill.dmg3, { key: `char_${key}_gen:skill.skillParams.2` }),
-          }, {
-            node: infoMut(dmgFormulas.skill.dmg4, { key: `char_${key}_gen:skill.skillParams.3` }),
-          }, {
-            text: tr("skill.skillParams.4"),
-            value: datamine.skill.duration,
-            unit: "s"
-          }, {
-            text: tr("skill.skillParams.5"),
-            value: datamine.skill.cd,
-          }],
-        },],
-      },
-      burst: {
-        name: tr("burst.name"),
-        img: burst,
-        sections: [{
-          text: tr("burst.description"),
-          fields: [{
-            node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
-          }, {
-            node: infoMut(dmgFormulas.burst.tenkoDmg, { key: `char_${key}_gen:burst.skillParams.1` }),
-          }, {
-            text: tr("burst.skillParams.2"),
-            value: datamine.burst.cd,
-            unit: "s"
-          }, {
-            text: tr("burst.skillParams.3"),
-            value: datamine.burst.enerCost,
-          }]
-        }],
-      },
+      skill: talentTemplate("skill", tr, skill, [{
+        node: infoMut(dmgFormulas.skill.dmg1, { key: `char_${key}_gen:skill.skillParams.0` }),
+      }, {
+        node: infoMut(dmgFormulas.skill.dmg2, { key: `char_${key}_gen:skill.skillParams.1` }),
+      }, {
+        node: infoMut(dmgFormulas.skill.dmg3, { key: `char_${key}_gen:skill.skillParams.2` }),
+      }, {
+        node: infoMut(dmgFormulas.skill.dmg4, { key: `char_${key}_gen:skill.skillParams.3` }),
+      }, {
+        text: tr("skill.skillParams.4"),
+        value: datamine.skill.duration,
+        unit: "s"
+      }, {
+        text: tr("skill.skillParams.5"),
+        value: datamine.skill.cd,
+      }]),
+      burst: talentTemplate("burst", tr, burst, [{
+        node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
+      }, {
+        node: infoMut(dmgFormulas.burst.tenkoDmg, { key: `char_${key}_gen:burst.skillParams.1` }),
+      }, {
+        text: tr("burst.skillParams.2"),
+        value: datamine.burst.cd,
+        unit: "s"
+      }, {
+        text: tr("burst.skillParams.3"),
+        value: datamine.burst.enerCost,
+      }]),
       passive1: talentTemplate("passive1", tr, passive1),
       passive2: talentTemplate("passive2", tr, passive2, [{ node: nodeAsc4 }]),
       passive3: talentTemplate("passive3", tr, passive3),
       constellation1: talentTemplate("constellation1", tr, c1),
       constellation2: talentTemplate("constellation2", tr, c2),
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
-      constellation4: {
-        name: tr("constellation4.name"),
-        img: c4,
-        sections: [{
-          text: tr("constellation4.description"),
-          conditional: {
-            value: condC4,
-            path: condC4Path,
-            teamBuff: true,
-            canShow: greaterEq(input.constellation, 4, 1),
-            header: conditionalHeader("constellation4", tr, passive1),
-            description: tr("constellation4.description"),
-            name: trm("c4"),
-            states: {
-              hit: {
-                fields: [{
-                  node: nodeC4,
-                },]
-              }
-            }
+      constellation4: talentTemplate("constellation4", tr, c4, undefined, {
+        value: condC4,
+        path: condC4Path,
+        teamBuff: true,
+        canShow: greaterEq(input.constellation, 4, 1),
+        name: trm("c4"),
+        states: {
+          hit: {
+            fields: [{
+              node: nodeC4,
+            },]
           }
-        }],
-      },
+        }
+      }),
       constellation5: talentTemplate("constellation5", tr, c5, [{ node: nodeC5 }]),
       constellation6: talentTemplate("constellation6", tr, c6),
     }

--- a/src/Data/Characters/YunJin/index.tsx
+++ b/src/Data/Characters/YunJin/index.tsx
@@ -185,8 +185,6 @@ const sheet: ICharacterSheet = {
         value: datamine.burst.enerCost,
       }], {
         teamBuff: true,
-        header: conditionalHeader("burst", tr, burst),
-        description: tr("burst.description"),
         value: condBurst,
         path: condBurstPath,
         name: trm("burst"),
@@ -213,7 +211,7 @@ const sheet: ICharacterSheet = {
       passive2: talentTemplate("passive2", tr, passive2, [{ node: infoMut(nodeA4, { key: `char_${key}:a4Inc_` }) }]),
       passive3: talentTemplate("passive3", tr, passive3),
       constellation1: talentTemplate("constellation1", tr, c1),
-      constellation2: talentTemplate("constellation2", tr, c2),
+      constellation2: talentTemplate("constellation2", tr, c2, [{ node: nodeC2 }]),
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
       constellation4: talentTemplate("constellation4", tr, c4, undefined, {
         canShow: greaterEq(input.constellation, 4, 1),


### PR DESCRIPTION
Add `conditionalHeader` to `talentTemplate`, since it is needed for every conditional anyways.
Add `description` to `talentTemplate` for `conditional`.
Standardized sheets to use `talentTemplate` when possible.

Fixed bugs:
- Add `conditionalHeader` to all conditionals.
- Kazuha C2 not showing as team buff.
- Make Kazuha A4 description only appear once.
- Fix Raiden A4 using `total` ER.
    - This is considered a team-buff and should not be affected by dynamic-scaling buffs
    - There was a discussion about this on the waverider-bugs channel as well, there might need to be more fixes for other skills and whether they should scale off of `total` or `premod`.
- Fix some conditionals appearing when they shouldn't.
- Fix typos for Kazuha.
- Add display for Yunjin C2.

TODOs:
There is a known bug with `canShow` when using ~a node~ `UIData` that relies on `target`. Once that bug is fixed, there ~are 2 lines~ is 1 line to uncomment to hide conditionals more appropriately. ~One for Kazuha and~ one for Sucrose. Search for "uncomment after \`target\` bug is fixed"
Edit: Nevermind, Kazuha one was just from using the wrong node for `canShow`