### PR TITLE
Add support for teambuff infusion amp reactions

### DIFF
--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -2,6 +2,7 @@ import { CardContent, Grid, MenuItem, ToggleButton, ToggleButtonGroupProps } fro
 import { useContext } from 'react';
 import { DataContext } from "../DataContext";
 import { uiInput as input } from "../Formula";
+import { infusionNode } from "../Data/Characters/dataUtil";
 import { ElementKey } from "../Types/consts";
 import CardLight from "./Card/CardLight";
 import ColorText from "./ColoredText";
@@ -27,22 +28,23 @@ export function InfusionAuraDropdown(props: InfusionAuraDropdownProps) {
 
 type ReactionToggleProps = Omit<ToggleButtonGroupProps, "color">
 export function ReactionToggle(props: ReactionToggleProps) {
-  const { data, character: { reactionMode, infusionAura }, characterDispatch } = useContext(DataContext)
+  const { data, character: { reactionMode }, characterDispatch } = useContext(DataContext)
   const charEleKey = data.get(input.charEle).value as ElementKey
-  if (!["pyro", "hydro", "cryo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusionAura)) return null
+  const infusion = data.get(infusionNode).value as ElementKey
+  if (!["pyro", "hydro", "cryo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusion)) return null
   return <SolidToggleButtonGroup exclusive baseColor="secondary"
     value={reactionMode} onChange={(e, reactionMode) => characterDispatch({ reactionMode })} {...props}>
     <ToggleButton value="" >No Reactions</ToggleButton >
-    {(charEleKey === "pyro" || infusionAura === "pyro") && <ToggleButton value="pyro_vaporize"  >
+    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value="pyro_vaporize"  >
       <ColorText color="vaporize">Vaporize(Pyro){StatIcon.hydro}+{StatIcon.pyro}</ColorText>
     </ToggleButton >}
-    {(charEleKey === "pyro" || infusionAura === "pyro") && <ToggleButton value={"pyro_melt"}  >
+    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value={"pyro_melt"}  >
       <ColorText color="melt">Melt(Pyro) {StatIcon.cryo}+{StatIcon.pyro}</ColorText>
     </ToggleButton >}
-    {(charEleKey === "hydro" || infusionAura === "hydro") && <ToggleButton value={"hydro_vaporize"}  >
+    {(charEleKey === "hydro" || infusion === "hydro") && <ToggleButton value={"hydro_vaporize"}  >
       <ColorText color="vaporize">Vaporize(Hydro) {StatIcon.pyro}+{StatIcon.hydro}</ColorText>
     </ToggleButton >}
-    {(charEleKey === "cryo" || infusionAura === "cryo") && <ToggleButton value={"cryo_melt"}  >
+    {(charEleKey === "cryo" || infusion === "cryo") && <ToggleButton value={"cryo_melt"}  >
       <ColorText color="melt">Melt(Cryo) {StatIcon.pyro}+{StatIcon.cryo}</ColorText>
     </ToggleButton >}
   </SolidToggleButtonGroup>

--- a/src/Data/Characters/dataUtil.tsx
+++ b/src/Data/Characters/dataUtil.tsx
@@ -15,12 +15,12 @@ const charCurves = objectMap(_charCurves, value => [0, ...Object.values(value)])
 const commonBasic = objectKeyMap(["hp", "atk", "def", "eleMas", "enerRech_", "critRate_", "critDMG_", "heal_"], key => input.total[key])
 commonBasic.critRate_ = input.total.cappedCritRate
 
-const infusion = stringPrio(
+export const infusionNode = stringPrio(
   input.infusion.nonOverridableSelf,
   input.infusion.team,
   input.infusion.overridableSelf)
 const meleeHitEle = lookup(input.hit.move, {
-  "normal": infusion, "charged": infusion, "plunging": infusion,
+  "normal": infusionNode, "charged": infusionNode, "plunging": infusionNode,
   "skill": input.charEle, "burst": input.charEle,
 }, undefined)
 const inferredHitEle = stringPrio(


### PR DESCRIPTION
Allow selecting amp reactions when infused via teambuff

Before, you couldn't select an amp reaction (e.g. Vape) if your element wasn't Pyro/Hydro, even if Bennett was giving you Pyro infusion