### PR TITLE
Fix Bennett C6, standardize sheet

### DIFF
--- a/public/locales/en/char_Bennett.json
+++ b/public/locales/en/char_Bennett.json
@@ -9,9 +9,8 @@
         "lvl1CD": "Lvl 1 CD",
         "lvl2CD": "Lvl 2 CD"
     },
-    "withinArea": "Within area of Fantastic Voyage",
     "additionalATK": "Additional ATK Increase",
     "additionalATKRatio_": "Additional ATK Bonus Ratio",
     "c4DMG": "Unexpected Odyssey DMG",
-    "swClPoChar": "Sword Claymore, or Polearm-wielding character"
+    "c6PyroInfusion": "<pyro>Sword, Claymore and Polearm Pyro Infusion"
 }


### PR DESCRIPTION
Fix Bennett C6 so it applies Pyro DMG bonus to all characters, not just sword/polearm/claymore characters
Update some strings
Move constellation fields to either the skill or burst, as appropriate
Make Bennett's A4 and C6 appear based on the burst conditional, rather than having their own conditional
Add Bennett charged attack 2