### PR TITLE
Add conditional headers to weapon sheets and some fixes/changes

### DIFF
--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -66,7 +66,9 @@
     "geo": "Geo affect duration"
   },
   "base": "Base",
+  "conditional": "Conditional",
   "stacks": "Stacks",
+  "members": "Members",
   "hits": "Hits",
   "protectedByShield": "Protected by a shield"
 }

--- a/public/locales/en/weapon_MemoryOfDust.json
+++ b/public/locales/en/weapon_MemoryOfDust.json
@@ -1,7 +1,4 @@
 {
-  "condName": "Hits",
-  "stackWithShield_one": "With Shield: {{count}} Stack",
-  "stackWithShield_other": "With Shield: {{count}} Stacks",
-  "stackWithoutShield_one": "Without Shield: {{count}} Stack",
-  "stackWithoutShield_other": "Without Shield: {{count}} Stacks"
+  "shield": "Shield",
+  "atkEffInc": "ATK Effect Increase"
 }

--- a/public/locales/en/weapon_SongOfBrokenPines.json
+++ b/public/locales/en/weapon_SongOfBrokenPines.json
@@ -1,3 +1,3 @@
 {
-  "name": "Millennial Movement: Banner-Hymn"
+  "name": "Gains Millennial Movement: Banner-Hymn effect"
 }

--- a/public/locales/en/weapon_VortexVanquisher.json
+++ b/public/locales/en/weapon_VortexVanquisher.json
@@ -1,7 +1,4 @@
 {
-  "condName": "Hits",
-  "stackWithShield_one": "With Shield: {{count}} Stack",
-  "stackWithShield_other": "With Shield: {{count}} Stacks",
-  "stackWithoutShield_one": "Without Shield: {{count}} Stack",
-  "stackWithoutShield_other": "Without Shield: {{count}} Stacks"
+  "shield": "Shield",
+  "atkEffInc": "ATK Effect Increase"
 }

--- a/src/Data/Weapons/Bow/AlleyHunter/index.tsx
+++ b/src/Data/Weapons/Bow/AlleyHunter/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { lookup, subscript, prod, naught } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { IWeaponSheet, conditionalHeader, conditionaldesc } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -17,7 +17,7 @@ const dmgInc = [.02, .025, .03, .035, .04]
 
 const [condPassivePath, condPassive] = cond(key, "OppidanAmbush")
 const all_dmg_ = lookup(condPassive, {
-  ...objectKeyMap(range(1, 10), i => prod(subscript(input.weapon.refineIndex, dmgInc), i)) 
+  ...objectKeyMap(range(1, 10), i => prod(subscript(input.weapon.refineIndex, dmgInc), i))
 }, naught)
 
 
@@ -34,14 +34,14 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 10).map(c => [c, {
         name: `${c}s`,
         fields: [{
           node: all_dmg_
-        }], 
+        }],
       }]))
     }
   }]

--- a/src/Data/Weapons/Bow/AmosBow/index.tsx
+++ b/src/Data/Weapons/Bow/AmosBow/index.tsx
@@ -40,6 +40,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       { node: normal_dmg_ },
       { node: charged_dmg_ },
@@ -47,8 +48,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: objectKeyMap(range(1, 5), i => ({

--- a/src/Data/Weapons/Bow/BlackcliffWarbow/index.tsx
+++ b/src/Data/Weapons/Bow/BlackcliffWarbow/index.tsx
@@ -3,20 +3,21 @@ import { input } from '../../../../Formula'
 import { lookup, subscript, prod, naught } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, st, sgt } from '../../../SheetUtil'
+import { cond, st, sgt, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "BlackcliffWarbow"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 const atkInc = [.12, .15, .18, .21, .24]
 
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
 const atk_ = lookup(condPassive, {
-  ...objectKeyMap(range(1, 3), i => prod(subscript(input.weapon.refineIndex, atkInc), i)) 
+  ...objectKeyMap(range(1, 3), i => prod(subscript(input.weapon.refineIndex, atkInc), i))
 }, naught)
 
 
@@ -33,16 +34,17 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("afterDefeatEnemy"),
       states: Object.fromEntries(range(1, 3).map(c => [c, {
-        name: `${c}`,
+        name: st("stack", { count: c }),
         fields: [{
           node: atk_
         }, {
           text: sgt("duration"),
           value: 30,
           unit: 's'
-        }], 
+        }],
       }]))
     }
   }]

--- a/src/Data/Weapons/Bow/CompoundBow/index.tsx
+++ b/src/Data/Weapons/Bow/CompoundBow/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { lookup, naught, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -38,11 +38,11 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 4).map(i => [i, {
-        name: `${i}`,
+        name: st("stack", { count: i }),
         fields: [{
           node: atk_
         }, {

--- a/src/Data/Weapons/Bow/ElegyForTheEnd/index.tsx
+++ b/src/Data/Weapons/Bow/ElegyForTheEnd/index.tsx
@@ -2,7 +2,7 @@ import type { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript, sum } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -31,13 +31,14 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: eleMas,
     }],
     conditional: {
       value: condNode,
       path: condPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: {

--- a/src/Data/Weapons/Bow/Hamayumi/index.tsx
+++ b/src/Data/Weapons/Bow/Hamayumi/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript, sum } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -34,6 +34,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: normal_dmg
     }, {
@@ -43,7 +44,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Bow/Messenger/index.tsx
+++ b/src/Data/Weapons/Bow/Messenger/index.tsx
@@ -3,17 +3,19 @@ import { input } from '../../../../Formula'
 import { constant, subscript, prod, infoMut } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Messenger"
 const data_gen = data_gen_json as WeaponData
-const dmg_s = [1, 1.25, 1.5, 1.75, 2]
+const [tr] = trans("weapon", key)
 
-const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_s), input.total.atk), "elemental", { hit: { ele: constant("physical") }})
+const dmg_s = [1, 1.25, 1.5, 1.75, 2]
+const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_s), input.total.atk), "elemental", { hit: { ele: constant("physical") } })
 
 const data = dataObjForWeaponSheet(key, data_gen)
 
@@ -21,6 +23,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmg, { key: "sheet:dmg" })
     }]

--- a/src/Data/Weapons/Bow/MitternachtsWaltz/index.tsx
+++ b/src/Data/Weapons/Bow/MitternachtsWaltz/index.tsx
@@ -36,7 +36,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condNormal,
       path: condNormalPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st("hitOp.skill"),
       states: {
@@ -55,7 +55,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condSkill,
       path: condSkillPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st("hitOp.normal"),
       states: {

--- a/src/Data/Weapons/Bow/MouunsMoon/index.tsx
+++ b/src/Data/Weapons/Bow/MouunsMoon/index.tsx
@@ -3,16 +3,16 @@ import { input } from '../../../../Formula'
 import { lookup, min, naught, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "MouunsMoon"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "WatatsumiWavewalker")
 const energyRange = range(4, 36).map(i => i * 10)
@@ -32,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("party"),
       states: Object.fromEntries(energyRange.map(i => [i, {
         name: i.toString(),

--- a/src/Data/Weapons/Bow/PolarStar/index.tsx
+++ b/src/Data/Weapons/Bow/PolarStar/index.tsx
@@ -40,6 +40,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: skill_dmg_,
     }, {
@@ -48,8 +49,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: objectKeyMap(range(1, 4), i => ({

--- a/src/Data/Weapons/Bow/Predator/index.tsx
+++ b/src/Data/Weapons/Bow/Predator/index.tsx
@@ -3,24 +3,25 @@ import { input } from '../../../../Formula'
 import { lookup, prod, naught, constant, percent, equal } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Predator"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const normalInc = percent(.1)
 const chargedInc = percent(.1)
-
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
 const normal_dmg_ = lookup(condPassive, {
-  ...objectKeyMap(range(1, 2), i => prod(normalInc, i)) 
+  ...objectKeyMap(range(1, 2), i => prod(normalInc, i))
 }, naught)
 const charged_dmg_ = lookup(condPassive, {
-  ...objectKeyMap(range(1, 2), i => prod(chargedInc, i)) 
+  ...objectKeyMap(range(1, 2), i => prod(chargedInc, i))
 }, naught)
 const atk = equal(input.activeCharKey, "Aloy", constant(66))
 
@@ -40,9 +41,10 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("hitOp.cryo"),
       states: Object.fromEntries(range(1, 2).map(c => [c, {
-        name: `${c}`,
+        name: st("stack", { count: c }),
         fields: [{
           node: normal_dmg_
         }, {
@@ -51,7 +53,7 @@ const sheet: IWeaponSheet = {
           text: sgt("duration"),
           value: 6,
           unit: 's'
-        }], 
+        }],
       }]))
     }
   }]

--- a/src/Data/Weapons/Bow/PrototypeCrescent/index.tsx
+++ b/src/Data/Weapons/Bow/PrototypeCrescent/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, percent, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -32,7 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: {

--- a/src/Data/Weapons/Bow/RavenBow/index.tsx
+++ b/src/Data/Weapons/Bow/RavenBow/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -32,7 +32,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Bow/RecurveBow/index.tsx
+++ b/src/Data/Weapons/Bow/RecurveBow/index.tsx
@@ -3,16 +3,18 @@ import { input } from '../../../../Formula'
 import { subscript, prod, infoMut } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { customHealNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "RecurveBow"
 const data_gen = data_gen_json as WeaponData
-const healing_s = [.08, .10, .12, .14, .16]
+const [tr] = trans("weapon", key)
 
+const healing_s = [.08, .10, .12, .14, .16]
 const healing = customHealNode(prod(input.total.hp, subscript(input.weapon.refineIndex, healing_s)))
 
 const data = dataObjForWeaponSheet(key, data_gen)
@@ -21,6 +23,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(healing, { key: "sheet_gen:healing", variant: "success" })
     }]

--- a/src/Data/Weapons/Bow/RoyalBow/index.tsx
+++ b/src/Data/Weapons/Bow/RoyalBow/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { lookup, naught, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -17,7 +17,7 @@ const data_gen = data_gen_json as WeaponData
 const critRate_s = [.08, .10, .12, .14, .16]
 const [condPassivePath, condPassive] = cond(key, "Focus")
 const critRate_ = lookup(condPassive, {
-  ...objectKeyMap(range(1, 5), i => prod(subscript(input.weapon.refineIndex, critRate_s), i)) 
+  ...objectKeyMap(range(1, 5), i => prod(subscript(input.weapon.refineIndex, critRate_s), i))
 }, naught)
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -33,11 +33,11 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 5).map(i => [i, {
-        name: `${i}`,
+        name: st("stack", { count: i }),
         fields: [{
           node: critRate_
         }]

--- a/src/Data/Weapons/Bow/Rust/index.tsx
+++ b/src/Data/Weapons/Bow/Rust/index.tsx
@@ -2,14 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { constant, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Rust"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const normal_dmg_s = [.4, .5, .6, .7, .8]
 
@@ -27,6 +29,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: normal_dmg_
     }, {

--- a/src/Data/Weapons/Bow/SacrificialBow/index.tsx
+++ b/src/Data/Weapons/Bow/SacrificialBow/index.tsx
@@ -1,16 +1,16 @@
 import { WeaponData } from 'pipeline'
 import { equal, percent } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SacrificialBow"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "Composed")
 const cdRed_ = equal(condPassive, 'on', percent(1))
@@ -28,6 +28,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Bow/SharpshootersOath/index.tsx
+++ b/src/Data/Weapons/Bow/SharpshootersOath/index.tsx
@@ -2,14 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SharpshootersOath"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const weakspotDMG_s = [.24, .30, .36, .42, .48]
 const weakspotDMG_ = subscript(input.weapon.refineIndex, weakspotDMG_s)
@@ -24,6 +26,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: weakspotDMG_
     }]

--- a/src/Data/Weapons/Bow/SkywardHarp/index.tsx
+++ b/src/Data/Weapons/Bow/SkywardHarp/index.tsx
@@ -3,19 +3,21 @@ import { input } from '../../../../Formula'
 import { constant, percent, subscript, prod, infoMut } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SkywardHarp"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const critd_s = [.20, .25, .30, .35, .40]
 const dmgPerc = percent(1.25)
-
 const critDMG_ = subscript(input.weapon.refineIndex, critd_s)
-const dmg = customDmgNode(prod(dmgPerc, input.total.atk), "elemental", { hit: { ele: constant("physical") }})
+const dmg = customDmgNode(prod(dmgPerc, input.total.atk), "elemental", { hit: { ele: constant("physical") } })
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
@@ -27,6 +29,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmg, { key: "sheet:dmg" })
     }]

--- a/src/Data/Weapons/Bow/Slingshot/index.tsx
+++ b/src/Data/Weapons/Bow/Slingshot/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, percent, subscript, sum } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -33,6 +33,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: normal_atk_decrease
     }, {
@@ -41,7 +42,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: {

--- a/src/Data/Weapons/Bow/TheStringless/index.tsx
+++ b/src/Data/Weapons/Bow/TheStringless/index.tsx
@@ -2,16 +2,18 @@ import type { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheStringless"
 const data_gen = data_gen_json as WeaponData
-const refinementVals = [0.24, 0.30, 0.36, 0.42, 0.48]
+const [tr] = trans("weapon", key)
 
+const refinementVals = [0.24, 0.30, 0.36, 0.42, 0.48]
 const skill_dmg_ = subscript(input.weapon.refineIndex, refinementVals)
 const burst_dmg_ = subscript(input.weapon.refineIndex, refinementVals)
 
@@ -25,6 +27,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: skill_dmg_,
     }, {

--- a/src/Data/Weapons/Bow/TheViridescentHunt/index.tsx
+++ b/src/Data/Weapons/Bow/TheViridescentHunt/index.tsx
@@ -3,24 +3,26 @@ import { input } from '../../../../Formula'
 import { constant, subscript, prod, infoMut } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheViridescentHunt"
 const data_gen = data_gen_json as WeaponData
-const dmgPerc_s = [.4, .5, .6, .7, .8]
+const [tr] = trans("weapon", key)
 
-const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc_s), input.total.atk), "elemental", { hit: { ele: constant("physical") }})
+const dmgPerc_s = [.4, .5, .6, .7, .8]
+const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc_s), input.total.atk), "elemental", { hit: { ele: constant("physical") } })
 
 const data = dataObjForWeaponSheet(key, data_gen)
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmg, { key: "sheet:dmg" })
     }]

--- a/src/Data/Weapons/Bow/ThunderingPulse/index.tsx
+++ b/src/Data/Weapons/Bow/ThunderingPulse/index.tsx
@@ -13,8 +13,8 @@ import icon from './Icon.png'
 const key: WeaponKey = "ThunderingPulse"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
-const atkSrc = [0.20, 0.25, 0.30, 0.35, 0.40]
 
+const atkSrc = [0.20, 0.25, 0.30, 0.35, 0.40]
 const naStack1 = [0.12, 0.15, 0.18, 0.21, 0.24]
 const naStack2 = [0.24, 0.3, 0.36, 0.42, 0.48]
 const naStack3 = [0.4, 0.5, 0.6, 0.7, 0.8]
@@ -36,14 +36,14 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: atk_,
     }],
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: objectKeyMap(range(1, 3), i => ({

--- a/src/Data/Weapons/Bow/WindblumeOde/index.tsx
+++ b/src/Data/Weapons/Bow/WindblumeOde/index.tsx
@@ -12,8 +12,8 @@ import icon from './Icon.png'
 const key: WeaponKey = "WindblumeOde"
 const data_gen = data_gen_json as WeaponData
 const [tr] = trans("weapon", key)
-const atk_s = [.16, .20, .24, .28, .32]
 
+const atk_s = [.16, .20, .24, .28, .32]
 const [condPassivePath, condPassive] = cond(key, "WindblumeWish")
 const atk_ = equal(condPassive, "on", subscript(input.weapon.refineIndex, atk_s))
 
@@ -31,7 +31,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: st("afterUse.skill"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/BlackcliffAgate/index.tsx
+++ b/src/Data/Weapons/Catalyst/BlackcliffAgate/index.tsx
@@ -33,12 +33,12 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: st("afterDefeatEnemy"),
       states:
         Object.fromEntries(opponentsDefeated.map(c => [c, {
-          name: `${c}`,
+          name: st("stack", { count: c }),
           fields: [{
             node: atk_,
           }, {

--- a/src/Data/Weapons/Catalyst/DodocoTales/index.tsx
+++ b/src/Data/Weapons/Catalyst/DodocoTales/index.tsx
@@ -22,11 +22,9 @@ const charged_dmg_ = equal("on", condNormal, subscript(input.weapon.refineIndex,
 const atk_ = equal("on", condCharged, subscript(input.weapon.refineIndex, atkInc))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
-  teamBuff: {
-    premod: {
-      charged_dmg_,
-      atk_
-    }
+  premod: {
+    charged_dmg_,
+    atk_
   }
 })
 

--- a/src/Data/Weapons/Catalyst/DodocoTales/index.tsx
+++ b/src/Data/Weapons/Catalyst/DodocoTales/index.tsx
@@ -38,7 +38,7 @@ const sheet: IWeaponSheet = {
       value: condNormal,
       path: condNormalPath,
       name: st("hitOp.normal"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/EmeraldOrb/index.tsx
+++ b/src/Data/Weapons/Catalyst/EmeraldOrb/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -32,7 +32,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/EverlastingMoonglow/index.tsx
+++ b/src/Data/Weapons/Catalyst/EverlastingMoonglow/index.tsx
@@ -5,28 +5,31 @@ import { prod, subscript } from "../../../../Formula/utils"
 import { dataObjForWeaponSheet } from '../../util'
 import { input } from '../../../../Formula'
 import data_gen_json from './data_gen.json'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import { WeaponKey } from '../../../../Types/consts'
-import { trans } from '../../../SheetUtil'
+import { st, trans } from '../../../SheetUtil'
 
 const key: WeaponKey = "EverlastingMoonglow"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const hp_conv = [0.01, 0.015, 0.02, 0.025, 0.03]
 const [, trm] = trans("weapon", key)
 const normal_dmgInc = prod(subscript(input.weapon.refineIndex, hp_conv, { key: '_' }), input.premod.hp)
 const heal_ = subscript(input.weapon.refineIndex, data_gen.addProps.map(x => x.heal_ ?? NaN))
 export const data = dataObjForWeaponSheet(key, data_gen, {
-  premod: { 
+  premod: {
     normal_dmgInc, // TODO: technically should be in "total", but should be fine as premod
     heal_
   }
-}, { 
-  normal_dmgInc 
+}, {
+  normal_dmgInc
 })
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: heal_
     }, {

--- a/src/Data/Weapons/Catalyst/EyeOfPerception/index.tsx
+++ b/src/Data/Weapons/Catalyst/EyeOfPerception/index.tsx
@@ -3,17 +3,18 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "EyeOfPerception"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmg_Src = [2.4, 2.7, 3, 3.3, 3.6]
-
 const dmg_ = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
@@ -26,6 +27,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: infoMut(dmg_, { key: "sheet:dmg" }) }],
   }]
 }

--- a/src/Data/Weapons/Catalyst/Frostbearer/index.tsx
+++ b/src/Data/Weapons/Catalyst/Frostbearer/index.tsx
@@ -3,33 +3,35 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Frostbearer"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgAoePerc = [0.8, 0.95, 1.1, 1.25, 1.4]
 const dmgCryoPerc = [2, 2.4, 2.8, 3.2, 3.6]
-
 const dmgAoe = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgAoePerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
 const dmgOnCryoOp = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgCryoPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
+
 const data = dataObjForWeaponSheet(key, data_gen, undefined, {
   dmgAoe,
   dmgOnCryoOp
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmgAoe, { key: `weapon_${key}:aoeDmg` }),
     }, {

--- a/src/Data/Weapons/Catalyst/HakushinRing/index.tsx
+++ b/src/Data/Weapons/Catalyst/HakushinRing/index.tsx
@@ -4,7 +4,7 @@ import { Translate } from '../../../../Components/Translate'
 import { input } from '../../../../Formula'
 import { equal, lookup, naught, subscript, unequal } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -50,7 +50,7 @@ const sheet: IWeaponSheet = {
       name: <Translate ns="weapon_HakushinRing" key18="afterElectroReaction" />,
       canShow: unequal(input.activeCharKey, input.charKey, 1),
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         anemo: {
@@ -60,6 +60,7 @@ const sheet: IWeaponSheet = {
           }, {
             node: electro_dmg_
           }, {
+            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
             text: sgt("duration"),
             value: 6,
             unit: "s"
@@ -72,6 +73,7 @@ const sheet: IWeaponSheet = {
           }, {
             node: electro_dmg_
           }, {
+            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
             text: sgt("duration"),
             value: 6,
             unit: "s"
@@ -84,6 +86,7 @@ const sheet: IWeaponSheet = {
           }, {
             node: electro_dmg_
           }, {
+            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
             text: sgt("duration"),
             value: 6,
             unit: "s"
@@ -96,6 +99,7 @@ const sheet: IWeaponSheet = {
           }, {
             node: electro_dmg_
           }, {
+            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
             text: sgt("duration"),
             value: 6,
             unit: "s"
@@ -108,6 +112,7 @@ const sheet: IWeaponSheet = {
           }, {
             node: electro_dmg_
           }, {
+            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
             text: sgt("duration"),
             value: 6,
             unit: "s"

--- a/src/Data/Weapons/Catalyst/KagurasVerity/index.tsx
+++ b/src/Data/Weapons/Catalyst/KagurasVerity/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { equal, subscript, sum } from "../../../../Formula/utils"
 import { allElements, WeaponKey } from '../../../../Types/consts'
 import { range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -13,11 +13,11 @@ import icon from './Icon.png'
 const key: WeaponKey = "KagurasVerity"
 const data_gen = data_gen_json as WeaponData
 const [tr] = trans("weapon", key)
-const dmg_ = [0.12, 0.15, 0.18, 0.21, 0.24]
+
 const [condPath, condNode] = cond(key, "KaguraDance")
-
-const skill_dmg_s = range(1, 3).map(i => equal(condNode, i.toString(), subscript(input.weapon.refineIndex, dmg_.map(d => d * i)), { key: "skill_dmg_" }))
-
+const totems = range(1, 3)
+const dmg_ = [0.12, 0.15, 0.18, 0.21, 0.24]
+const skill_dmg_s = totems.map(i => equal(condNode, i.toString(), subscript(input.weapon.refineIndex, dmg_.map(d => d * i)), { key: "skill_dmg_" }))
 const ele_dmg_s = Object.fromEntries(allElements.map(ele => [ele, equal(condNode, "3", subscript(input.weapon.refineIndex, dmg_))]))
 
 export const data = dataObjForWeaponSheet(key, data_gen, {
@@ -33,25 +33,17 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condNode,
       path: condPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
-      name: "Kagura Dance",
-      states: {
-        1: {
-          name: "1",
-          fields: [{ node: skill_dmg_s[0] }]
-        },
-        2: {
-          name: "2",
-          fields: [{ node: skill_dmg_s[1] }]
-        },
-        3: {
-          name: "3",
-          fields: [{ node: skill_dmg_s[2], },
-          ...allElements.map(ele => ({ node: ele_dmg_s[ele] }))
-          ]
-        }
-      }
+      name: st("afterUse.skill"),
+      states:
+        Object.fromEntries(totems.map(i => [i, {
+          name: st("stack", { count: i }),
+          fields: [{
+            node: skill_dmg_s[i - 1]
+          },
+          ...allElements.map(ele => ({ node: ele_dmg_s[ele] }))]
+        }]))
     }
   }],
 }

--- a/src/Data/Weapons/Catalyst/LostPrayerToTheSacredWinds/index.tsx
+++ b/src/Data/Weapons/Catalyst/LostPrayerToTheSacredWinds/index.tsx
@@ -33,11 +33,12 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: moveSPD_ }],
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: objectKeyMap(range(1, 4), i => ({

--- a/src/Data/Weapons/Catalyst/MagicGuide/index.tsx
+++ b/src/Data/Weapons/Catalyst/MagicGuide/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -30,7 +30,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/MappaMare/index.tsx
+++ b/src/Data/Weapons/Catalyst/MappaMare/index.tsx
@@ -33,7 +33,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: objectKeyMap(range(1, 2), i => ({

--- a/src/Data/Weapons/Catalyst/MemoryOfDust/index.tsx
+++ b/src/Data/Weapons/Catalyst/MemoryOfDust/index.tsx
@@ -1,11 +1,11 @@
 import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
-import { lookup, naught, prod, subscript } from '../../../../Formula/utils'
+import { equal, lookup, naught, prod, subscript, sum } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { objectKeyMap, objectKeyValueMap, range } from '../../../../Util/Util'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { range } from '../../../../Util/Util'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
@@ -19,52 +19,64 @@ const atkSrc = [0.04, 0.05, 0.06, 0.07, 0.08]
 const [condPassivePath, condPassive] = cond(key, "GoldenMajesty")
 const shield_ = subscript(input.weapon.refineIndex, shieldSrc)
 
+const [condWithShieldPath, condWithShield] = cond(key, "WithShield")
+
 const atkInc = subscript(input.weapon.refineIndex, atkSrc)
-const atkStacks = lookup(condPassive, {
-  ...objectKeyMap(range(1, 5), i => prod(atkInc, i)),
-  ...objectKeyValueMap(range(1, 5), i => [`w${i}`, prod(atkInc, i, 2)]),
-}, naught)
+const atkStacks = prod(
+  sum(1, equal(condWithShield, "protected", 1)),
+  lookup(condPassive, Object.fromEntries(range(1, 5).map(i =>
+    [i, prod(atkInc, i)])), naught)
+)
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     shield_,
     atk_: atkStacks
-  }
+  },
 })
 
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
+    fields: [{
+      node: shield_
+    }],
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
-      description: conditionaldesc(tr),
-      name: trm("condName"),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
+      name: st("hits"),
+      states: Object.fromEntries(range(1, 5).map(i => 
+        [i, {
+          name: st("stack", { count: i }),
+          fields: [{
+            node: atkStacks
+          }, {
+            text: sgt("duration"),
+            value: 8,
+            unit: "s"
+          }]
+        }]
+      )),
+    }
+  }, {
+    conditional: {
+      value: condWithShield,
+      path: condWithShieldPath,
+      header: conditionalHeader(tr, icon, iconAwaken, trm("shield")),
+      name: st("protectedByShield"),
       states: {
-        ...objectKeyMap(range(1, 5), i => ({
-          name: trm("stackWithoutShield", { count: i }),
+        protected: {
           fields: [{
-            node: atkStacks
-          }, {
-            text: sgt("duration"),
-            value: 8,
-            unit: "s"
+            text: trm("atkEffInc"),
+            value: 100,
+            unit: "%"
           }]
-        })),
-        ...objectKeyValueMap(range(1, 5), i => [`w${i}`, {
-          name: trm("stackWithShield", { count: i }),
-          fields: [{
-            node: atkStacks
-          }, {
-            text: sgt("duration"),
-            value: 8,
-            unit: "s"
-          }]
-        }])
+        }
       }
     }
-  }]
+  }],
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Catalyst/OathswornEye/index.tsx
+++ b/src/Data/Weapons/Catalyst/OathswornEye/index.tsx
@@ -32,7 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condSkillBurst,
       path: condSkillBurstPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st("afterUse.skill"),
       states: {

--- a/src/Data/Weapons/Catalyst/OtherworldlyStory/index.tsx
+++ b/src/Data/Weapons/Catalyst/OtherworldlyStory/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { infoMut, prod, subscript } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { customHealNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "OtherworldlyStory"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const healPerc = [0.01, 0.0125, 0.015, 0.0175, 0.02]
 const heal = customHealNode(prod(subscript(input.weapon.refineIndex, healPerc, { key: "_" }), input.total.hp))
@@ -19,6 +21,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(heal, { key: "sheet_gen:healing", variant: "success" })
     }]

--- a/src/Data/Weapons/Catalyst/PrototypeAmber/index.tsx
+++ b/src/Data/Weapons/Catalyst/PrototypeAmber/index.tsx
@@ -27,7 +27,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: st("afterUse.burst"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/RoyalGrimoire/index.tsx
+++ b/src/Data/Weapons/Catalyst/RoyalGrimoire/index.tsx
@@ -30,7 +30,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 5).map(i => [i, {

--- a/src/Data/Weapons/Catalyst/SacrificialFragments/index.tsx
+++ b/src/Data/Weapons/Catalyst/SacrificialFragments/index.tsx
@@ -1,7 +1,7 @@
 import { WeaponData } from 'pipeline'
 import { equal, percent } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -28,7 +28,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: {

--- a/src/Data/Weapons/Catalyst/SkywardAtlas/index.tsx
+++ b/src/Data/Weapons/Catalyst/SkywardAtlas/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { allElements, WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SkywardAtlas"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgBonus = [0.12, 0.15, 0.18, 0.21, 0.24]
 const eleBonus_ = Object.fromEntries(allElements.map(ele => [ele, subscript(input.weapon.refineIndex, dmgBonus)]))
@@ -29,6 +31,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       ...allElements.map(ele => ({ node: eleBonus_[ele] })),
       {

--- a/src/Data/Weapons/Catalyst/SolarPearl/index.tsx
+++ b/src/Data/Weapons/Catalyst/SolarPearl/index.tsx
@@ -37,7 +37,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condNormal,
       path: condNormalPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st("hitOp.normal"),
       states: {
@@ -54,7 +54,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condSkillBurst,
       path: condSkillBurstPath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st("hitOp.skillOrBurst"),
       states: {

--- a/src/Data/Weapons/Catalyst/TheWidsith/index.tsx
+++ b/src/Data/Weapons/Catalyst/TheWidsith/index.tsx
@@ -3,7 +3,7 @@ import { Translate } from '../../../../Components/Translate'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -47,7 +47,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: <Translate ns="weapon_TheWidsith_gen" key18="passiveName" />,
       states: {

--- a/src/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
+++ b/src/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input, target } from '../../../../Formula'
 import { equal, subscript, unequal } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -36,7 +36,7 @@ const sheet: IWeaponSheet = {
       name: trm('condName'),
       canShow: unequal(input.activeCharKey, input.charKey, 1),
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/TwinNephrite/index.tsx
+++ b/src/Data/Weapons/Catalyst/TwinNephrite/index.tsx
@@ -34,7 +34,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: st("afterDefeatEnemy"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Catalyst/WineAndSong/index.tsx
+++ b/src/Data/Weapons/Catalyst/WineAndSong/index.tsx
@@ -32,7 +32,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: st("afterSprint"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Claymore/Akuoumaru/index.tsx
+++ b/src/Data/Weapons/Claymore/Akuoumaru/index.tsx
@@ -3,16 +3,16 @@ import { input } from '../../../../Formula'
 import { lookup, min, naught, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Akuoumaru"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "WatatsumiWavewalker")
 const energyRange = range(4, 36).map(i => i * 10)
@@ -32,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("party"),
       states: Object.fromEntries(energyRange.map(i => [i, {
         name: i.toString(),

--- a/src/Data/Weapons/Claymore/BlackcliffSlasher/index.tsx
+++ b/src/Data/Weapons/Claymore/BlackcliffSlasher/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, lookup, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
+
 const key: WeaponKey = "BlackcliffSlasher"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
 const opponentsDefeated = range(1, 3)
@@ -23,7 +25,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atk_: atk_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -31,10 +32,11 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("afterDefeatEnemy"),
       states:
         Object.fromEntries(opponentsDefeated.map(c => [c, {
-          name: `${c}`,
+          name: st("stack", { count: c }),
           fields: [{
             node: atk_,
           }, {

--- a/src/Data/Weapons/Claymore/BloodtaintedGreatsword/index.tsx
+++ b/src/Data/Weapons/Claymore/BloodtaintedGreatsword/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -30,7 +30,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Claymore/DebateClub/index.tsx
+++ b/src/Data/Weapons/Claymore/DebateClub/index.tsx
@@ -3,25 +3,27 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "DebateClub"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgPerc = [0.6, 0.75, 0.9, 1.05, 1.2]
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
 const data = dataObjForWeaponSheet(key, data_gen)
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmg, { key: "sheet:dmg" }),
     }]

--- a/src/Data/Weapons/Claymore/FerrousShadow/index.tsx
+++ b/src/Data/Weapons/Claymore/FerrousShadow/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -33,7 +33,7 @@ const sheet: IWeaponSheet = {
       // TODO: need st("lessPercentHP", { percent: xx }) to change depending on the weapon refine index.
       // Probably need to change IConditional.name to have (data:Data)=>Displayable as well.
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Claymore/KatsuragikiriNagamasa/index.tsx
+++ b/src/Data/Weapons/Claymore/KatsuragikiriNagamasa/index.tsx
@@ -2,16 +2,18 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "KatsuragikiriNagamasa"
 const data_gen = data_gen_json as WeaponData
-const skill_dmg_Src = [0.06, 0.075, 0.09, 0.105, 0.12]
+const [tr] = trans("weapon", key)
 
+const skill_dmg_Src = [0.06, 0.075, 0.09, 0.105, 0.12]
 const skill_dmg_ = subscript(input.weapon.refineIndex, skill_dmg_Src)
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -19,11 +21,11 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     skill_dmg_
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: skill_dmg_ }],
   }],
 }

--- a/src/Data/Weapons/Claymore/LithicBlade/index.tsx
+++ b/src/Data/Weapons/Claymore/LithicBlade/index.tsx
@@ -5,15 +5,14 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "LithicBlade"
 const data_gen = data_gen_json as WeaponData
-
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const atkInc = [0.07, 0.08, 0.09, 0.1, 0.11]
@@ -33,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 4).map(i => [i, {
         name: st("member", { count: i }),

--- a/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
+++ b/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
@@ -13,9 +13,9 @@ import icon from './Icon.png'
 const key: WeaponKey = "LuxuriousSeaLord"
 const data_gen = data_gen_json as WeaponData
 const [tr] = trans("weapon", key)
+
 const burst_dmg_Src = [0.12, 0.15, 0.18, 0.21, 0.24]
 const dmg_Src = [1, 1.25, 1.5, 1.75, 2]
-
 const burst_dmg_ = subscript(input.weapon.refineIndex, burst_dmg_Src)
 const [condPassivePath, condPassive] = cond(key, "OceanicVictory")
 const dmg_ = equal(condPassive, 'on', customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
@@ -27,7 +27,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     burst_dmg_
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -37,7 +36,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st('hitOp.burst'),
       states: {

--- a/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
+++ b/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
@@ -35,7 +35,6 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      teamBuff: true,
       header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: st('hitOp.burst'),

--- a/src/Data/Weapons/Claymore/PrototypeArchaic/index.tsx
+++ b/src/Data/Weapons/Claymore/PrototypeArchaic/index.tsx
@@ -3,26 +3,28 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "PrototypeArchaic"
 const data_gen = data_gen_json as WeaponData
-const dmg_Src = [2.4, 3, 3.6, 4.2, 4.8]
+const [tr] = trans("weapon", key)
 
+const dmg_Src = [2.4, 3, 3.6, 4.2, 4.8]
 const dmg_ = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
 
 const data = dataObjForWeaponSheet(key, data_gen)
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: infoMut(dmg_, { key: "sheet:dmg" }) }],
   }],
 }

--- a/src/Data/Weapons/Claymore/Rainslasher/index.tsx
+++ b/src/Data/Weapons/Claymore/Rainslasher/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -21,7 +21,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     all_dmg_
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -30,7 +29,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Claymore/RedhornStonethresher/index.tsx
+++ b/src/Data/Weapons/Claymore/RedhornStonethresher/index.tsx
@@ -2,14 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "RedhornStonethresher"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const def_Src = [0.28, 0.35, 0.42, 0.49, 0.56]
 const normal_dmg_Src = [0.4, 0.5, 0.6, 0.7, 0.8]
@@ -19,7 +21,7 @@ const normal_dmgInc = prod(subscript(input.weapon.refineIndex, normal_dmg_Src, {
 const charged_dmgInc = prod(subscript(input.weapon.refineIndex, charged_dmg_Src, { key: "_" }), input.premod.def)
 
 const data = dataObjForWeaponSheet(key, data_gen, {
-  premod: { //
+  premod: {
     def_,
     normal_dmgInc, // TODO: technically should be in "total", but should be fine as premod
     charged_dmgInc, // TODO: technically should be in "total", but should be fine as premod
@@ -28,11 +30,11 @@ const data = dataObjForWeaponSheet(key, data_gen, {
   normal_dmgInc,
   charged_dmgInc,
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: def_
     }, {

--- a/src/Data/Weapons/Claymore/RoyalGreatsword/index.tsx
+++ b/src/Data/Weapons/Claymore/RoyalGreatsword/index.tsx
@@ -12,12 +12,12 @@ import icon from './Icon.png'
 
 const key: WeaponKey = "RoyalGreatsword"
 const data_gen = data_gen_json as WeaponData
-
 const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const crit_ = [0.08, 0.1, 0.12, 0.14, 0.16]
 const critRate_ = lookup(condStack, objectKeyMap(range(1, 5), i => prod(subscript(input.weapon.refineIndex, crit_, { key: "_" }), i)), naught)
+
 export const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     critRate_

--- a/src/Data/Weapons/Claymore/SacrificialGreatsword/index.tsx
+++ b/src/Data/Weapons/Claymore/SacrificialGreatsword/index.tsx
@@ -1,16 +1,16 @@
 import { WeaponData } from 'pipeline'
 import { equal, percent } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SacrificialGreatsword"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "Composed")
 const cdRed_ = equal(condPassive, 'on', percent(1))
@@ -28,6 +28,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
+++ b/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
@@ -36,7 +36,6 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      teamBuff: true,
       header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),

--- a/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
+++ b/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
@@ -37,7 +37,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
       name: trm("condName"),
       states: {

--- a/src/Data/Weapons/Claymore/SkyriderGreatsword/index.tsx
+++ b/src/Data/Weapons/Claymore/SkyriderGreatsword/index.tsx
@@ -17,6 +17,7 @@ const [tr] = trans("weapon", key)
 const [condStackPath, condStack] = cond(key, "stack")
 const bonusInc = [0.06, 0.07, 0.08, 0.09, 0.1]
 const atk_ = lookup(condStack, objectKeyMap(range(1, 4), i => prod(subscript(input.weapon.refineIndex, bonusInc, { key: "_" }), i)), naught)
+
 export const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     atk_

--- a/src/Data/Weapons/Claymore/SkywardPride/index.tsx
+++ b/src/Data/Weapons/Claymore/SkywardPride/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SkywardPride"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgInc = [0.08, 0.1, 0.12, 0.14, 0.16]
 const dmgPerc = [0.8, 1, 1.2, 1.4, 1.6]
@@ -18,16 +20,17 @@ const all_dmg_ = subscript(input.weapon.refineIndex, dmgInc)
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
+
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     all_dmg_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: all_dmg_,
     }, {

--- a/src/Data/Weapons/Claymore/SnowTombedStarsilver/index.tsx
+++ b/src/Data/Weapons/Claymore/SnowTombedStarsilver/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SnowTombedStarsilver"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgAoePerc = [0.8, 0.95, 1.1, 1.25, 1.4]
 const dmgCryoPerc = [2, 2.4, 2.8, 3.2, 3.6]
@@ -20,12 +22,13 @@ const dmgAoe = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgAoePerc
 const dmgOnCryoOp = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgCryoPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
-const data = dataObjForWeaponSheet(key, data_gen)
 
+const data = dataObjForWeaponSheet(key, data_gen)
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmgAoe, { key: `weapon_${key}:aoeDmg` }),
     }, {

--- a/src/Data/Weapons/Claymore/SongOfBrokenPines/index.tsx
+++ b/src/Data/Weapons/Claymore/SongOfBrokenPines/index.tsx
@@ -1,9 +1,8 @@
 import { WeaponData } from 'pipeline'
-import { Translate } from '../../../../Components/Translate'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -12,11 +11,11 @@ import icon from './Icon.png'
 
 const key: WeaponKey = "SongOfBrokenPines"
 const data_gen = data_gen_json as WeaponData
-const [tr] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
+
 const atk_Src = [0.16, 0.20, 0.24, 0.28, 0.32]
 const atkTeam_Src = [0.20, 0.25, 0.30, 0.35, 0.40]
 const atkSPD_Src = [0.12, 0.15, 0.18, 0.21, 0.24]
-
 const [condPassivePath, condPassive] = cond(key, "RebelsBannerHymn")
 const atk_ = subscript(input.weapon.refineIndex, atk_Src, { key: "_" })
 const atkTeam_ = equal("on", condPassive, subscript(input.weapon.refineIndex, atkTeam_Src, { key: "atk_" }))
@@ -33,19 +32,19 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     }
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: atk_ }],
     conditional: {
       value: condPassive,
       path: condPassivePath,
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
-      name: <Translate ns="weapon_SongOfBrokenPines" key18="name" />,
+      name: trm("name"),
       states: {
         on: {
           fields: [{

--- a/src/Data/Weapons/Claymore/TheBell/index.tsx
+++ b/src/Data/Weapons/Claymore/TheBell/index.tsx
@@ -13,11 +13,11 @@ import icon from './Icon.png'
 const key: WeaponKey = "TheBell"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
+
 const shieldSrc = [0.2, 0.23, 0.26, 0.29, 0.32]
 const allDmgSrc = [0.12, 0.15, 0.18, 0.21, 0.24]
 const [condPassivePath, condPassive] = cond(key, "RebelliousGuardian")
 const shield = customShieldNode(prod(subscript(input.weapon.refineIndex, shieldSrc, { key: "_" }), input.total.hp))
-
 const [condWithShieldPath, condWithShield] = cond(key, "WithShield")
 const all_dmg_ = subscript(input.weapon.refineIndex, allDmgSrc, { key: "_" })
 

--- a/src/Data/Weapons/Claymore/TheUnforged/index.tsx
+++ b/src/Data/Weapons/Claymore/TheUnforged/index.tsx
@@ -13,14 +13,12 @@ import icon from './Icon.png'
 const key: WeaponKey = "TheUnforged"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
+
 const shieldSrc = [0.2, 0.25, 0.3, 0.35, 0.40]
 const atkSrc = [0.04, 0.05, 0.06, 0.07, 0.08]
-
 const [condPassivePath, condPassive] = cond(key, "GoldenMajesty")
 const shield_ = subscript(input.weapon.refineIndex, shieldSrc)
-
 const [condWithShieldPath, condWithShield] = cond(key, "WithShield")
-
 const atkInc = subscript(input.weapon.refineIndex, atkSrc)
 const atkStacks = prod(
   sum(1, equal(condWithShield, "protected", 1)),
@@ -34,7 +32,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atk_: atkStacks
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Claymore/WhiteIronGreatsword/index.tsx
+++ b/src/Data/Weapons/Claymore/WhiteIronGreatsword/index.tsx
@@ -11,11 +11,11 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "WhiteIronGreatsword"
-const [tr] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const hpRegen = [0.08, 0.1, 0.12, 0.14, 0.16]
 const [condPath, condNode] = cond(key, "CullTheWeak")
-
 const heal = equal(condNode, 'on', customHealNode(prod(subscript(input.weapon.refineIndex, hpRegen, { key: "_" }), input.total.hp)))
 
 export const data = dataObjForWeaponSheet(key, data_gen, undefined, { heal })
@@ -36,6 +36,6 @@ const sheet: IWeaponSheet = {
         }
       }
     }
-  }],
+  }]
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Claymore/Whiteblind/index.tsx
+++ b/src/Data/Weapons/Claymore/Whiteblind/index.tsx
@@ -12,13 +12,13 @@ import icon from './Icon.png'
 
 const key: WeaponKey = "Whiteblind"
 const data_gen = data_gen_json as WeaponData
-
 const [tr] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const bonusInc = [0.06, 0.075, 0.09, 0.105, 0.12]
 const atk_ = lookup(condStack, objectKeyMap(range(1, 4), i => prod(subscript(input.weapon.refineIndex, bonusInc, { key: "_" }), i)), naught)
 const def_ = lookup(condStack, objectKeyMap(range(1, 4), i => prod(subscript(input.weapon.refineIndex, bonusInc, { key: "_" }), i)), naught)
+
 export const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     atk_,
@@ -48,6 +48,6 @@ const sheet: IWeaponSheet = {
         }]
       }]))
     }
-  }],
+  }]
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Claymore/WolfsGravestone/index.tsx
+++ b/src/Data/Weapons/Claymore/WolfsGravestone/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -12,11 +12,11 @@ import icon from './Icon.png'
 const key: WeaponKey = "WolfsGravestone"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
+
 const atk_Src = [0.2, 0.25, 0.3, 0.35, 0.4]
 const atkTeam_Src = [0.4, 0.5, 0.6, 0.7, 0.8]
-
-const atk_ = subscript(input.weapon.refineIndex, atk_Src)
 const [condPassivePath, condPassive] = cond(key, "WolfishTracker")
+const atk_ = subscript(input.weapon.refineIndex, atk_Src)
 const atkTeam_ = equal("on", condPassive, subscript(input.weapon.refineIndex, atkTeam_Src, { key: "atk_" }))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -29,7 +29,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     }
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -39,7 +38,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       teamBuff: true,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       name: trm('condName'),
       states: {

--- a/src/Data/Weapons/Polearm/BlackTassel/index.tsx
+++ b/src/Data/Weapons/Polearm/BlackTassel/index.tsx
@@ -2,16 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "BlackTassel"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const dmgInc = [0.4, 0.5, 0.6, 0.7, 0.8]
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
@@ -29,6 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Polearm/BlackcliffPole/index.tsx
+++ b/src/Data/Weapons/Polearm/BlackcliffPole/index.tsx
@@ -3,14 +3,15 @@ import { input } from '../../../../Formula'
 import { constant, lookup, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 const key: WeaponKey = "BlackcliffPole"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
 const opponentsDefeated = range(1, 3)
@@ -31,10 +32,11 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("afterDefeatEnemy"),
       states:
         Object.fromEntries(opponentsDefeated.map(c => [c, {
-          name: `${c}`,
+          name: st("stack", { count: c }),
           fields: [{
             node: atk_,
           }, {

--- a/src/Data/Weapons/Polearm/CalamityQueller/index.tsx
+++ b/src/Data/Weapons/Polearm/CalamityQueller/index.tsx
@@ -5,7 +5,7 @@ import { allElements, WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
@@ -39,10 +39,12 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: Object.values(dmg_Nodes).map(node => ({ node })),
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: tr("passiveName"),
       states: Object.fromEntries(range(1, 6).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Polearm/CrescentPike/index.tsx
+++ b/src/Data/Weapons/Polearm/CrescentPike/index.tsx
@@ -3,16 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, equal, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "CrescentPike"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const atkInc = [0.2, 0.25, 0.3, 0.35, 0.4]
 const [condPassivePath, condPassive] = cond(key, "InfusionNeedle")
@@ -30,6 +30,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Polearm/Deathmatch/index.tsx
+++ b/src/Data/Weapons/Polearm/Deathmatch/index.tsx
@@ -2,9 +2,9 @@ import type { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { lookup, naught, equal, subscript } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
@@ -12,7 +12,7 @@ import icon from './Icon.png'
 const key: WeaponKey = "Deathmatch"
 const data_gen = data_gen_json as WeaponData
 
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const atkDefInc = [0.16, 0.2, 0.24, 0.28, 0.32]
@@ -33,6 +33,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         "oneOrNone": {

--- a/src/Data/Weapons/Polearm/DragonsBane/index.tsx
+++ b/src/Data/Weapons/Polearm/DragonsBane/index.tsx
@@ -2,16 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "DragonsBane"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const dmgInc = [0.2, 0.24, 0.28, 0.32, 0.36]
 const [condPassivePath, condPassive] = cond(key, "BaneOfFlameAndWater")
@@ -29,6 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Polearm/DragonspineSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/DragonspineSpear/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "DragonspineSpear"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgAoePerc = [0.8, 0.95, 1.1, 1.25, 1.4]
 const dmgCryoPerc = [2, 2.4, 2.8, 3.2, 3.6]
@@ -26,6 +28,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmgAoe, { key: `weapon_${key}:aoeDmg` }),
     }, {

--- a/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
+++ b/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
@@ -2,15 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, min, percent, prod, subscript, sum } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "EngulfingLightning"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const atk = [0.28, 0.35, 0.42, 0.49, 0.56]
 const atkMax = [0.8, 0.9, 1, 1.1, 1.2]
@@ -30,12 +31,14 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: atk_,
     }],
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: st("afterUse.burst"),
       states: {
         on: {

--- a/src/Data/Weapons/Polearm/Halberd/index.tsx
+++ b/src/Data/Weapons/Polearm/Halberd/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "Halberd"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgPerc = [1.6, 2, 2.4, 2.8, 3.2]
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc, { key: "_" }), input.total.atk), "elemental", {
@@ -22,6 +24,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: infoMut(dmg, { key: "sheet:dmg" }),
     }]

--- a/src/Data/Weapons/Polearm/KitainCrossSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/KitainCrossSpear/index.tsx
@@ -2,14 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "KitainCrossSpear"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const skill_dmgInc = [0.06, 0.075, 0.09, 0.105, 0.12]
 const skill_dmg_ = subscript(input.weapon.refineIndex, skill_dmgInc)
@@ -23,6 +25,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: skill_dmg_,
     }]

--- a/src/Data/Weapons/Polearm/LithicSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/LithicSpear/index.tsx
@@ -5,7 +5,7 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
@@ -13,7 +13,7 @@ import icon from './Icon.png'
 const key: WeaponKey = "LithicSpear"
 const data_gen = data_gen_json as WeaponData
 
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const atkInc = [0.07, 0.08, 0.09, 0.1, 0.11]
@@ -33,6 +33,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("members")),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 4).map(i => [i, {
         name: st("member", { count: i }),

--- a/src/Data/Weapons/Polearm/PrimordialJadeWingedSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/PrimordialJadeWingedSpear/index.tsx
@@ -5,7 +5,7 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
@@ -13,7 +13,7 @@ import icon from './Icon.png'
 const key: WeaponKey = "PrimordialJadeWingedSpear"
 const data_gen = data_gen_json as WeaponData
 
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const atkInc = [0.032, 0.039, 0.046, 0.053, 0.06]
@@ -33,6 +33,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 7).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Polearm/PrototypeStarglitter/index.tsx
+++ b/src/Data/Weapons/Polearm/PrototypeStarglitter/index.tsx
@@ -3,15 +3,16 @@ import { input } from '../../../../Formula'
 import { lookup, naught, prod, subscript } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, st } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "PrototypeStarglitter"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const dmgInc = [0.08, 0.1, 0.12, 0.14, 0.16]
@@ -30,6 +31,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("afterUse.skill"),
       states: Object.fromEntries(range(1, 2).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Polearm/RoyalSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/RoyalSpear/index.tsx
@@ -5,15 +5,14 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "RoyalSpear"
 const data_gen = data_gen_json as WeaponData
-
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const crit_ = [0.08, 0.1, 0.12, 0.14, 0.16]
@@ -30,6 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 5).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Polearm/SkywardSpine/index.tsx
+++ b/src/Data/Weapons/Polearm/SkywardSpine/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, percent, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SkywardSpine"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const critRateInc = [0.08, 0.1, 0.12, 0.14, 0.16]
 const dmgPerc = [0.4, 0.55, 0.7, 0.85, 1]
@@ -30,6 +32,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: critRate_,
     }, {

--- a/src/Data/Weapons/Polearm/StaffOfHoma/index.tsx
+++ b/src/Data/Weapons/Polearm/StaffOfHoma/index.tsx
@@ -2,15 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, infoMut, prod, subscript, sum } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, st } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "StaffOfHoma"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const hpInc = [0.2, 0.25, 0.3, 0.35, 0.4]
 const atkInc = [0.008, 0.01, 0.012, 0.014, 0.016]
@@ -32,6 +33,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: hp_
     }, {
@@ -40,6 +42,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: st("lessPercentHP", { percent: 50 }),
       states: {
         on: {

--- a/src/Data/Weapons/Polearm/TheCatch/index.tsx
+++ b/src/Data/Weapons/Polearm/TheCatch/index.tsx
@@ -2,17 +2,19 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheCatch"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const burstDmgSrc_ = [0.16, 0.2, 0.24, 0.28, 0.32]
 const burstCritSrc_ = [0.06, 0.075, 0.09, 0.105, 0.12]
-
 const burst_dmg_ = subscript(input.weapon.refineIndex, burstDmgSrc_)
 const burst_critRate_ = subscript(input.weapon.refineIndex, burstCritSrc_)
 
@@ -27,6 +29,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: burst_dmg_ }, { node: burst_critRate_ }],
   }],
 }

--- a/src/Data/Weapons/Polearm/WavebreakersFin/index.tsx
+++ b/src/Data/Weapons/Polearm/WavebreakersFin/index.tsx
@@ -3,16 +3,16 @@ import { input } from '../../../../Formula'
 import { lookup, min, naught, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { range } from '../../../../Util/Util'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "WavebreakersFin"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "WatatsumiWavewalker")
 const energyRange = range(4, 36).map(i => i * 10)
@@ -32,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("party"),
       states: Object.fromEntries(energyRange.map(i => [i, {
         name: i.toString(),

--- a/src/Data/Weapons/Polearm/WhiteTassel/index.tsx
+++ b/src/Data/Weapons/Polearm/WhiteTassel/index.tsx
@@ -2,14 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "WhiteTassel"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmgInc = [0.24, 0.30, 0.36, 0.42, 0.48]
 const normal_dmg_ = subscript(input.weapon.refineIndex, dmgInc)
@@ -23,6 +25,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: normal_dmg_,
     }]

--- a/src/Data/Weapons/Sword/AquilaFavonia/index.tsx
+++ b/src/Data/Weapons/Sword/AquilaFavonia/index.tsx
@@ -11,12 +11,12 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "AquilaFavonia"
-const [tr, trm] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
+const [tr, trm] = trans("weapon", key)
+
 const atkDealt = [2, 2.3, 2.6, 2.9, 3.2]
 const hpRegen = [1, 1.15, 1.3, 1.45, 1.6]
 const [condPath, condNode] = cond(key, "FalconOfTheWest")
-
 const atk_ = subscript(input.weapon.refineIndex, data_gen.addProps.map(x => x.atk_ ?? NaN))
 const heal = equal(condNode, 'on', prod(subscript(input.weapon.refineIndex, hpRegen, { key: "_" }), input.premod.atk))
 const dmg = equal(condNode, 'on', customDmgNode(prod(subscript(input.weapon.refineIndex, atkDealt, { key: "_" }), input.premod.atk), "elemental", {

--- a/src/Data/Weapons/Sword/BlackcliffLongsword/index.tsx
+++ b/src/Data/Weapons/Sword/BlackcliffLongsword/index.tsx
@@ -3,15 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, lookup, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "BlackcliffLongsword"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "PressTheAdvantage")
 const opponentsDefeated = range(1, 3)
@@ -24,7 +25,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atk_: atk_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -32,10 +32,11 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("afterDefeatEnemy"),
       states:
         Object.fromEntries(opponentsDefeated.map(c => [c, {
-          name: `${c}`,
+          name: st("stack", { count: c }),
           fields: [{
             node: atk_,
           }, {

--- a/src/Data/Weapons/Sword/CinnabarSpindle/index.tsx
+++ b/src/Data/Weapons/Sword/CinnabarSpindle/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -12,8 +12,8 @@ import icon from './Icon.png'
 const key: WeaponKey = "CinnabarSpindle"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
-const eleDmgIncSrc = [0.4, 0.5, 0.6, 0.7, 0.8]
 
+const eleDmgIncSrc = [0.4, 0.5, 0.6, 0.7, 0.8]
 const [condPassivePath, condPassive] = cond(key, "SpotlessHeart")
 const skill_dmgInc = equal("on", condPassive, prod(subscript(input.weapon.refineIndex, eleDmgIncSrc, { key: "_" }), input.premod.def))
 
@@ -24,7 +24,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
 }, {
   skill_dmgInc
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -32,7 +31,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("name"),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/CoolSteel/index.tsx
+++ b/src/Data/Weapons/Sword/CoolSteel/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -16,12 +16,12 @@ const [tr, trm] = trans("weapon", key)
 const dmgInc = [0.12, 0.15, 0.18, 0.21, 0.24]
 const [condPassivePath, condPassive] = cond(key, "BaneOfWaterAndIce")
 const all_dmg_ = equal("on", condPassive, subscript(input.weapon.refineIndex, dmgInc))
+
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     all_dmg_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -30,7 +30,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/DarkIronSword/index.tsx
+++ b/src/Data/Weapons/Sword/DarkIronSword/index.tsx
@@ -16,12 +16,12 @@ const [tr, trm] = trans("weapon", key)
 const atkInc = [0.2, 0.25, 0.3, 0.35, 0.5]
 const [condPassivePath, condPassive] = cond(key, "Overloaded")
 const atk_ = equal("on", condPassive, subscript(input.weapon.refineIndex, atkInc, { key: "_" }))
+
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     atk_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -30,7 +30,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       description: conditionaldesc(tr),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/FesteringDesire/index.tsx
+++ b/src/Data/Weapons/Sword/FesteringDesire/index.tsx
@@ -5,11 +5,14 @@ import { subscript } from "../../../../Formula/utils"
 import { dataObjForWeaponSheet } from '../../util'
 import { input } from '../../../../Formula'
 import data_gen_json from './data_gen.json'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import { WeaponKey } from '../../../../Types/consts'
+import { st, trans } from '../../../SheetUtil'
 
 const key: WeaponKey = "FesteringDesire"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const skill_dmgInc = [0.16, 0.2, 0.24, 0.28, 0.32]
 const skill_critInc = [0.06, 0.075, 0.09, 0.105, 0.12]
 const skill_dmg_ = subscript(input.weapon.refineIndex, skill_dmgInc, { key: '_' })
@@ -25,6 +28,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{
       node: skill_dmg_
     }, {

--- a/src/Data/Weapons/Sword/FilletBlade/index.tsx
+++ b/src/Data/Weapons/Sword/FilletBlade/index.tsx
@@ -3,15 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
-import { sgt } from '../../../SheetUtil'
+import { sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "FilletBlade"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmg_Src = [2.4, 2.8, 3.2, 3.6, 4]
 const cd_Src = [15, 14, 13, 12, 11]
@@ -26,6 +27,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       { node: infoMut(dmg_, { key: "sheet:dmg" }) },
       {

--- a/src/Data/Weapons/Sword/FreedomSworn/index.tsx
+++ b/src/Data/Weapons/Sword/FreedomSworn/index.tsx
@@ -12,15 +12,14 @@ import icon from './Icon.png'
 const key: WeaponKey = "FreedomSworn"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
-const autoSrc = [0.16, 0.20, 0.24, 0.28, 0.32]
-const atk_Src = [0.2, 0.25, 0.3, 0.35, 0.40]
 
 const [condPassivePath, condPassive] = cond(key, "MillennialMovement")
+const autoSrc = [0.16, 0.20, 0.24, 0.28, 0.32]
+const atk_Src = [0.2, 0.25, 0.3, 0.35, 0.40]
 const atk_ = equal("on", condPassive, subscript(input.weapon.refineIndex, atk_Src))
 const normal_dmg_ = equal("on", condPassive, subscript(input.weapon.refineIndex, autoSrc))
 const charged_dmg_ = { ...normal_dmg_ }
 const plunging_dmg_ = { ...normal_dmg_ }
-
 const dmg_ = subscript(input.weapon.refineIndex, data_gen.addProps.map(x => x.dmg_ ?? NaN))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -36,7 +35,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     }
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Sword/HarbingerOfDawn/index.tsx
+++ b/src/Data/Weapons/Sword/HarbingerOfDawn/index.tsx
@@ -12,9 +12,9 @@ import icon from './Icon.png'
 const key: WeaponKey = "HarbingerOfDawn"
 const data_gen = data_gen_json as WeaponData
 const [tr] = trans("weapon", key)
-const critRateSrc_ = [0.14, 0.175, 0.21, 0.245, 0.28]
 
 const [condPassivePath, condPassive] = cond(key, "SkyPiercingMight")
+const critRateSrc_ = [0.14, 0.175, 0.21, 0.245, 0.28]
 const critRate_ = equal("on", condPassive, subscript(input.weapon.refineIndex, critRateSrc_))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -22,7 +22,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     critRate_,
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -30,7 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: st("greaterPercentHP", { percent: 90 }),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/IronSting/index.tsx
+++ b/src/Data/Weapons/Sword/IronSting/index.tsx
@@ -5,14 +5,14 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "IronSting"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "InfusionStinger")
 const eleDmgDealtStack = range(1, 2)
@@ -25,7 +25,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     all_dmg_
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -33,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: trm("condName"),
       states:
         Object.fromEntries(eleDmgDealtStack.map(c => [c, {

--- a/src/Data/Weapons/Sword/LionsRoar/index.tsx
+++ b/src/Data/Weapons/Sword/LionsRoar/index.tsx
@@ -2,26 +2,26 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "LionsRoar"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
-const dmgInc = [0.2, 0.24, 0.28, 0.32, 0.36]
 const [condPassivePath, condPassive] = cond(key, "BaneOfFireAndThunder")
+const dmgInc = [0.2, 0.24, 0.28, 0.32, 0.36]
 const all_dmg_ = equal("on", condPassive, subscript(input.weapon.refineIndex, dmgInc))
+
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     all_dmg_
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -29,6 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/MistsplitterReforged/index.tsx
+++ b/src/Data/Weapons/Sword/MistsplitterReforged/index.tsx
@@ -11,8 +11,9 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "MistsplitterReforged"
-const [tr, trm] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
+const [tr, trm] = trans("weapon", key)
+
 const stacks = ["1", "2", "3"] as const
 const passiveRefine = [0.12, 0.15, 0.18, 0.21, 0.24]
 const stacksRefine = {
@@ -20,9 +21,7 @@ const stacksRefine = {
   "2": [0.16, 0.2, 0.24, 0.28, 0.32],
   "3": [0.28, 0.35, 0.42, 0.49, 0.56]
 }
-
 const [condPath, condNode] = cond(key, "MistsplittersEmblem")
-
 const passive_dmg_ = Object.fromEntries(allElements.map(ele =>
   [`${ele}_dmg_`,
   subscript(input.weapon.refineIndex, passiveRefine, { key: `${ele}_dmg_`, variant: ele })]
@@ -31,7 +30,7 @@ const stacks_dmg_ = Object.fromEntries(allElements.map(ele =>
   [`${ele}_dmg_`,
   equal(input.charEle, ele,
     lookup(condNode, objectKeyMap(stacks, stack =>
-      subscript(input.weapon.refineIndex, stacksRefine[stack])), naught, { key: `${ele}_dmg_`, variant: ele})
+      subscript(input.weapon.refineIndex, stacksRefine[stack])), naught, { key: `${ele}_dmg_`, variant: ele })
   )]
 ))
 const allEle_dmg_ = Object.fromEntries(allElements.map(ele =>
@@ -51,7 +50,7 @@ const sheet: IWeaponSheet = {
     fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [ // Passive
       ...allElements.map((ele) => {
-        return {node: passive_dmg_[`${ele}_dmg_`]}
+        return { node: passive_dmg_[`${ele}_dmg_`] }
       })
     ],
     conditional: { // Stacks - Mistsplitter's Emblem

--- a/src/Data/Weapons/Sword/PrimordialJadeCutter/index.tsx
+++ b/src/Data/Weapons/Sword/PrimordialJadeCutter/index.tsx
@@ -2,7 +2,7 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { trans } from '../../../SheetUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -10,11 +10,11 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "PrimordialJadeCutter"
-const [tr, ] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const hpSrc = [0.2, 0.25, 0.3, 0.35, 0.4]
 const atkSrc = [0.012, 0.015, 0.018, 0.021, 0.024]
-
 const hp_ = subscript(input.weapon.refineIndex, hpSrc)
 const atk = prod(subscript(input.weapon.refineIndex, atkSrc, { key: "_" }), input.premod.hp)
 
@@ -26,12 +26,11 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atk
   }
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
-    fieldsHeader: conditionalHeader(tr, icon, iconAwaken),
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: hp_ }, { node: atk }]
   }],
 }

--- a/src/Data/Weapons/Sword/PrototypeRancour/index.tsx
+++ b/src/Data/Weapons/Sword/PrototypeRancour/index.tsx
@@ -3,20 +3,22 @@ import { input } from '../../../../Formula'
 import { lookup, naught, prod, subscript } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "PrototypeRancour"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const bonusInc = [0.04, 0.05, 0.06, 0.07, 0.08]
 const atk_ = lookup(condStack, objectKeyMap(range(1, 4), i => prod(subscript(input.weapon.refineIndex, bonusInc, { key: "_" }), i)), naught)
 const def_ = lookup(condStack, objectKeyMap(range(1, 4), i => prod(subscript(input.weapon.refineIndex, bonusInc, { key: "_" }), i)), naught)
+
 export const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     atk_,
@@ -30,6 +32,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("onHit"),
       states: Object.fromEntries(range(1, 4).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Sword/RoyalLongsword/index.tsx
+++ b/src/Data/Weapons/Sword/RoyalLongsword/index.tsx
@@ -5,14 +5,14 @@ import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "RoyalLongsword"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const crit_ = [0.08, 0.1, 0.12, 0.14, 0.16]
@@ -30,6 +30,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condStack,
       path: condStackPath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: trm("condName"),
       states: Object.fromEntries(range(1, 5).map(i => [i, {
         name: st("stack", { count: i }),

--- a/src/Data/Weapons/Sword/SacrificialSword/index.tsx
+++ b/src/Data/Weapons/Sword/SacrificialSword/index.tsx
@@ -1,7 +1,7 @@
 import { WeaponData } from 'pipeline'
 import { equal, percent } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -20,7 +20,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     cdRed_,
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -29,7 +28,7 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm("condName"),
-      header: conditionalHeader(tr, icon, iconAwaken),
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       states: {
         on: {
           fields: [{

--- a/src/Data/Weapons/Sword/SkyriderSword/index.tsx
+++ b/src/Data/Weapons/Sword/SkyriderSword/index.tsx
@@ -2,15 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, sgt, st } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SkyriderSword"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "Determination")
 const bonusInc = [0.12, 0.15, 0.18, 0.21, 0.24]
@@ -30,6 +31,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: st("afterUse.burst"),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/SkywardBlade/index.tsx
+++ b/src/Data/Weapons/Sword/SkywardBlade/index.tsx
@@ -13,15 +13,14 @@ import icon from './Icon.png'
 const key: WeaponKey = "SkywardBlade"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
-const atkSrc_ = [0.2, 0.25, 0.3, 0.35, 0.40]
 
 const [condPassivePath, condPassive] = cond(key, "SkyPiercingMight")
+const atkSrc_ = [0.2, 0.25, 0.3, 0.35, 0.40]
 const moveSPD_ = equal("on", condPassive, percent(0.1))
 const atkSPD_ = equal("on", condPassive, percent(0.1))
 const dmg = equal("on", condPassive, customDmgNode(prod(subscript(input.weapon.refineIndex, atkSrc_, { key: "_" }), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 }))
-
 const critRate_ = subscript(input.weapon.refineIndex, data_gen.addProps.map(x => x.critRate_ ?? NaN))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
@@ -31,7 +30,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atkSPD_,
   }
 }, { dmg })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Sword/SummitShaper/index.tsx
+++ b/src/Data/Weapons/Sword/SummitShaper/index.tsx
@@ -13,14 +13,12 @@ import icon from './Icon.png'
 const key: WeaponKey = "SummitShaper"
 const data_gen = data_gen_json as WeaponData
 const [tr, trm] = trans("weapon", key)
-const shieldSrc = [0.2, 0.25, 0.3, 0.35, 0.40]
-const atkSrc = [0.04, 0.05, 0.06, 0.07, 0.08]
 
 const [condPassivePath, condPassive] = cond(key, "GoldenMajesty")
-const shield_ = subscript(input.weapon.refineIndex, shieldSrc)
-
 const [condWithShieldPath, condWithShield] = cond(key, "WithShield")
-
+const shieldSrc = [0.2, 0.25, 0.3, 0.35, 0.40]
+const atkSrc = [0.04, 0.05, 0.06, 0.07, 0.08]
+const shield_ = subscript(input.weapon.refineIndex, shieldSrc)
 const atkInc = subscript(input.weapon.refineIndex, atkSrc)
 const atkStacks = prod(
   sum(1, equal(condWithShield, "protected", 1)),
@@ -34,7 +32,6 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     atk_: atkStacks
   },
 })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
@@ -48,7 +45,7 @@ const sheet: IWeaponSheet = {
       path: condPassivePath,
       header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       name: st("hits"),
-      states: Object.fromEntries(range(1, 5).map(i => 
+      states: Object.fromEntries(range(1, 5).map(i =>
         [i, {
           name: st("stack", { count: i }),
           fields: [{
@@ -77,6 +74,6 @@ const sheet: IWeaponSheet = {
         }
       }
     }
-  }],
+  }]
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Sword/SwordOfDescension/index.tsx
+++ b/src/Data/Weapons/Sword/SwordOfDescension/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, equal, infoMut, percent, prod } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "SwordOfDescension"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const atk = equal("Traveler", input.charKey, constant(66))
 const dmg_ = customDmgNode(prod(percent(2), input.premod.atk), "elemental", {
@@ -28,6 +30,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       {
         node: atk

--- a/src/Data/Weapons/Sword/TheAlleyFlash/index.tsx
+++ b/src/Data/Weapons/Sword/TheAlleyFlash/index.tsx
@@ -2,16 +2,16 @@ import { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
 import { equal, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
-import { cond, trans } from '../../../SheetUtil'
+import { cond, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheAlleyFlash"
 const data_gen = data_gen_json as WeaponData
-const [, trm] = trans("weapon", key)
+const [tr, trm] = trans("weapon", key)
 
 const [condPassivePath, condPassive] = cond(key, "ItinerantHero")
 const bonusInc = [0.12, 0.15, 0.18, 0.21, 0.24]
@@ -29,6 +29,7 @@ const sheet: IWeaponSheet = {
     conditional: {
       value: condPassive,
       path: condPassivePath,
+      header: conditionalHeader(tr, icon, iconAwaken, st("conditional")),
       name: trm("condName"),
       states: {
         on: {

--- a/src/Data/Weapons/Sword/TheBlackSword/index.tsx
+++ b/src/Data/Weapons/Sword/TheBlackSword/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customHealNode } from '../../../Characters/dataUtil'
-import { trans } from '../../../SheetUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -11,11 +11,11 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheBlackSword"
-const [tr] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
+
 const autoSrc = [0.2, 0.25, 0.3, 0.35, 0.4]
 const hpRegenSrc = [0.6, 0.7, 0.8, 0.9, 1]
-
 const normal_dmg_ = subscript(input.weapon.refineIndex, autoSrc)
 const charged_dmg_ = subscript(input.weapon.refineIndex, autoSrc)
 const heal = customHealNode(prod(subscript(input.weapon.refineIndex, hpRegenSrc, { key: "_" }), input.total.atk))
@@ -26,12 +26,11 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     charged_dmg_
   }
 }, { heal })
-
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
-    fieldsHeader: conditionalHeader(tr, icon, iconAwaken),
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       { node: normal_dmg_ },
       { node: charged_dmg_ },

--- a/src/Data/Weapons/Sword/TheFlute/index.tsx
+++ b/src/Data/Weapons/Sword/TheFlute/index.tsx
@@ -3,14 +3,16 @@ import { input } from '../../../../Formula'
 import { constant, infoMut, percent, prod } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
-import WeaponSheet, { IWeaponSheet } from '../../WeaponSheet'
+import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
 import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TheFlute"
 const data_gen = data_gen_json as WeaponData
+const [tr] = trans("weapon", key)
 
 const dmg_ = customDmgNode(prod(percent(2), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
@@ -23,6 +25,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: infoMut(dmg_, { key: "sheet:dmg" }) }]
   }]
 }

--- a/src/Data/Weapons/Sword/TravelersHandySword/index.tsx
+++ b/src/Data/Weapons/Sword/TravelersHandySword/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customHealNode } from '../../../Characters/dataUtil'
-import { trans } from '../../../SheetUtil'
+import { st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -11,10 +11,10 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "TravelersHandySword"
-const [tr] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
-const hpRegenSrc = [0.01, 0.0125, 0.015, 0.0175, 0.02]
+const [tr] = trans("weapon", key)
 
+const hpRegenSrc = [0.01, 0.0125, 0.015, 0.0175, 0.02]
 const heal = customHealNode(prod(subscript(input.weapon.refineIndex, hpRegenSrc, { key: "_" }), input.total.hp))
 const data = dataObjForWeaponSheet(key, data_gen, undefined, { heal })
 
@@ -22,7 +22,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
-    fieldsHeader: conditionalHeader(tr, icon, iconAwaken),
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [
       { node: infoMut(heal, { key: "sheet_gen:healing", variant: "success" }) }
     ]


### PR DESCRIPTION
Notable changes on:

- Memory of Dust
- Vortex Vanquisher
- Kagura's Verity

Removed `teamBuff` on some weapons:

- Dodoco Tales
- Luxurious Sea Lord
- Serpent Spine

Everything else is only minor changes; adds `conditionalHeader` to `conditional` section and/or `fields` section