### PR TITLE
Fix "0" nodes appearing in TeamBuffCard

### DIFF
--- a/src/PageBuild/Components/TeamBuffCard.tsx
+++ b/src/PageBuild/Components/TeamBuffCard.tsx
@@ -8,9 +8,12 @@ export default function TeamBuffCard() {
   const { data } = useContext(DataContext)
   const teamBuffs = data.getTeamBuff()
   const nodes: Array<NodeDisplay<number>> = []
-  Object.values(teamBuffs.total ?? {}).forEach(node => !node.isEmpty && nodes.push(node))
-  Object.values(teamBuffs.premod ?? {}).forEach(node => !node.isEmpty && nodes.push(node))
-  Object.values(teamBuffs.enemy ?? {}).forEach(node => !node.isEmpty && nodes.push(node))
+  Object.values(teamBuffs.total ?? {}).forEach(node =>
+    !node.isEmpty && node.value != 0 && nodes.push(node))
+  Object.values(teamBuffs.premod ?? {}).forEach(node =>
+    !node.isEmpty && node.value != 0 && nodes.push(node))
+  Object.values(teamBuffs.enemy ?? {}).forEach(node =>
+    !node.isEmpty && node.value != 0 && nodes.push(node))
   if (!nodes.length) return null
 
   return <CardLight>

--- a/src/PageBuild/Components/TeamBuffCard.tsx
+++ b/src/PageBuild/Components/TeamBuffCard.tsx
@@ -9,11 +9,11 @@ export default function TeamBuffCard() {
   const teamBuffs = data.getTeamBuff()
   const nodes: Array<NodeDisplay<number>> = []
   Object.values(teamBuffs.total ?? {}).forEach(node =>
-    !node.isEmpty && node.value != 0 && nodes.push(node))
+    !node.isEmpty && node.value !== 0 && nodes.push(node))
   Object.values(teamBuffs.premod ?? {}).forEach(node =>
-    !node.isEmpty && node.value != 0 && nodes.push(node))
+    !node.isEmpty && node.value !== 0 && nodes.push(node))
   Object.values(teamBuffs.enemy ?? {}).forEach(node =>
-    !node.isEmpty && node.value != 0 && nodes.push(node))
+    !node.isEmpty && node.value !== 0 && nodes.push(node))
   if (!nodes.length) return null
 
   return <CardLight>


### PR DESCRIPTION
Same fix as #135, just forgot to apply it to the TeamBuffCard as well.

Maybe `TeamBuffCard()` and `TeamBuffDisplay()` should be merged at some point? They are almost identical.