### PR TITLE
Fix Yae charged stamina display, duct tape Diona

### DIFF
--- a/public/locales/en/char_Diona.json
+++ b/public/locales/en/char_Diona.json
@@ -2,7 +2,7 @@
   "skillDuration" : "Duration per Paw",
   "pressShield" : "Shield DMG Absorption",
   "holdShield" : "Hold Shield DMG Absorption",
-  "a1shielded" : "Character Shielded",
-  "c6below" : "Characters within radius below or equal to 50% HP",
-  "c6above" : "Characters within radius above 50% HP"
+  "a1shielded" : "Character shielded by <strong>Icy Paws</strong>",
+  "c6below" : "Active character within radius below or equal to 50% HP",
+  "c6above" : "Active character within radius above 50% HP"
 }

--- a/src/Data/Characters/Diona/index.tsx
+++ b/src/Data/Characters/Diona/index.tsx
@@ -1,5 +1,5 @@
 import { CharacterData } from 'pipeline'
-import { input } from '../../../Formula'
+import { input, target } from '../../../Formula'
 import { constant, equal, greaterEq, infoMut, percent, prod, sum } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, trans } from '../../SheetUtil'
@@ -116,8 +116,10 @@ const dmgFormulas = {
 const nodeA1MoveSpeed = equal(condA1, "on", percent(datamine.passive1.moveSpeed_),)
 const nodeA1Stamina = equal(condA1, "on", percent(datamine.passive1.stamRed_),)
 
-const nodeC6healing_ = equal(condC6Below, "on", percent(datamine.constellation6.healingBonus_),)
-const nodeC6em = equal(condC6Above, "on", datamine.constellation6.emBonus,)
+const nodeC6healing_Disp = equal(condC6Below, "on", percent(datamine.constellation6.healingBonus_),)
+const nodeC6healing_ = equal(input.activeCharKey, target.charKey, nodeC6healing_Disp)
+const nodeC6emDisp = equal(condC6Above, "on", datamine.constellation6.emBonus,)
+const nodeC6em = equal(input.activeCharKey, target.charKey, nodeC6emDisp)
 
 export const data = dataObjForCharacterSheet(key, elementKey, "mondstadt", data_gen, dmgFormulas, {
   bonus: {
@@ -250,7 +252,7 @@ const sheet: ICharacterSheet = {
         states: {
           on: {
             fields: [{
-              node: nodeC6healing_,
+              node: infoMut(nodeC6healing_Disp, { key: "heal_" }),
             }]
           }
         }
@@ -265,7 +267,7 @@ const sheet: ICharacterSheet = {
           states: {
             on: {
               fields: [{
-                node: nodeC6em,
+                node: infoMut(nodeC6emDisp, { key: "eleMas" }),
               }]
             }
           }

--- a/src/Data/Characters/YaeMiko/index.tsx
+++ b/src/Data/Characters/YaeMiko/index.tsx
@@ -130,7 +130,7 @@ const sheet: ICharacterSheet = {
           fields: [{
             node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.3` }),
           }, {
-            text: tr("auto.skillParams.6"),
+            text: tr("auto.skillParams.4"),
             value: datamine.charged.stamina,
           }]
         }, {


### PR DESCRIPTION
Fix Yae charged stamina display (was using wrong string)
Make Diona burst+C6 only apply to active character. Technically her shield should also only apply to active character, but I just limited it to her C6 to minimize the amount of jank we would have to undo later.
This one matters since it applies EM, and Kazuha A4 applies a team-wide buff that scales off EM