### PR TITLE
Active character conditional fix

### DIFF
--- a/public/locales/en/char_Ganyu.json
+++ b/public/locales/en/char_Ganyu.json
@@ -7,7 +7,6 @@
     "condName": "Opponent takes DMG from a Charge Level 2 Frostflake Arrow or Frostflake Arrow Bloom"
   },
   "c4": {
-    "condName": "Opponents standing within the AoE of Celestial Shower",
     "lingerDuration": "Effect Linger Duration"
   }
 }

--- a/public/locales/en/char_Ganyu.json
+++ b/public/locales/en/char_Ganyu.json
@@ -1,16 +1,10 @@
 {
   "a1": {
     "condName": "After firing a Frostflake Arrow",
-    "critRateInc": "Frostflake CRIT Rate"
-  },
-  "a4": {
-    "condName": "Active party members within AoE of Celestial Shower"
+    "critRateInc": "Frostflake CRIT Rate Increase"
   },
   "c1": {
     "condName": "Opponent takes DMG from a Charge Level 2 Frostflake Arrow or Frostflake Arrow Bloom"
-  },
-  "c2": {
-    "charges": "Charges"
   },
   "c4": {
     "condName": "Opponents standing within the AoE of Celestial Shower",

--- a/public/locales/en/char_Jean.json
+++ b/public/locales/en/char_Jean.json
@@ -1,6 +1,5 @@
 {
-  "c1CondName": "Skill DMG (Hold > 1s)",
-  "c2CondName": "Jean picks up an Elemental Orb/Particle",
-  "c4CondName": "Opponents are within the field created by Dandelion Breeze",
-  "c6CondName": "Active Character is within the field created by Dandelion Breeze"
+  "c1CondName": "Skill held for more than 1s",
+  "c1PullSpeed": "Pulling speed increased",
+  "c2CondName": "Jean picks up an Elemental Orb/Particle"
 }

--- a/public/locales/en/char_KaedeharaKazuha.json
+++ b/public/locales/en/char_KaedeharaKazuha.json
@@ -7,7 +7,6 @@
   },
   "c1": "Using <strong>Kazuha Slash</strong> resets CD",
   "c2": "Autumn Whirlwind field active",
-  "c2p": "Active character in Autumn Whirlwind field",
   "c6": {
     "after": "After using <strong>Chihayaburu</strong> or <strong>Kazuha Slash</strong>",
     "bonus": "Normal, Charged and Plunging DMG Bonus"

--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -52,7 +52,8 @@
   "absorDot": "Absorption DoT",
   "incInterRes": "Increase resistance to interruption",
   "charges": "Charges",
-  "activeCharField": "Active Character in field",
+  "activeCharField": "Active character in field",
+  "opponentsField": "Opponents in field",
   "takeDmg": "On taking DMG",
   "onHit": "On Hit",
   "infusion": {

--- a/src/Data/Characters/Albedo/index.tsx
+++ b/src/Data/Characters/Albedo/index.tsx
@@ -100,22 +100,20 @@ const c2_burst_dmgInc = greaterEq(input.constellation, 2,
 )
 
 const [condSkillInFieldPath, condSkillInField] = cond(key, "skillInField")
-const c4_plunging_dmg_ = greaterEq(input.constellation, 4,
-  equal(condSkillInField, "skillInField",
-    equal(input.activeCharKey, target.charKey, datamine.constellation4.plunging_dmg_)
-  )
+const c4_plunging_dmg_disp = greaterEq(input.constellation, 4,
+  equal(condSkillInField, "skillInField", datamine.constellation4.plunging_dmg_)
 )
+const c4_plunging_dmg_ = equal(input.activeCharKey, target.charKey, c4_plunging_dmg_disp)
 
 // Maybe we should just have a single conditional for "in field AND crystallize shield"?
 // This is technically a nested conditional
 const [condC6CrystallizePath, condC6Crystallize] = cond(key, "c6Crystallize")
-const c6_Crystal_all_dmg_ = greaterEq(input.constellation, 6,
+const c6_Crystal_all_dmg_disp = greaterEq(input.constellation, 6,
   equal(condSkillInField, "skillInField",
-    equal(condC6Crystallize, "c6Crystallize",
-      equal(input.activeCharKey, target.charKey, datamine.constellation6.bonus_dmg_)
-    )
+    equal(condC6Crystallize, "c6Crystallize", datamine.constellation6.bonus_dmg_)
   )
 )
+const c6_Crystal_all_dmg_ = equal(input.activeCharKey, target.charKey, c6_Crystal_all_dmg_disp)
 
 const dmgFormulas = {
   normal: Object.fromEntries(datamine.normal.hitArr.map((arr, i) =>
@@ -245,7 +243,7 @@ const sheet: ICharacterSheet = {
           states: {
             skillInField: {
               fields: [{
-                node: c4_plunging_dmg_
+                node: infoMut(c4_plunging_dmg_disp, { key: "plunging_dmg_" })
               }]
             }
           }
@@ -259,7 +257,7 @@ const sheet: ICharacterSheet = {
           states: {
             c6Crystallize: {
               fields: [{
-                node: c6_Crystal_all_dmg_,
+                node: infoMut(c6_Crystal_all_dmg_disp, { key: "all_dmg_"}),
               }]
             }
           }

--- a/src/Data/Characters/Albedo/index.tsx
+++ b/src/Data/Characters/Albedo/index.tsx
@@ -177,26 +177,24 @@ const sheet: ICharacterSheet = {
         text: tr("auto.fields.normal")
       }, {
         ...sectionTemplate("auto", tr, auto, [{
-            node: infoMut(dmgFormulas.charged.dmg1, { key: `char_${key}_gen:auto.skillParams.5` }),
-            textSuffix: "(1)"
-          }, {
-            node: infoMut(dmgFormulas.charged.dmg2, { key: `char_${key}_gen:auto.skillParams.5` }),
-            textSuffix: "(2)"
-          }, {
-            text: tr("auto.skillParams.6"),
-            value: datamine.charged.stamina,
-          }]
-        ),
+          node: infoMut(dmgFormulas.charged.dmg1, { key: `char_${key}_gen:auto.skillParams.5` }),
+          textSuffix: "(1)"
+        }, {
+          node: infoMut(dmgFormulas.charged.dmg2, { key: `char_${key}_gen:auto.skillParams.5` }),
+          textSuffix: "(2)"
+        }, {
+          text: tr("auto.skillParams.6"),
+          value: datamine.charged.stamina,
+        }]),
         text: tr("auto.fields.charged"),
       }, {
         ...sectionTemplate("auto", tr, auto, [{
-            node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
-          }]
-        ),
+          node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
+        }]),
         text: tr("auto.fields.plunging"),
       }]),
       skill: talentTemplate("skill", tr, skill, [{

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -84,7 +84,8 @@ const atkIncRatio = sum(subscript(input.total.burstIndex, datamine.burst.atkBonu
 const [condInAreaPath, condInArea] = cond(key, "activeInArea")
 const activeInArea = equal("activeInArea", condInArea, equal(input.activeCharKey, target.charKey, 1))
 const c1AddlAtk = greaterEq(input.constellation, 1, prod(c1Atk, input.base.atk))
-const activeInAreaAtk = equal(activeInArea, 1, prod(atkIncRatio, input.base.atk))
+const activeInAreaAtkDisp = prod(atkIncRatio, input.base.atk)
+const activeInAreaAtk = equal(activeInArea, 1, activeInAreaAtkDisp)
 
 const activeInAreaA4 = greaterEq(input.asc, 4,
   equal(activeInArea, 1, datamine.passive2.cd_red)
@@ -93,10 +94,9 @@ const activeInAreaA4 = greaterEq(input.asc, 4,
 const c6AndCorrectWep = greaterEq(input.constellation, 6,
   lookup(target.weaponType,
     { "sword": constant(1), "claymore": constant(1), "polearm": constant(1) }, constant(0)))
-const activeInAreaC6PyroDmg = equal(activeInArea, 1,
-  equal(c6AndCorrectWep, 1, datamine.constellation6.pyro_dmg))
-const activeInAreaC6Infusion = equalStr(activeInArea, 1,
-  equalStr(c6AndCorrectWep, 1, elementKey))
+const activeInAreaC6PyroDmgDisp = equal(c6AndCorrectWep, 1, datamine.constellation6.pyro_dmg)
+const activeInAreaC6PyroDmg = equal(activeInArea, 1, activeInAreaC6PyroDmgDisp)
+const activeInAreaC6Infusion = equalStr(c6AndCorrectWep, 1, elementKey)
 
 const [condUnderHPPath, condUnderHP] = cond(key, "underHP")
 const underHP = greaterEq(input.constellation, 2,
@@ -255,7 +255,7 @@ const sheet: ICharacterSheet = {
                   value: data => data.get(atkIncRatio).value * 100,
                   unit: "%",
                 }, {
-                  node: infoMut(activeInAreaAtk, { key: `sheet:increase.atk` })
+                  node: infoMut(activeInAreaAtkDisp, { key: `sheet:increase.atk` })
                 }]
               }
             }
@@ -289,7 +289,7 @@ const sheet: ICharacterSheet = {
             states: {
               activeInArea: {
                 fields: [{
-                  node: activeInAreaC6PyroDmg
+                  node: infoMut(activeInAreaC6PyroDmgDisp, { key: "pyro_dmg_", variant: "pyro" })
                 }, {
                   text: <ColorText color={elementKey}>{st("infusion.pyro")}</ColorText>
                 }]

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -5,13 +5,14 @@ import { UIData } from '../../../Formula/uiData'
 import { constant, equal, equalStr, greaterEq, infoMut, lookup, prod, subscript, sum } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
-import CharacterSheet, { conditionalHeader, ICharacterSheet, normalSrc, talentTemplate } from '../CharacterSheet'
+import CharacterSheet, { conditionalHeader, ICharacterSheet, normalSrc, sectionTemplate, talentTemplate } from '../CharacterSheet'
 import { dataObjForCharacterSheet, dmgNode, healNodeTalent } from '../dataUtil'
 import { banner, burst, c1, c2, c3, c4, c5, c6, card, passive1, passive2, passive3, skill, thumb, thumbSide } from './assets'
 import data_gen_src from './data_gen.json'
 import skillParam_gen from './skillParam_gen.json'
 
 const data_gen = data_gen_src as CharacterData
+const auto = normalSrc(data_gen.weaponTypeKey)
 
 const key: CharacterKey = "Bennett"
 const elementKey: ElementKey = "pyro"
@@ -164,34 +165,33 @@ const sheet: ICharacterSheet = {
   title: tr("title"),
   talent: {
     sheets: {
-      auto: {
-        name: tr("auto.name"),
-        img: normalSrc(data_gen.weaponTypeKey),
-        sections: [{
-          text: tr("auto.fields.normal"),
-          fields: datamine.normal.hitArr.map((percentArr, i) =>
+      auto: talentTemplate("auto", tr, auto, undefined, undefined, [{
+        ...sectionTemplate("auto", tr, auto, 
+          datamine.normal.hitArr.map((percentArr, i) =>
           ({
             node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
           }))
-        }, {
-          text: tr("auto.fields.charged"),
-          fields: [{
+        ),
+          text: tr("auto.fields.normal"),
+      }, {
+        ...sectionTemplate("auto", tr, auto, [{
             node: infoMut(dmgFormulas.charged.dmg1, { key: `char_${key}_gen:auto.skillParams.5` }),
           }, {
             text: tr("auto.skillParams.6"),
             value: datamine.charged.stamina,
           }]
+        ),
+        text: tr("auto.fields.charged"),
+      }, {
+        ...sectionTemplate("auto", tr, auto, [{
+          node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
         }, {
-          text: tr("auto.fields.plunging"),
-          fields: [{
-            node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
-          }]
-        }],
-      },
+          node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
+        }]),
+        text: tr("auto.fields.plunging"),
+      }]),
       skill: talentTemplate("skill", tr, skill, [{
         // Press
         node: infoMut(dmgFormulas.skill.press, { key: `char_${key}:skill.pressDMG` }),
@@ -220,84 +220,74 @@ const sheet: ICharacterSheet = {
         unit: "s",
         value: data => calculateSkillCD(data, datamine.skill.cd_hold2),
       }]),
-      burst: { // Cannot use talentTemplate because this has multiple sections.
-        name: tr("burst.name"),
-        img: burst,
-        sections: [{
-          text: tr("burst.description"),
-          fields: [{
-            node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` })
-          }, {
-            node: infoMut(dmgFormulas.burst.regen, { key: `char_${key}_gen:burst.skillParams.1`, variant: "success" })
-          }, {
-            text: tr("burst.skillParams.3"),
-            value: datamine.burst.duration,
-            unit: "s",
-          }, {
-            text: tr("burst.skillParams.4"),
-            value: datamine.burst.cd,
-            unit: "s",
-          }, {
-            text: tr("burst.skillParams.5"),
-            value: datamine.burst.enerCost,
-          }],
-          conditional: {
-            value: condInArea,
-            path: condInAreaPath,
-            header: conditionalHeader("burst", tr, burst),
-            description: tr("burst.description"),
-            name: st("activeCharField"),
-            teamBuff: true,
-            states: {
-              activeInArea: {
-                fields: [{
-                  text: tr("burst.skillParams.2"),
-                  value: data => data.get(atkIncRatio).value * 100,
-                  unit: "%",
-                }, {
-                  node: infoMut(activeInAreaAtkDisp, { key: `sheet:increase.atk` })
-                }]
-              }
+      burst: talentTemplate("burst", tr, burst, [{
+        node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` })
+      }, {
+        node: infoMut(dmgFormulas.burst.regen, { key: `char_${key}_gen:burst.skillParams.1`, variant: "success" })
+      }, {
+        text: tr("burst.skillParams.3"),
+        value: datamine.burst.duration,
+        unit: "s",
+      }, {
+        text: tr("burst.skillParams.4"),
+        value: datamine.burst.cd,
+        unit: "s",
+      }, {
+        text: tr("burst.skillParams.5"),
+        value: datamine.burst.enerCost,
+      }], {
+        value: condInArea,
+        path: condInAreaPath,
+        header: conditionalHeader("burst", tr, burst),
+        description: tr("burst.description"),
+        name: st("activeCharField"),
+        teamBuff: true,
+        states: {
+          activeInArea: {
+            fields: [{
+              text: tr("burst.skillParams.2"),
+              value: data => data.get(atkIncRatio).value * 100,
+              unit: "%",
+            }, {
+              node: infoMut(activeInAreaAtkDisp, { key: `sheet:increase.atk` })
+            }]
+          }
+        }
+      }, [
+        sectionTemplate("passive2", tr, passive2, undefined, {
+          canShow: greaterEq(input.asc, 4, 4),
+          value: condInArea,
+          path: condInAreaPath,
+          header: conditionalHeader("passive2", tr, passive2),
+          name: st("activeCharField"),
+          states: {
+            activeInArea: {
+              fields: [{ // Node will not show CD reduction, have to use value instead
+                text: st("skillCDRed"),
+                value: datamine.passive2.cd_red,
+                unit: "%",
+              }]
             }
           }
-        }, {
-          conditional: {
-            canShow: greaterEq(input.asc, 4, 4),
-            value: condInArea,
-            path: condInAreaPath,
-            header: conditionalHeader("passive2", tr, passive2),
-            name: st("activeCharField"),
-            states: {
-              activeInArea: {
-                fields: [{ // Node will not show CD reduction, have to use value instead
-                  text: st("skillCDRed"),
-                  value: datamine.passive2.cd_red,
-                  unit: "%",
-                }]
-              }
+        }), sectionTemplate("constellation6", tr, c6, undefined, {
+          canShow: c6AndCorrectWep,
+          value: condInArea,
+          path: condInAreaPath,
+          header: conditionalHeader("constellation6", tr, c6),
+          description: tr("constellation6.description"),
+          name: st("activeCharField"),
+          teamBuff: true,
+          states: {
+            activeInArea: {
+              fields: [{
+                node: infoMut(activeInAreaC6PyroDmgDisp, { key: "pyro_dmg_", variant: "pyro" })
+              }, {
+                text: <ColorText color={elementKey}>{st("infusion.pyro")}</ColorText>
+              }]
             }
           }
-        }, {
-          conditional: {  
-            canShow: c6AndCorrectWep,
-            value: condInArea,
-            path: condInAreaPath,
-            header: conditionalHeader("constellation6", tr, c6),
-            description: tr("constellation6.description"),
-            name: st("activeCharField"),
-            teamBuff: true,
-            states: {
-              activeInArea: {
-                fields: [{
-                  node: infoMut(activeInAreaC6PyroDmgDisp, { key: "pyro_dmg_", variant: "pyro" })
-                }, {
-                  text: <ColorText color={elementKey}>{st("infusion.pyro")}</ColorText>
-                }]
-              }
-            }
-          }
-        }]
-      },
+        }),
+      ]),
       passive1: talentTemplate("passive1", tr, passive1, [{
         canShow: data => data.get(input.asc).value > 1,
         text: st("skillCDRed"),

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -167,7 +167,7 @@ const sheet: ICharacterSheet = {
     sheets: {
       auto: talentTemplate("auto", tr, auto, undefined, undefined, [{
         ...sectionTemplate("auto", tr, auto, 
-          datamine.normal.hitArr.map((percentArr, i) => ({
+          datamine.normal.hitArr.map((_, i) => ({
             node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
           }))
         ),

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -5,7 +5,7 @@ import { UIData } from '../../../Formula/uiData'
 import { constant, equal, equalStr, greaterEq, infoMut, lookup, prod, subscript, sum } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
-import CharacterSheet, { conditionalHeader, ICharacterSheet, normalSrc, sectionTemplate, talentTemplate } from '../CharacterSheet'
+import CharacterSheet, { ICharacterSheet, normalSrc, sectionTemplate, talentTemplate } from '../CharacterSheet'
 import { dataObjForCharacterSheet, dmgNode, healNodeTalent } from '../dataUtil'
 import { banner, burst, c1, c2, c3, c4, c5, c6, card, passive1, passive2, passive3, skill, thumb, thumbSide } from './assets'
 import data_gen_src from './data_gen.json'
@@ -238,8 +238,6 @@ const sheet: ICharacterSheet = {
       }], {
         value: condInArea,
         path: condInAreaPath,
-        header: conditionalHeader("burst", tr, burst),
-        description: tr("burst.description"),
         name: st("activeCharField"),
         teamBuff: true,
         states: {
@@ -258,7 +256,6 @@ const sheet: ICharacterSheet = {
           canShow: greaterEq(input.asc, 4, 4),
           value: condInArea,
           path: condInAreaPath,
-          header: conditionalHeader("passive2", tr, passive2),
           name: st("activeCharField"),
           states: {
             activeInArea: {
@@ -273,8 +270,6 @@ const sheet: ICharacterSheet = {
           canShow: c6AndCorrectWep,
           value: condInArea,
           path: condInAreaPath,
-          header: conditionalHeader("constellation6", tr, c6),
-          description: tr("constellation6.description"),
           name: st("activeCharField"),
           teamBuff: true,
           states: {

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -167,20 +167,18 @@ const sheet: ICharacterSheet = {
     sheets: {
       auto: talentTemplate("auto", tr, auto, undefined, undefined, [{
         ...sectionTemplate("auto", tr, auto, 
-          datamine.normal.hitArr.map((percentArr, i) =>
-          ({
+          datamine.normal.hitArr.map((percentArr, i) => ({
             node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
           }))
         ),
-          text: tr("auto.fields.normal"),
+        text: tr("auto.fields.normal"),
       }, {
         ...sectionTemplate("auto", tr, auto, [{
-            node: infoMut(dmgFormulas.charged.dmg1, { key: `char_${key}_gen:auto.skillParams.5` }),
-          }, {
-            text: tr("auto.skillParams.6"),
-            value: datamine.charged.stamina,
-          }]
-        ),
+          node: infoMut(dmgFormulas.charged.dmg1, { key: `char_${key}_gen:auto.skillParams.5` }),
+        }, {
+          text: tr("auto.skillParams.6"),
+          value: datamine.charged.stamina,
+        }]),
         text: tr("auto.fields.charged"),
       }, {
         ...sectionTemplate("auto", tr, auto, [{

--- a/src/Data/Characters/Ganyu/index.tsx
+++ b/src/Data/Characters/Ganyu/index.tsx
@@ -234,7 +234,7 @@ const sheet: ICharacterSheet = {
           path: condC4Path,
           canShow: greaterEq(input.constellation, 4, 1),
           teamBuff: true,
-          name: trm("c4.condName"),
+          name: st("opponentsField"),
           states: Object.fromEntries(range(1, 5).map(i => [i, {
           name: st("seconds", { count: (i - 1) * 3 }),
             fields: [{ node: all_dmg_ }, { text: trm("c4.lingerDuration"), value: 3, unit: "s" }]

--- a/src/Data/Characters/Jean/index.tsx
+++ b/src/Data/Characters/Jean/index.tsx
@@ -1,5 +1,5 @@
 import { CharacterData } from 'pipeline'
-import { input } from '../../../Formula'
+import { input, target } from '../../../Formula'
 import { equal, greaterEq, infoMut, percent, prod } from '../../../Formula/utils'
 import { CharacterKey, ElementKey, Region } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
@@ -80,7 +80,8 @@ const regen = healNodeTalent("atk", datamine.burst.burstActivationAtkModifier, d
 const contRegen = healNodeTalent("atk", datamine.burst.burstRegenAtkModifier, datamine.burst.burstRegenFlatModifier, "burst")
 const a1Regen = greaterEq(input.asc, 1, customHealNode(prod(percent(datamine.passive1.atkPercentage), input.total.atk)))
 
-const skill_dmg_ = greaterEq(input.constellation, 1, percent(datamine.constellation1.increaseDmg))
+const [condC1Path, condC1] = cond(key, "c1")
+const skill_dmg_ = equal(condC1, "on", greaterEq(input.constellation, 1, datamine.constellation1.increaseDmg))
 
 const [condC2Path, condC2] = cond(key, "c2")
 const atkSPD_ = equal(condC2, "on", greaterEq(input.constellation, 2, percent(datamine.constellation2.atkSpd)))
@@ -90,7 +91,8 @@ const [condC4Path, condC4] = cond(key, "c4")
 const anemo_enemyRes_ = equal(condC4, "on", greaterEq(input.constellation, 4, percent(-Math.abs(datamine.constellation4.anemoRes))))
 
 const [condC6Path, condC6] = cond(key, "c6")
-const dmgRed_ = equal(condC6, "on", greaterEq(input.constellation, 6, percent(datamine.constellation6.dmgReduction)))
+const dmgRed_disp = equal(condC6, "on", greaterEq(input.constellation, 6, percent(datamine.constellation6.dmgReduction)))
+const dmgRed_ = equal(input.activeCharKey, target.charKey, dmgRed_disp)
 
 const dmgFormulas = {
   normal: Object.fromEntries(datamine.normal.hitArr.map((arr, i) =>
@@ -102,7 +104,6 @@ const dmgFormulas = {
     [key, dmgNode("atk", value, "plunging")])),
   skill: {
     dmg: dmgNode("atk", datamine.skill.dmg, "skill"),
-    c1Dmg: dmgNode("atk", datamine.skill.dmg, "skill", { premod: { skill_dmg_ } }),
   },
   burst: {
     dmg: dmgNode("atk", datamine.burst.dmg, "burst"),
@@ -125,6 +126,9 @@ export const data = dataObjForCharacterSheet(key, elementKey, regionKey, data_ge
   bonus: {
     skill: nodeC5,
     burst: nodeC3,
+  },
+  premod: {
+    skill_dmg_
   },
   teamBuff: {
     premod: {
@@ -178,10 +182,6 @@ const sheet: ICharacterSheet = {
       skill: talentTemplate("skill", tr, burst, [{
         node: infoMut(dmgFormulas.skill.dmg, { key: `char_${key}_gen:skill.skillParams.0` }),
       }, {
-        canShow: (data) => data.get(input.constellation).value >= 1,
-        node: infoMut(dmgFormulas.skill.c1Dmg, { key: `char_${key}:c1CondName` }),
-        textSuffix: "(C1)"
-      }, {
         text: tr("skill.skillParams.1"),
         value: `${datamine.skill.stamina}`,
         unit: "/s"
@@ -193,7 +193,23 @@ const sheet: ICharacterSheet = {
         text: tr("skill.skillParams.3"),
         value: `${datamine.skill.cd}`,
         unit: "s"
-      }]),
+      }], undefined, [
+        sectionTemplate("constellation1", tr, c1, undefined, {
+          canShow: greaterEq(input.constellation, 1, 1),
+          value: condC1,
+          path: condC1Path,
+          name: trm("c1CondName"),
+          states: {
+            on: {
+              fields: [{
+                text: trm("c1PullSpeed")
+              }, {
+                node: skill_dmg_
+              }]
+            }
+          }
+        })
+      ]),
       burst: talentTemplate("burst", tr, burst, [{
         node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),
       }, {
@@ -213,7 +229,36 @@ const sheet: ICharacterSheet = {
       }, {
         text: tr("burst.skillParams.5"),
         value: `${datamine.burst.enerCost}`,
-      }]),
+      }], undefined, [
+        sectionTemplate("constellation4", tr, c4, undefined, {
+          canShow: greaterEq(input.constellation, 4, 1),
+          value: condC4,
+          path: condC4Path,
+          teamBuff: true,
+          name: st("opponentsField"),
+          states: {
+            on: {
+              fields: [{
+                node: anemo_enemyRes_
+              }]
+            }
+          }
+        }),
+        sectionTemplate("constellation6", tr, c6, undefined, {
+          canShow: greaterEq(input.constellation, 6, 1),
+          value: condC6,
+          path: condC6Path,
+          teamBuff: true,
+          name: st("activeCharField"),
+          states: {
+            on: {
+              fields: [{
+                node: infoMut(dmgRed_disp, {key: "dmgRed_" })
+              }]
+            }
+          }
+        })
+      ]),
       passive1: talentTemplate("passive1", tr, passive1, [{
         canShow: (data) => data.get(input.asc).value >= 1,
         node: infoMut(dmgFormulas.passive1.a1Regen, { key: `sheet_gen:healing`, variant: "success" }),
@@ -246,35 +291,9 @@ const sheet: ICharacterSheet = {
         }
       }),
       constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
-      constellation4: talentTemplate("constellation4", tr, c4, undefined, {
-        canShow: greaterEq(input.constellation, 4, 1),
-        value: condC4,
-        path: condC4Path,
-        teamBuff: true,
-        name: trm("c4CondName"),
-        states: {
-          on: {
-            fields: [{
-              node: anemo_enemyRes_
-            }]
-          }
-        }
-      }),
+      constellation4: talentTemplate("constellation4", tr, c4),
       constellation5: talentTemplate("constellation5", tr, c5, [{ node: nodeC5 }]),
-      constellation6: talentTemplate("constellation6", tr, c6, undefined, {
-        canShow: greaterEq(input.constellation, 6, 1),
-        value: condC6,
-        path: condC6Path,
-        teamBuff: true,
-        name: trm("c6CondName"),
-        states: {
-          on: {
-            fields: [{
-              node: dmgRed_
-            }]
-          }
-        }
-      }),
+      constellation6: talentTemplate("constellation6", tr, c6),
     },
   },
 }

--- a/src/Data/Characters/Jean/index.tsx
+++ b/src/Data/Characters/Jean/index.tsx
@@ -3,13 +3,14 @@ import { input } from '../../../Formula'
 import { equal, greaterEq, infoMut, percent, prod } from '../../../Formula/utils'
 import { CharacterKey, ElementKey, Region } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
-import CharacterSheet, { ICharacterSheet, normalSrc, talentTemplate } from '../CharacterSheet'
+import CharacterSheet, { ICharacterSheet, normalSrc, sectionTemplate, talentTemplate } from '../CharacterSheet'
 import { customHealNode, dataObjForCharacterSheet, dmgNode, healNodeTalent } from '../dataUtil'
 import { banner, burst, c1, c2, c3, c4, c5, c6, card, passive1, passive2, passive3, thumb, thumbSide } from './assets'
 import data_gen_src from './data_gen.json'
 import skillParam_gen from './skillParam_gen.json'
 
 const data_gen = data_gen_src as CharacterData
+const auto = normalSrc(data_gen.weaponTypeKey)
 
 const key: CharacterKey = "Jean"
 const elementKey: ElementKey = "anemo"
@@ -149,36 +150,31 @@ const sheet: ICharacterSheet = {
   title: tr("title"),
   talent: {
     sheets: {
-      auto: {
-        name: tr("auto.name"),
-        img: normalSrc(data_gen.weaponTypeKey),
-        sections: [
-          {
-            text: tr("auto.fields.normal"),
-            fields: datamine.normal.hitArr.map((_, i) =>
-            ({
-              node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
-            }))
-          }, {
-            text: tr("auto.fields.charged"),
-            fields: [{
-              node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.5` }),
-            }, {
-              text: tr("auto.skillParams.6"),
-              value: datamine.charged.stamina,
-            }]
-          }, {
-            text: tr("auto.fields.plunging"),
-            fields: [{
-              node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
-            }, {
-              node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
-            }, {
-              node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
-            }]
-          }
-        ],
-      },
+      auto: talentTemplate("auto", tr, auto, undefined, undefined, [{
+        ...sectionTemplate("auto", tr, auto,
+          datamine.normal.hitArr.map((_, i) => ({
+            node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
+          }))
+        ),
+        text: tr("auto.fields.normal"),
+      }, {
+        ...sectionTemplate("auto", tr, auto, [{
+          node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.5` }),
+        }, {
+          text: tr("auto.skillParams.6"),
+          value: datamine.charged.stamina,
+        }]),
+        text: tr("auto.fields.charged"),
+      }, {
+        ...sectionTemplate("auto", tr, auto, [{
+          node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
+        }]),
+        text: tr("auto.fields.plunging"),
+      }]),
       skill: talentTemplate("skill", tr, burst, [{
         node: infoMut(dmgFormulas.skill.dmg, { key: `char_${key}_gen:skill.skillParams.0` }),
       }, {
@@ -218,19 +214,15 @@ const sheet: ICharacterSheet = {
         text: tr("burst.skillParams.5"),
         value: `${datamine.burst.enerCost}`,
       }]),
-      passive1: talentTemplate("passive1", tr, passive1, [
-        {
-          canShow: (data) => data.get(input.asc).value >= 1,
-          node: infoMut(dmgFormulas.passive1.a1Regen, { key: `sheet_gen:healing`, variant: "success" }),
-        }
-      ]),
-      passive2: talentTemplate("passive2", tr, passive2, [
-        {
-          canShow: (data) => data.get(input.asc).value >= 4,
-          text: st("energyRegen"),
-          value: datamine.passive2.energyRegen
-        }
-      ]),
+      passive1: talentTemplate("passive1", tr, passive1, [{
+        canShow: (data) => data.get(input.asc).value >= 1,
+        node: infoMut(dmgFormulas.passive1.a1Regen, { key: `sheet_gen:healing`, variant: "success" }),
+      }]),
+      passive2: talentTemplate("passive2", tr, passive2, [{
+        canShow: (data) => data.get(input.asc).value >= 4,
+        text: st("energyRegen"),
+        value: datamine.passive2.energyRegen
+      }]),
       passive3: talentTemplate("passive3", tr, passive3),
       constellation1: talentTemplate("constellation1", tr, c1),
       constellation2: talentTemplate("constellation2", tr, c2, undefined, {
@@ -285,5 +277,5 @@ const sheet: ICharacterSheet = {
       }),
     },
   },
-};
-export default new CharacterSheet(sheet, data);
+}
+export default new CharacterSheet(sheet, data)

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -86,12 +86,11 @@ const c2EleMas = greaterEq(input.constellation, 2,
   equal("c2", condC2, datamine.constellation2.elemas))
 
 const [condC2PPath, condC2P] = cond(key, "c2p")
-const c2PEleMas = greaterEq(input.constellation, 2,
-  equal("c2p", condC2P,
-    equal(input.activeCharKey, target.charKey, // Apply to active character
-      unequal(target.charKey, key, datamine.constellation2.elemas) // But not to Kazuha
-    )
-  )
+const c2PEleMasDisp = greaterEq(input.constellation, 2,
+  equal("c2p", condC2P, datamine.constellation2.elemas)
+)
+const c2PEleMas = equal(input.activeCharKey, target.charKey, // Apply to active character
+  unequal(target.charKey, key, c2PEleMasDisp) // But not to Kazuha
 )
 
 const [condC6Path, condC6] = cond(key, "c6")
@@ -289,12 +288,12 @@ const sheet: ICharacterSheet = {
           path: condC2PPath,
           teamBuff: true,
           description: tr("constellation2.description"),
-          name: trm("c2p"),
+          name: st("activeCharField"),
           header: conditionalHeader("constellation2", tr, c2),
           states: {
             c2p: {
               fields: [{
-                node: c2PEleMas
+                node: infoMut(c2PEleMasDisp, { key: "eleMas" })
               }]
             }
           }


### PR DESCRIPTION
Fix all* active character conditional issues. In this case, the nodes were not showing in the team buff panel due to the `input.activeCharKey` and `target.charKey` logic. So I added a new display node for those conditionals.

Fix Ganyu and Jean buffs applying to the whole team

Refactor Sara, Ganyu, and Bennett to use only `sectionTemplate` and `talentTemplate`

Also standardized some of the strings

(*) I think it's all, let's hope so