### PR TITLE
Move BS 4-set and other transient CR buffs to new key

### DIFF
--- a/src/Components/StatIcon.tsx
+++ b/src/Components/StatIcon.tsx
@@ -1,5 +1,6 @@
 import { faDiceD20 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { hitMoves } from '../StatConstants'
 import { objectKeyMap } from '../Util/Util'
 import ColorText from './ColoredText'
 import { faAnemo, faAtk, faCdReduction, faCritRate, faCryo, faDef, faDendro, faElectro, faElementalMastery, faEnergyRecharge, faGeo, faHealingBonus, faHp, faHydro, faMaxStamina, faPhysicalDmgBonus, faPyro, faShieldStrength } from './faIcons'
@@ -28,7 +29,12 @@ const StatIcon = {
 
   eleMas: <FontAwesomeIcon icon={faElementalMastery as any} />,
   critRate_: <FontAwesomeIcon icon={faCritRate as any} />,
+  bonus_critRate_: <FontAwesomeIcon icon={faCritRate as any} />,
   critDMG_: <FontAwesomeIcon icon={faDiceD20 as any} />,
+  ...Object.fromEntries(Object.keys(hitMoves).flatMap(move => [
+    [`${move}_critRate_`, <FontAwesomeIcon icon={faCritRate as any} />],
+    [`${move}_critDmg_`, <FontAwesomeIcon icon={faCritRate as any} />],
+  ])),
   enerRech_: <FontAwesomeIcon icon={faEnergyRecharge as any} />,
   heal_: <FontAwesomeIcon icon={faHealingBonus as any} />,
 

--- a/src/Data/Artifacts/BlizzardStrayer/index.tsx
+++ b/src/Data/Artifacts/BlizzardStrayer/index.tsx
@@ -19,8 +19,8 @@ const set4 = greaterEq(input.artSet.BlizzardStrayer, 4, lookup(condState, { "cry
 export const data: Data = dataObjForArtifactSheet(key, {
   premod: {
     cryo_dmg_: set2,
-    critRate_: set4
-  }
+    bonus_critRate_: set4,
+  },
 })
 
 const sheet: IArtifactSheet = {//Icebreaker

--- a/src/Data/Characters/dataUtil.tsx
+++ b/src/Data/Characters/dataUtil.tsx
@@ -15,7 +15,6 @@ export const absorbableEle = ["hydro", "pyro", "cryo", "electro"] as ElementKey[
 const charCurves = objectMap(_charCurves, value => [0, ...Object.values(value)])
 
 const commonBasic = objectKeyMap([...allSubstats, "heal_"], key => input.total[key])
-commonBasic.critRate_ = input.total.cappedCritRate
 
 const inferredHitEle = stringPrio(
   // Inferred Element

--- a/src/Data/Characters/dataUtil.tsx
+++ b/src/Data/Characters/dataUtil.tsx
@@ -3,7 +3,7 @@ import { input } from "../../Formula";
 import { inferInfoMut, mergeData } from "../../Formula/api";
 import { reactions } from "../../Formula/reaction";
 import { Data, DisplaySub, NumNode } from "../../Formula/type";
-import { constant, data, equalStr, infoMut, max, min, naught, percent, prod, stringPrio, subscript, sum, unit } from "../../Formula/utils";
+import { constant, data, equalStr, infoMut, percent, prod, stringPrio, subscript, sum, unit } from "../../Formula/utils";
 import { allMainStatKeys, allSubstats, MainStatKey } from "../../Types/artifact";
 import { CharacterKey, ElementKey, Region } from "../../Types/consts";
 import { layeredAssignment, objectKeyMap, objectMap } from "../../Util/Util";

--- a/src/Data/Characters/dataUtil.tsx
+++ b/src/Data/Characters/dataUtil.tsx
@@ -3,7 +3,7 @@ import { input } from "../../Formula";
 import { inferInfoMut, mergeData } from "../../Formula/api";
 import { reactions } from "../../Formula/reaction";
 import { Data, DisplaySub, NumNode } from "../../Formula/type";
-import { constant, data, equalStr, infoMut, percent, prod, stringPrio, subscript, sum, unit } from "../../Formula/utils";
+import { constant, data, equalStr, infoMut, max, min, naught, percent, prod, stringPrio, subscript, sum, unit } from "../../Formula/utils";
 import { allMainStatKeys, allSubstats, MainStatKey } from "../../Types/artifact";
 import { CharacterKey, ElementKey, Region } from "../../Types/consts";
 import { layeredAssignment, objectKeyMap, objectMap } from "../../Util/Util";
@@ -15,6 +15,8 @@ export const absorbableEle = ["hydro", "pyro", "cryo", "electro"] as ElementKey[
 const charCurves = objectMap(_charCurves, value => [0, ...Object.values(value)])
 
 const commonBasic = objectKeyMap([...allSubstats, "heal_"], key => input.total[key])
+// TODO
+//commonBasic.critRate_ = max(min(input.total.critRate_, unit), naught)
 
 const inferredHitEle = stringPrio(
   // Inferred Element

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -21,6 +21,7 @@ const allMisc = [
 const allModStats = [
   ...allArtModStats,
   ...(["all", "burning", ...allTransformative, ...allAmplifying, ...allMoves] as const).map(x => `${x}_dmg_` as const),
+  "bonus_critRate_" as const,
 ]
 const allNonModStats = [
   ...allArtNonModStats,
@@ -155,8 +156,7 @@ const common: Data = {
           operands.push(prod(base[key], sum(unit, premod[`${key}_`])))
           break
         case "critRate_":
-          operands.push(percent(0.05, { key, prefix: "default" }),
-            lookup(hit.move, objectKeyMap(allMoves, move => premod[`${move}_critRate_`]), 0))
+          operands.push(percent(0.05, { key, prefix: "default" }))
           break
         case "critDMG_":
           operands.push(percent(0.5, { key, prefix: "default" }),
@@ -166,6 +166,8 @@ const common: Data = {
         case "enerRech_":
           operands.push(percent(1, { key, prefix: "default" }))
           break
+        case "bonus_critRate_":
+          operands.push(lookup(hit.move, objectKeyMap(allMoves, move => premod[`${move}_critRate_`]), 0))
       }
       return sum(...[...operands, art[key], customBonus[key]].filter(x => x))
     }),
@@ -177,7 +179,7 @@ const common: Data = {
     ...objectKeyValueMap(allTalents, talent => [`${talent}Index`, sum(total[talent], -1)]),
     stamina: sum(constant(100, { key: "stamina", prefix: "default" }), customBonus.stamina),
 
-    cappedCritRate: max(min(total.critRate_, unit), naught),
+    cappedCritRate: max(min(sum(total.critRate_, total.bonus_critRate_), unit), naught),
   },
 
   hit: {

--- a/src/KeyMap.tsx
+++ b/src/KeyMap.tsx
@@ -32,6 +32,8 @@ const statMap = {
 
   heal_multi: "Heal multiplier",
 
+  bonus_critRate_: "Bonus Crit Rate",
+
   // Reaction
   transformative_level_multi: "Reaction Level Multiplier",
   amplificative_dmg_: "Amplificative Reaction DMG Bonus",


### PR DESCRIPTION
Moved the CR buffs that only affect the hit (and not the character's actual stats) to a new key `bonus_critRate_` (working name, feel free to change it)
This resolves an issue with Rosaria A4 and Blizzard Strayer 4-set (https://discord.com/channels/785153694478893126/940483674166665227/952492617256542218)
Also means the stats page will be more accurate to what is actually shown in-game

One thing to note is I had to remove the `cappedCritRate_` node from the character card display, because I can't assign a `NumNode` directly. So negative values, or values over 100% can show in the character card now. I guess we could add another key in `total` for `cappedNonBonusCritRate_` or similar, but it felt kind of silly.

Add missing icons for crit rate and crit damage modifiers

Before:
![image](https://user-images.githubusercontent.com/36019388/159102938-98179b77-7b53-416f-9555-792c626ae45e.png)

After (I marked the 2 fields that were changed, and also you can see damage is unchanged):
![image](https://user-images.githubusercontent.com/36019388/159102920-042fcda5-71ae-4e26-927e-667a14e4d4e2.png)

