### PR TITLE
Add ability to display fields in Team Buff Panel

### DIFF
--- a/src/Components/DocumentDisplay.tsx
+++ b/src/Components/DocumentDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box, CardHeader, ListItem, Divider } from "@mui/material"
+import { Box, CardHeader, ListItem, Divider, CardContent } from "@mui/material"
 import { useContext } from "react"
 import { DataContext } from "../DataContext"
 import { DocumentSection } from "../Types/sheet"
@@ -7,24 +7,28 @@ import ConditionalDisplay from "./ConditionalDisplay"
 import CardDark from "./Card/CardDark"
 import FieldDisplay, { FieldDisplayList } from "./FieldDisplay"
 
-export default function DocumentDisplay({ sections }: { sections: DocumentSection[] }) {
+export default function DocumentDisplay({ sections, teamBuffOnly }: { sections: DocumentSection[], teamBuffOnly?: boolean }) {
   const { data } = useContext(DataContext)
   const sectionsDisplay = sections?.map((section, i) => {
     if (section.canShow && !section.canShow(data)) return null
+    if (teamBuffOnly && !section.teamBuff && !section.conditional?.teamBuff) return null
     const talentText = evalIfFunc(section.text, data)
+    const description = evalIfFunc(section.fieldsDescription, data)
     const fields = section.fields ?? []
     let { icon, title, action } = section.fieldsHeader ?? {}
     icon = evalIfFunc(icon, data)
     return <Box key={"section" + i} display="flex" flexDirection="column" gap={1}>
-        {talentText && <div>{talentText}</div>}
-      <CardDark>
+      {!teamBuffOnly && talentText && <div>{talentText}</div>}
+      {(!teamBuffOnly || section.teamBuff) && <CardDark>
+        {teamBuffOnly && talentText && <div>{talentText}</div>}
         {section.fieldsHeader && <CardHeader avatar={icon} title={title} action={action} titleTypographyProps={{ variant: "subtitle2" }} />}
         {section.fieldsHeader && <Divider />}
+        {teamBuffOnly && description && <CardContent>{description}</CardContent>}
         {fields.length > 0 && <FieldDisplayList>
           {fields?.map?.((field, i) => <FieldDisplay key={i} field={field} component={ListItem} />)}
         </FieldDisplayList>}
-      </CardDark>
-      {!!section.conditional && <ConditionalDisplay conditional={section.conditional} hideDesc />}
+      </CardDark>}
+      {!!section.conditional && (!teamBuffOnly || section.conditional.teamBuff) && <ConditionalDisplay conditional={section.conditional} hideDesc={!teamBuffOnly} />}
     </Box>
   }).filter(s => s)
   if (!sectionsDisplay.length) return null

--- a/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
@@ -2,9 +2,11 @@ import { PersonAdd } from "@mui/icons-material";
 import { CardContent, Divider, Grid } from "@mui/material";
 import { Box } from "@mui/system";
 import React, { useContext, useMemo } from 'react';
+import CardDark from "../../Components/Card/CardDark";
 import CardLight from "../../Components/Card/CardLight";
 import CharacterDropdownButton from "../../Components/Character/CharacterDropdownButton";
 import ConditionalDisplay from "../../Components/ConditionalDisplay";
+import DocumentDisplay from "../../Components/DocumentDisplay";
 import { NodeFieldDisplay } from "../../Components/FieldDisplay";
 import { ArtifactSheet } from "../../Data/Artifacts/ArtifactSheet";
 import { DataContext, dataContextObj } from "../../DataContext";
@@ -111,15 +113,15 @@ function TeammateDisplay({ index }: { index: number }) {
     {teamMateDataContext && <DataContext.Provider value={teamMateDataContext}>
       <CharacterCard characterKey={characterKey}
         onClickHeader={onClickHandler}
-        artifactChildren={<CharArtifactCondDisplay dataContext={dataContext} />}
-        weaponChildren={<CharWeaponCondDisplay dataContext={dataContext} />}
-        characterChildren={<CharTalentCondDisplay dataContext={dataContext} />}
+        artifactChildren={<CharArtifactCondDisplay />}
+        weaponChildren={<CharWeaponCondDisplay />}
+        characterChildren={<CharTalentCondDisplay />}
       />
     </DataContext.Provider>}
   </CardLight>
 
 }
-function CharArtifactCondDisplay({ dataContext }: { dataContext: dataContextObj }) {
+function CharArtifactCondDisplay() {
   const { data, } = useContext(DataContext)
   const artifactSheets = usePromise(ArtifactSheet.getAll, [])
   const sections = useMemo(() => artifactSheets &&
@@ -128,24 +130,17 @@ function CharArtifactCondDisplay({ dataContext }: { dataContext: dataContextObj 
         setNums.flatMap(sn => artifactSheets[setKey]!.setEffectDocument(sn)!))
     , [artifactSheets, data])
   if (!sections) return null
-  return <DisplaySectionsTeamCond sections={sections} dataContext={dataContext} />
+  return <DocumentDisplay sections={sections} teamBuffOnly={true} />
 }
-function CharWeaponCondDisplay({ dataContext }: { dataContext: dataContextObj }) {
+function CharWeaponCondDisplay() {
   const { teamData, character: { key: charKey } } = useContext(DataContext)
   const weaponSheet = teamData[charKey]!.weaponSheet
-
-  return <DisplaySectionsTeamCond sections={weaponSheet.document} dataContext={dataContext} />
+  return <DocumentDisplay sections={weaponSheet.document} teamBuffOnly={true} />
 }
-function CharTalentCondDisplay({ dataContext }: { dataContext: dataContextObj }) {
+function CharTalentCondDisplay() {
   const { data, teamData, character: { key: charKey } } = useContext(DataContext)
   const characterSheet = teamData[charKey]!.characterSheet
   const talent = characterSheet.getTalent(data.get(input.charEle).value as ElementKey)!
   const sections = Object.values(talent.sheets).flatMap(sts => sts.sections)
-  return <DisplaySectionsTeamCond sections={sections} dataContext={dataContext} />
-}
-
-function DisplaySectionsTeamCond({ sections, dataContext }: { sections: DocumentSection[], dataContext: dataContextObj }) {
-  return <Box display="flex" flexDirection="column" gap={1} pt={0} >
-    {sections.map(section => section.conditional?.teamBuff && <ConditionalDisplay conditional={section.conditional} fieldContext={dataContext} />)}
-  </Box >
+  return <DocumentDisplay sections={sections} teamBuffOnly={true} />
 }

--- a/src/Types/sheet.ts
+++ b/src/Types/sheet.ts
@@ -10,6 +10,8 @@ export interface DocumentSection {
     icon?: Displayable | ((data: UIData) => Displayable);
     action?: Displayable;
   }
+  fieldsDescription?: Displayable | ((data: UIData) => Displayable);
   fields?: IFieldDisplay[]
   conditional?: IConditional
+  teamBuff?: boolean
 }


### PR DESCRIPTION
Add `fieldsDescription` to `DocumentSection` to match the `description` that appears with `IConditional` when shown as a team buff
Add `teamBuff` boolean to match `IConditional`
Update `DocumentDisplay` with new parameter `teamBuffOnly` to show only team buff-relevant information
Refactor `DisplaySectionsTeamCond`; now use updated `DocumentDisplay`

Here's an example (not included in the PR) of the team buff fields in the Team Buff panel.
![image](https://user-images.githubusercontent.com/36019388/158718374-b9f3159f-7638-4e1d-9d5e-5b973b8eed3f.png)

Sheet code:
![image](https://user-images.githubusercontent.com/36019388/158718267-e698f326-b910-4f8b-a71c-e7a78ea04f7c.png)
