### PR TITLE
Prefer reaction variant to raw element variant

### DIFF
--- a/src/Formula/uiData.tsx
+++ b/src/Formula/uiData.tsx
@@ -306,6 +306,9 @@ function mergeVariants<V>(operands: ContextNodeDisplay<V>[]): ContextNodeDisplay
   const unique = new Set(operands.map(x => x.variant))
   if (unique.size > 1) unique.delete(undefined)
   if (unique.size > 1) unique.delete("physical")
+  // Prefer reactions
+  if (unique.has("melt")) return "melt"
+  if (unique.has("vaporize")) return "vaporize"
   return unique.values().next().value
 }
 function computeNodeDisplay<V>(node: ContextNodeDisplay<V>): NodeDisplay<V> {


### PR DESCRIPTION
https://discord.com/channels/785153694478893126/943850131864838144/951315858809045092

The reaction variant was there, but it wasn't getting picked since it was second in the list of variants for the node (first is the raw element of the attack). I wasn't sure how to get the reaction variant to take priority in the node itself, so I just made it take priority when being displayed