### PR TITLE
Fix scanner decimal % display error

### DIFF
--- a/src/PageArtifact/ScanningUtil.tsx
+++ b/src/PageArtifact/ScanningUtil.tsx
@@ -3,7 +3,7 @@ import { createScheduler, createWorker, RecognizeResult, Scheduler } from 'tesse
 import ColorText from '../Components/ColoredText';
 import Artifact from '../Data/Artifacts/Artifact';
 import { ArtifactSheet } from '../Data/Artifacts/ArtifactSheet';
-import KeyMap, { valueString } from '../KeyMap';
+import KeyMap, { cacheValueString, valueString } from '../KeyMap';
 import { allMainStatKeys, allSubstats, IArtifact, ICachedArtifact, ISubstat, MainStatKey, SubstatKey } from '../Types/artifact';
 import { allArtifactRarities, allArtifactSets, allSlotKeys, ArtifactRarity, ArtifactSetKey, Rarity, SlotKey } from '../Types/consts';
 import { clamp, hammingDistance, objectKeyMap } from '../Util/Util';
@@ -259,21 +259,21 @@ export function findBestArtifact(sheets: StrictDict<ArtifactSetKey, ArtifactShee
   addText("slotKey", slotKeys, "Slot", (value) => <>{Artifact.slotName(value)}</>)
   addText("mainStatKey", mainStatKeys, "Main Stat", (value) => <>{KeyMap.getStr(value)}</>)
   texts.substats = <>{result.substats.filter(substat => substat.key !== "").map((substat, i) =>
-    <div key={i}>{detectedText(substat, "Sub Stat", (value) => <>{KeyMap.getStr(value.key)}+{valueString(value.value, KeyMap.unit(value.key))}</>)}</div>)
+    <div key={i}>{detectedText(substat, "Sub Stat", (value) => <>{KeyMap.getStr(value.key)}+{cacheValueString(value.value, KeyMap.unit(value.key))}</>)}</div>)
   }</>
 
   const unit = KeyMap.unit(result.mainStatKey)
   if (mainStatValues.find(value => value.mainStatValue === resultMainStatVal)) {
     if (mainStatKeys.has(result.mainStatKey)) {
       texts.level = detectedText(result.level, "Level", (value) => "+" + value)
-      texts.mainStatVal = detectedText(resultMainStatVal, "Main Stat value", (value) => <>{valueString(value, unit)}</>)
+      texts.mainStatVal = detectedText(resultMainStatVal, "Main Stat value", (value) => <>{cacheValueString(value, unit)}</>)
     } else {
       texts.level = inferredText(result.level, "Level", (value) => "+" + value)
-      texts.mainStatVal = inferredText(resultMainStatVal, "Main Stat value", (value) => <>{valueString(value, unit)}</>)
+      texts.mainStatVal = inferredText(resultMainStatVal, "Main Stat value", (value) => <>{cacheValueString(value, unit)}</>)
     }
   } else {
     texts.level = unknownText(result.level, "Level", (value) => "+" + value)
-    texts.mainStatVal = unknownText(resultMainStatVal, "Main Stat value", (value) => <>{valueString(value, unit)}</>)
+    texts.mainStatVal = unknownText(resultMainStatVal, "Main Stat value", (value) => <>{cacheValueString(value, unit)}</>)
   }
 
   return [result, texts]


### PR DESCRIPTION
Scanned substats were getting multiplied by 100, changed to use `cacheValueString`

This causes the stats to not have the "%" appended to them, when needed, but at least the number is accurate now?
See https://discord.com/channels/785153694478893126/943850131864838144/955174896042930238

Before:
![image](https://user-images.githubusercontent.com/36019388/159177880-174c627a-462d-4c9a-a9bf-21096e4cf8b5.png)

After:
![image](https://user-images.githubusercontent.com/36019388/159177867-7cc19607-c8d3-4bb8-b5d3-73c93d5124d0.png)

Can unpin [this](https://discord.com/channels/785153694478893126/943850131864838144/954969524300550174) when merged