### PR TITLE
Fix small things again

### DIFF
--- a/public/locales/en/char_AratakiItto.json
+++ b/public/locales/en/char_AratakiItto.json
@@ -5,6 +5,10 @@
   "a4": {
     "dmgInc": "Arataki Kesagiri DMG increase"
   },
+  "c1": {
+    "initialGain": "Stacks of Superlative Superstrength gained",
+    "timedGain": "After 1s, stacks of Superlative Superstrength gained every 0.5s for 1.5s"
+  },
   "c4": {
     "name": "When the Raging Oni King state caused by <strong>Royal Descent: Behold, Itto the Evil!</strong> ends"
   }

--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -48,6 +48,7 @@
     "atk": "ATK Increase"
   },
   "skillCDRed": "Ele. Skill CD Reduction",
+  "burstCDRed": "Ele. Burst CD Reduction",
   "pressCD": "Press CD",
   "holdCD": "Hold CD",
   "triggerCD": "Trigger CD",

--- a/src/Data/Characters/AratakiItto/index.tsx
+++ b/src/Data/Characters/AratakiItto/index.tsx
@@ -91,8 +91,8 @@ const dmgFormulas = {
     [i, dmgNode("atk", arr, "normal")])),
   charged: {
     sSlash: dmgNode("atk", datamine.charged.sSlash, "charged"),
-    akSlash: dmgNode("atk", datamine.charged.akSlash, "charged", { total: { charged_dmgInc: nodeA4Bonus } }),
-    akFinal: dmgNode("atk", datamine.charged.akFinal, "charged", { total: { charged_dmgInc: nodeA4Bonus } }),
+    akSlash: dmgNode("atk", datamine.charged.akSlash, "charged", { premod: { charged_dmgInc: nodeA4Bonus } }),
+    akFinal: dmgNode("atk", datamine.charged.akFinal, "charged", { premod: { charged_dmgInc: nodeA4Bonus } }),
   },
   plunging: Object.fromEntries(Object.entries(datamine.plunging).map(([name, arr]) =>
     [name, dmgNode("atk", arr, "plunging")])),

--- a/src/Data/Characters/AratakiItto/index.tsx
+++ b/src/Data/Characters/AratakiItto/index.tsx
@@ -1,19 +1,21 @@
 import { CharacterData } from 'pipeline'
-import { input } from '../../../Formula'
-import { constant, equal, equalStr, greaterEq, infoMut, lookup, percent, prod, subscript, sum } from '../../../Formula/utils'
+import { input, tally } from '../../../Formula'
+import { constant, equal, equalStr, greaterEq, infoMut, lookup, min, percent, prod, subscript, sum } from '../../../Formula/utils'
 import { allElementsWithPhy, CharacterKey, ElementKey } from '../../../Types/consts'
 import { range } from '../../../Util/Util'
 import { cond, sgt, st, trans } from '../../SheetUtil'
-import CharacterSheet, { conditionalHeader, ICharacterSheet, normalSrc, talentTemplate } from '../CharacterSheet'
+import CharacterSheet, { ICharacterSheet, normalSrc, sectionTemplate, talentTemplate } from '../CharacterSheet'
 import { dataObjForCharacterSheet, dmgNode } from '../dataUtil'
 import { banner, burst, c1, c2, c3, c4, c5, c6, card, passive1, passive2, passive3, skill, thumb, thumbSide } from './assets'
 import data_gen_src from './data_gen.json'
 import skillParam_gen from './skillParam_gen.json'
 
+const data_gen = data_gen_src as CharacterData
+const auto = normalSrc(data_gen.weaponTypeKey)
 
 const key: CharacterKey = "AratakiItto"
 const elementKey: ElementKey = "geo"
-const data_gen = data_gen_src as CharacterData
+
 const [tr, trm] = trans("char", key)
 
 const datamine = {
@@ -61,6 +63,14 @@ const datamine = {
   passive2: {
     def_: skillParam_gen.passive2[0][0],
   },
+  constellation1: {
+    initialStacks: skillParam_gen.constellation1[0],
+    timedStacks: skillParam_gen.constellation1[1]
+  },
+  constellation2: {
+    burstCdRed: skillParam_gen.constellation2[0],
+    energyRegen: skillParam_gen.constellation2[1],
+  },
   constellation4: {
     def_: skillParam_gen.constellation4[0],
     atk_: skillParam_gen.constellation4[1],
@@ -82,6 +92,8 @@ const allNodeBurstRes = Object.fromEntries(allElementsWithPhy.map(ele => [`${ele
 const nodeBurstInfusion = equalStr(condBurst, "on", "geo")
 const nodeA4Bonus = greaterEq(input.asc, 4, prod(percent(datamine.passive2.def_), input.premod.def))
 const nodeP1AtkSpd = greaterEq(input.asc, 4, lookup(condP1, Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i => [i, constant(datamine.passive1.atkSPD_ * i)])), 0, { key: 'atkSPD_' }))
+const nodeC2BurstRed = prod(min(tally.geo, 3), datamine.constellation2.burstCdRed)
+const nodeC2EnergyRegen = prod(min(tally.geo, 3), datamine.constellation2.energyRegen)
 const nodeC4Atk = equal(condC4, "on", greaterEq(input.constellation, 4, datamine.constellation4.atk_))
 const nodeC4Def = equal(condC4, "on", greaterEq(input.constellation, 4, datamine.constellation4.def_))
 const nodeC6CritDMG = greaterEq(input.constellation, 6, datamine.constellation6.charged_critDMG_)
@@ -141,65 +153,70 @@ const sheet: ICharacterSheet = {
   title: tr("title"),
   talent: {
     sheets: {
-      auto: {
-        name: tr("auto.name"),
-        img: normalSrc(data_gen.weaponTypeKey),
-        sections: [{
-          text: tr("auto.fields.normal"),
-          fields: datamine.normal.hitArr.map((_, i) => ({
+      auto: talentTemplate("auto", tr, auto, undefined, undefined, [{
+        ...sectionTemplate("auto", tr, auto,
+          datamine.normal.hitArr.map((_, i) => ({
             node: infoMut(dmgFormulas.normal[i], { key: `char_${key}_gen:auto.skillParams.${i}` }),
           }))
-        },
-        {
-          text: tr("auto.fields.charged"),
-          fields: [{
-            node: infoMut(dmgFormulas.charged.akSlash, { key: `char_${key}_gen:auto.skillParams.4` }),
-          }, {
-            node: infoMut(dmgFormulas.charged.akFinal, { key: `char_${key}_gen:auto.skillParams.5` }),
-          }, {
-            text: tr("auto.skillParams.6"),
-            value: datamine.ss.duration,
-            unit: "s"
-          }, {
-            node: infoMut(dmgFormulas.charged.sSlash, { key: `char_${key}_gen:auto.skillParams.7` }),
-          }, {
-            text: tr("auto.skillParams.8"),
-            value: datamine.charged.stam,
-          }]
+        ),
+        text: tr("auto.fields.normal")
+      }, {
+        ...sectionTemplate("auto", tr, auto, [{
+          node: infoMut(dmgFormulas.charged.akSlash, { key: `char_${key}_gen:auto.skillParams.4` }),
         }, {
-          text: tr(`auto.fields.plunging`),
-          fields: [{
-            node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
-          }, {
-            node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
+          node: infoMut(dmgFormulas.charged.akFinal, { key: `char_${key}_gen:auto.skillParams.5` }),
+        }, {
+          text: tr("auto.skillParams.6"),
+          value: datamine.ss.duration,
+          unit: "s"
+        }, {
+          node: infoMut(dmgFormulas.charged.sSlash, { key: `char_${key}_gen:auto.skillParams.7` }),
+        }, {
+          text: tr("auto.skillParams.8"),
+          value: datamine.charged.stam,
+        }]),
+        text: tr("auto.fields.charged"),
+      }, sectionTemplate("passive1", tr, passive1, undefined, {
+        name: trm("a1.name"),
+        canShow: greaterEq(input.asc, 1, 1),
+        value: condP1,
+        path: condP1Path,
+        states: Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i =>
+          [i, {
+            name: st("stack_one", { count: i }),
+            fields: [{
+              node: nodeP1AtkSpd
+            }]
           }]
-        }
-        ],
-      },
-      skill: {
-        name: tr("skill.name"),
-        img: skill,
-        sections: [{
-          text: tr("skill.description"),
-          fields: [
-            {
-              node: infoMut(dmgFormulas.skill.dmg, { key: `char_${key}_gen:skill.skillParams.0` }),
-            }, {
-              node: infoMut(dmgFormulas.skill.hp, { key: `char_${key}_gen:skill.skillParams.1`, variant: "success" }),
-            }, {
-              text: tr("skill.skillParams.2"),
-              value: datamine.skill.duration,
-              unit: "s"
-            }, {
-              text: tr("skill.skillParams.3"),
-              value: datamine.skill.cd,
-              unit: "s"
-            }
-          ],
-        }],
-      },
+        ))
+      }), sectionTemplate("passive2", tr, passive2, [{
+        node: infoMut(nodeA4Bonus, { key: `char_${key}:a4:dmgInc` })
+      }], undefined, data => data.get(input.asc).value >= 4, false, true),
+      sectionTemplate("constellation6", tr, c6, [{
+        node: nodeC6CritDMG
+      }], undefined, data => data.get(input.constellation).value >= 6, false, true), {
+        ...sectionTemplate("auto", tr, auto, [{
+          node: infoMut(dmgFormulas.plunging.dmg, { key: "sheet_gen:plunging.dmg" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.low, { key: "sheet_gen:plunging.low" }),
+        }, {
+          node: infoMut(dmgFormulas.plunging.high, { key: "sheet_gen:plunging.high" }),
+        }]),
+        text: tr("auto.fields.plunging"),
+      }]),
+      skill: talentTemplate("skill", tr, skill, [{
+        node: infoMut(dmgFormulas.skill.dmg, { key: `char_${key}_gen:skill.skillParams.0` }),
+      }, {
+        node: infoMut(dmgFormulas.skill.hp, { key: `char_${key}_gen:skill.skillParams.1`, variant: "success" }),
+      }, {
+        text: tr("skill.skillParams.2"),
+        value: datamine.skill.duration,
+        unit: "s"
+      }, {
+        text: tr("skill.skillParams.3"),
+        value: datamine.skill.cd,
+        unit: "s"
+      }]),
       burst: talentTemplate("burst", tr, burst, [{
         text: tr("burst.skillParams.3"),
         value: datamine.burst.cd,
@@ -208,7 +225,7 @@ const sheet: ICharacterSheet = {
         text: tr("burst.skillParams.4"),
         value: datamine.burst.cost,
       }], {
-        name: tr("burst.name"),
+        name: st("afterUse.burst"),
         value: condBurst,
         path: condBurstPath,
         states: {
@@ -229,51 +246,55 @@ const sheet: ICharacterSheet = {
             }]
           }
         }
-      }),
-      passive1: talentTemplate("passive1", tr, passive1, undefined, {
-        name: trm("a1.name"),
-        canShow: greaterEq(input.asc, 1, 1),
-        value: condP1,
-        path: condP1Path,
-        states: Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i =>
-          [i, {
-            name: st("stack_one", { count: i }),
-            fields: [
-              {
-                node: nodeP1AtkSpd
-              },
-            ]
-          }]))
-      }),
-      passive2: talentTemplate("passive2", tr, passive2, [{ node: infoMut(nodeA4Bonus, { key: `char_${key}:a4:dmgInc` }) }]),
-      passive3: talentTemplate("passive3", tr, passive3),
-      constellation1: talentTemplate("constellation1", tr, c1),
-      constellation2: talentTemplate("constellation2", tr, c2),
-      constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
-      constellation4: talentTemplate("constellation4", tr, c4, undefined, {
-        canShow: greaterEq(input.constellation, 4, 1),
-        header: conditionalHeader("constellation4", tr, c4),
-        description: tr("constellation4.description"),
-        name: trm("c4.name"),
-        teamBuff: true,
-        value: condC4,
-        path: condC4Path,
-        states: {
-          on: {
-            fields: [
-              {
+      }, [
+        sectionTemplate("constellation1", tr, c1, [{
+          text: trm("c1.initialGain"),
+          value: datamine.constellation1.initialStacks
+        }, {
+          text: trm("c1.timedGain"),
+          value: datamine.constellation1.timedStacks
+        }], undefined,
+        data => data.get(input.constellation).value >= 1 && data.get(condBurst).value === "on",
+        false, true),
+        sectionTemplate("constellation2", tr, c2, [{
+          text: st("burstCDRed"),
+          value: data => data.get(nodeC2BurstRed).value,
+          unit: "s",
+          fixed: 1
+        }, {
+          text: st("energyRegen"),
+          value: data => data.get(nodeC2EnergyRegen).value,
+        }], undefined,
+        data => data.get(input.constellation).value >= 2 && data.get(condBurst).value === "on",
+        false, true),
+        sectionTemplate("constellation4", tr, c4, undefined, {
+          canShow: greaterEq(input.constellation, 4, 1),
+          name: trm("c4.name"),
+          teamBuff: true,
+          value: condC4,
+          path: condC4Path,
+          states: {
+            on: {
+              fields: [{
                 node: nodeC4Atk
               }, {
                 node: nodeC4Def
-              },
-              {
+              }, {
                 text: sgt("duration"),
                 value: datamine.constellation4.duration,
                 unit: "s"
               }]
+            }
           }
-        }
-      }),
+        })
+      ]),
+      passive1: talentTemplate("passive1", tr, passive1),
+      passive2: talentTemplate("passive2", tr, passive2),
+      passive3: talentTemplate("passive3", tr, passive3),
+      constellation1: talentTemplate("constellation1", tr, c1),
+      constellation2: talentTemplate("constellation2", tr, c2),
+      constellation3: talentTemplate("constellation3", tr, c3, [{ node: nodeC3 }]),
+      constellation4: talentTemplate("constellation4", tr, c4),
       constellation5: talentTemplate("constellation5", tr, c5, [{ node: nodeC5 }]),
       constellation6: talentTemplate("constellation6", tr, c6, [{ node: nodeC6CritDMG }])
     },

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -70,8 +70,6 @@ const [condSwirlReactionPath, condSwirlReaction] = cond(key, "swirl")
 const [condSkillHitOpponentPath, condSkillHitOpponent] = cond(key, "skillHit")
 
 // Conditional Output
-// It would be nice for this node to display only if the current
-// character's element matches, but I don't think that is possible
 const asc1Disp = greaterEq(input.asc, 1, datamine.passive1.eleMas)
 const asc1 = unequal(target.charKey, key, // Not applying to Sucrose
     equal(target.charEle, condSwirlReaction, asc1Disp)) // And element matches the swirl

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -73,10 +73,10 @@ const asc1Condition = greaterEq(input.asc, 1,
   unequal(target.charKey, characterKey,
     equal(target.charEle, condSwirlReaction, 1)))
 const asc1 = equal(asc1Condition, 1, datamine.passive1.eleMas)
-const asc4 = equal("hit", condSkillHitOpponent,
-  unequal(target.charKey, characterKey,
+const asc4Disp = equal("hit", condSkillHitOpponent,
     greaterEq(input.asc, 4,
-      prod(percent(datamine.passive2.eleMas_), input.premod.eleMas))))
+      prod(percent(datamine.passive2.eleMas_), input.premod.eleMas)))
+const asc4 = unequal(target.charKey, characterKey, asc4Disp)
 const c6Base = greaterEq(input.constellation, 6, percent(0.2))
 
 const c6Bonus = objectKeyMap(absorbableEle.map(ele => `${ele}_dmg_` as const), key =>
@@ -250,11 +250,11 @@ const sheet: ICharacterSheet = {
         value: condSkillHitOpponent,
         path: condSkillHitOpponentPath,
         name: trm("asc4"),
-        canShow: greaterEq(input.asc, 4, unequal(target.charKey, characterKey, 1)),
+        canShow: greaterEq(input.asc, 4, unequal(input.activeCharKey, characterKey, 1)),
         states: {
           hit: {
             fields: [{
-              node: asc4,
+              node: infoMut(asc4Disp, { key: "eleMas" }),
             }, {
               text: sgt("duration"),
               value: datamine.passive2.duration,

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -70,6 +70,8 @@ const [condSwirlReactionPath, condSwirlReaction] = cond(key, "swirl")
 const [condSkillHitOpponentPath, condSkillHitOpponent] = cond(key, "skillHit")
 
 // Conditional Output
+// It would be nice for this node to display only if the current
+// character's element matches, but I don't think that is possible
 const asc1Disp = greaterEq(input.asc, 1, datamine.passive1.eleMas)
 const asc1 = unequal(target.charKey, key, // Not applying to Sucrose
     equal(target.charEle, condSwirlReaction, asc1Disp)) // And element matches the swirl

--- a/src/Data/Resonance.tsx
+++ b/src/Data/Resonance.tsx
@@ -149,7 +149,7 @@ const condERPath = ["resonance", "EnduringRock"]
 const condER = condReadNode(condERPath)
 const erNodeshield_ = greaterEq(tally.geo, 2, percent(0.15))
 const erNodeDMG_ = greaterEq(tally.geo, 2, equal(condER, "on", percent(0.15)))
-const erNodeRes_ = greaterEq(tally.geo, 2, equal(condER, "on", percent(0.2)))
+const erNodeRes_ = greaterEq(tally.geo, 2, equal(condER, "on", percent(-0.2)))
 const enduringRock: IResonance = {
   name: tr("EnduringRock.name"),
   icon: <span>{StatIcon.geo} {StatIcon.geo}</span>,


### PR DESCRIPTION
Fix Itto charged attack not interacting with redhorn correctly
Fix Sucrose A4 not displaying
Fix Sucrose A1 not displaying
Fix Geo resonance adding res, instead of reducing res
Add Itto C1 and C2 displays

Refactor Sucrose and Itto to use `sectionTemplate`/`talentTemplate` and move their conditionals/fields to the corresponding skill/burst when applicable