### PR TITLE
Fix small things

### DIFF
--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -23,6 +23,7 @@
   "uses_other": "{{count}} Uses",
   "afterDefeatEnemy": "After defeating an opponent",
   "hitOp": {
+    "none": "Hits on opponents",
     "normal": "Normal Attack hits on opponents",
     "charged": "Charged Attack hits on opponents",
     "normalOrCharged": "Normal / Charged Attack hits on opponents",

--- a/public/locales/en/weapon_LostPrayerToTheSacredWinds.json
+++ b/public/locales/en/weapon_LostPrayerToTheSacredWinds.json
@@ -1,3 +1,0 @@
-{
-  "condName": "Duration on Field (4s / stack)"
-}

--- a/public/locales/en/weapon_PrimordialJadeWingedSpear.json
+++ b/public/locales/en/weapon_PrimordialJadeWingedSpear.json
@@ -1,3 +1,0 @@
-{
-  "condName": "On Hit"
-}

--- a/public/locales/en/weapon_SerpentSpine.json
+++ b/public/locales/en/weapon_SerpentSpine.json
@@ -1,4 +1,3 @@
 {
-  "condName": "Duration on Field (4s / stack)",
   "takeMoreDmg": "Take more DMG"
 }

--- a/src/Data/Artifacts/ArchaicPetra/index.tsx
+++ b/src/Data/Artifacts/ArchaicPetra/index.tsx
@@ -10,7 +10,7 @@ import icons from './icons'
 const key: ArtifactSetKey = "ArchaicPetra"
 const [tr, trm] = trans("artifact", key)
 
-const set2 = greaterEq(input.artSet.ArchaicPetra, 2, percent(0.2))
+const set2 = greaterEq(input.artSet.ArchaicPetra, 2, percent(0.15))
 const [condPath, condNode] = cond(key, "element")
 const set4Nodes = Object.fromEntries(absorbableEle.map(e => [`${e}_dmg_`,
 greaterEq(input.artSet.ArchaicPetra, 4,

--- a/src/Data/Weapons/Catalyst/LostPrayerToTheSacredWinds/index.tsx
+++ b/src/Data/Weapons/Catalyst/LostPrayerToTheSacredWinds/index.tsx
@@ -11,9 +11,9 @@ import data_gen_json from './data_gen.json'
 import icon from './Icon.png'
 
 const key: WeaponKey = "LostPrayerToTheSacredWinds"
-const [tr, trm] = trans("weapon", key)
+const [tr] = trans("weapon", key)
 const data_gen = data_gen_json as WeaponData
-const ele_dmg_s = [0.12, 0.15, 0.18, 0.21, 0.24]
+const ele_dmg_s = [0.8, 0.10, 0.12, 0.14, 0.16]
 
 const [condPassivePath, condPassive] = cond(key, "BoundlessBlessing")
 
@@ -40,9 +40,9 @@ const sheet: IWeaponSheet = {
       path: condPassivePath,
       header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
-      name: trm("condName"),
+      name: st("activeCharField"),
       states: objectKeyMap(range(1, 4), i => ({
-        name: st("stack", { count: i }),
+        name: st("seconds", { count: i * 4 }),
         fields: allElements.map(ele => ({ node: eleDmgStacks[ele] }))
       }))
     }

--- a/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
+++ b/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
@@ -3,7 +3,7 @@ import { input } from '../../../../Formula'
 import { constant, equal, infoMut, prod, subscript } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { customDmgNode } from '../../../Characters/dataUtil'
-import { cond, st, trans } from '../../../SheetUtil'
+import { cond, sgt, st, trans } from '../../../SheetUtil'
 import { dataObjForWeaponSheet } from '../../util'
 import WeaponSheet, { conditionaldesc, conditionalHeader, IWeaponSheet } from '../../WeaponSheet'
 import iconAwaken from './AwakenIcon.png'
@@ -31,6 +31,7 @@ const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
+    fieldsHeader: conditionalHeader(tr, icon, iconAwaken, st("base")),
     fields: [{ node: burst_dmg_ }],
     conditional: {
       value: condPassive,
@@ -42,6 +43,10 @@ const sheet: IWeaponSheet = {
         on: {
           fields: [{
             node: infoMut(dmg_, { key: "sheet:dmg" })
+          }, {
+            text: sgt("cd"),
+            value: 15,
+            unit: "s"
           }]
         }
       }

--- a/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
+++ b/src/Data/Weapons/Claymore/SerpentSpine/index.tsx
@@ -38,10 +38,10 @@ const sheet: IWeaponSheet = {
       path: condPassivePath,
       header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
       description: conditionaldesc(tr),
-      name: trm("condName"),
+      name: st("activeCharField"),
       states: {
         ...objectKeyMap(range(1, 5), i => ({
-          name: st("stack", { count: i }),
+          name: st("seconds", { count: i * 4 }),
           fields: [{
             node: all_dmg_stack
           }, {

--- a/src/Data/Weapons/Polearm/PrimordialJadeWingedSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/PrimordialJadeWingedSpear/index.tsx
@@ -13,7 +13,7 @@ import icon from './Icon.png'
 const key: WeaponKey = "PrimordialJadeWingedSpear"
 const data_gen = data_gen_json as WeaponData
 
-const [tr, trm] = trans("weapon", key)
+const [tr] = trans("weapon", key)
 
 const [condStackPath, condStack] = cond(key, "stack")
 const atkInc = [0.032, 0.039, 0.046, 0.053, 0.06]
@@ -34,9 +34,9 @@ const sheet: IWeaponSheet = {
       value: condStack,
       path: condStackPath,
       header: conditionalHeader(tr, icon, iconAwaken, st("stacks")),
-      name: trm("condName"),
+      name: st("hitOp.none"),
       states: Object.fromEntries(range(1, 7).map(i => [i, {
-        name: st("stack", { count: i }),
+        name: st("hits", { count: i }),
         fields: [{ node: atk_ }, { node: all_dmg_ }]
       }]))
     }


### PR DESCRIPTION
Fix Lost Prayer passive value. Change the text to be in "seconds", rather than "stacks".
Adjust Serpent Spine passive text to be in "seconds", rather than "stacks". I guess this one is a bit inaccurate, but it is a bit easier to read. So I could be convinced to undo this one.
Fix Archaic Petra 2-set value
Add header and cooldown field for Luxurious Sea Lord passives
Adjust PJWS passive text to use generic string

Before
![image](https://user-images.githubusercontent.com/36019388/160260741-a08d3c7f-f305-4a14-b696-ee498c1072b2.png)

After (the text bold changing is from FieldDisplay changes)
![image](https://user-images.githubusercontent.com/36019388/160260729-45dfbe8b-98e3-47f7-9240-ffc7b19a114a.png)
