### PR TITLE
Fix some calculations/displays

### DIFF
--- a/src/Data/Characters/Barbara/index.tsx
+++ b/src/Data/Characters/Barbara/index.tsx
@@ -127,9 +127,9 @@ const sheet: ICharacterSheet = {
         text: tr("auto.fields.normal"),
       }, {
         ...sectionTemplate("auto", tr, auto, [{
-          node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.5` }),
+          node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.4` }),
         }, {
-          text: tr("auto.skillParams.6"),
+          text: tr("auto.skillParams.5"),
           value: datamine.charged.stamina,
         }]),
         text: tr("auto.fields.charged"),

--- a/src/Data/Characters/Bennett/index.tsx
+++ b/src/Data/Characters/Bennett/index.tsx
@@ -143,6 +143,9 @@ export const data = dataObjForCharacterSheet(key, elementKey, "mondstadt", data_
   teamBuff: {
     premod: {
       pyro_dmg_: activeInAreaC6PyroDmg,
+    },
+    total: {
+      // Not 100% sure if this should be in premod or total
       atk: activeInAreaAtk,
     },
     infusion: {

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -77,8 +77,7 @@ const condSwirls = Object.fromEntries(absorbableEle.map(e => [e, condReadNode(co
 const asc4 = Object.fromEntries(absorbableEle.map(ele =>
   [`${ele}_dmg_`, greaterEq(input.asc, 4,
     equal("swirl", condSwirls[ele],
-      // TODO: this percent of 0.04% is displayed as 0.0%
-      prod(percent(datamine.passive2.elemas_dmg_), input.premod.eleMas)
+      prod(percent(datamine.passive2.elemas_dmg_, { fixed: 2 }), input.premod.eleMas)
     ))]))
 
 const [condC2Path, condC2] = cond(key, "c2")

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -146,8 +146,6 @@ export const data = dataObjForCharacterSheet(key, "anemo", "inazuma", data_gen, 
     premod: {
       ...asc4,
       staminaSprintDec_: passive,
-    },
-    total: {
       eleMas: c2PEleMas,
     },
   },
@@ -158,8 +156,6 @@ export const data = dataObjForCharacterSheet(key, "anemo", "inazuma", data_gen, 
     normal_dmg_: c6NormDmg_,
     charged_dmg_: c6ChargedDmg_,
     plunging_dmg_: c6PlungingDmg_,
-  },
-  total: {
     eleMas: c2EleMas,
   },
 })

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -77,9 +77,11 @@ const condSwirls = Object.fromEntries(absorbableEle.map(e => [e, condReadNode(co
 const asc4 = Object.fromEntries(absorbableEle.map(ele =>
   [`${ele}_dmg_`, greaterEq(input.asc, 4,
     equal("swirl", condSwirls[ele],
+      // Use premod since this is a percentage-based effect
       prod(percent(datamine.passive2.elemas_dmg_, { fixed: 2 }), input.premod.eleMas)
     ))]))
 
+// 2 C2 conds for the 2 parts of his C2
 const [condC2Path, condC2] = cond(key, "c2")
 const c2EleMas = greaterEq(input.constellation, 2,
   equal("c2", condC2, datamine.constellation2.elemas))
@@ -96,6 +98,7 @@ const [condC6Path, condC6] = cond(key, "c6")
 const c6infusion = greaterEqStr(input.constellation, 6,
   equalStr("c6", condC6, "anemo"))
 const c6Dmg_ = greaterEq(input.constellation, 6,
+  // Not sure if this should be premod or total. I am guessing premod
   equal("c6", condC6, prod(percent(datamine.constellation6.auto_), input.premod.eleMas))
 )
 // Share `match` and `prod` between the three nodes
@@ -144,10 +147,14 @@ export const data = dataObjForCharacterSheet(key, "anemo", "inazuma", data_gen, 
   },
   teamBuff: {
     premod: {
-      ...asc4,
       staminaSprintDec_: passive,
       eleMas: c2PEleMas,
     },
+    total: {
+      // Should be in total, since other character abilities should not scale off this
+      // if those abilities are percentage-based (e.g. XQ skill dmg red.)
+      ...asc4,
+    }
   },
   infusion: {
     overridableSelf: c6infusion,

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -159,10 +159,12 @@ export const data = dataObjForCharacterSheet(key, "anemo", "inazuma", data_gen, 
   infusion: {
     overridableSelf: c6infusion,
   },
-  premod: {
+  total: {
     normal_dmg_: c6NormDmg_,
     charged_dmg_: c6ChargedDmg_,
     plunging_dmg_: c6PlungingDmg_,
+  },
+  premod: {
     eleMas: c2EleMas,
   },
 })

--- a/src/Data/Characters/Shenhe/index.tsx
+++ b/src/Data/Characters/Shenhe/index.tsx
@@ -79,7 +79,7 @@ const datamine = {
 
 const [condQuillPath, condQuill] = cond(key, "quill")
 const nodeSkill = equal("quill", condQuill,
-  prod(input.premod.atk, subscript(input.total.skillIndex, datamine.skill.dmgAtk_, { key: '_' })))
+  prod(input.total.atk, subscript(input.total.skillIndex, datamine.skill.dmgAtk_, { key: '_' })))
 
 
 const [condBurstPath, condBurst] = cond(key, "burst")

--- a/src/Data/Characters/Xingqiu/index.tsx
+++ b/src/Data/Characters/Xingqiu/index.tsx
@@ -75,7 +75,7 @@ const nodeC4 = greaterEq(input.constellation, 4,
   equal(condBurst, "on", datamine.constellation4.dmg_), { key: `char_${key}:c4dmg_` })
 
 const nodeSkillDmgRed_ = equal(condSkill, "on",
-  sum(subscript(input.total.skillIndex, datamine.skill.dmgRed_, { key: "_" }), min(percent(0.24), prod(percent(0.2), input.total.hydro_dmg_))))
+  sum(subscript(input.total.skillIndex, datamine.skill.dmgRed_, { key: "_" }), min(percent(0.24), prod(percent(0.2), input.premod.hydro_dmg_))))
 
 const nodeA4Heal = customHealNode(greaterEq(input.asc, 1, prod(input.total.hp, percent(0.06))))
 

--- a/src/Data/Characters/YaeMiko/index.tsx
+++ b/src/Data/Characters/YaeMiko/index.tsx
@@ -60,7 +60,7 @@ const datamine = {
 
 } as const
 
-const nodeAsc4 = greaterEq(input.asc, 4, prod(input.total.eleMas, percent(datamine.passive2.eleMas_dmg_)))
+const nodeAsc4 = greaterEq(input.asc, 4, prod(input.total.eleMas, percent(datamine.passive2.eleMas_dmg_, { fixed: 2 })))
 
 const [condC4Path, condC4] = cond(key, "c4")
 const nodeC4 = greaterEq(input.constellation, 4, equal("hit", condC4, datamine.constellation4.ele_dmg_))

--- a/src/Data/Weapons/Bow/Slingshot/index.tsx
+++ b/src/Data/Weapons/Bow/Slingshot/index.tsx
@@ -19,8 +19,8 @@ const charged_atk_increase_s = [.46, .52, .58, .64, .70]
 const [condPassivePath, condPassive] = cond(key, "Slingshot")
 const normal_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, normal_atk_increase_s), { key: "normal_dmg_" })
 const charged_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, charged_atk_increase_s), { key: "charged_dmg_" })
-const normal_atk_decrease = percent(.1, { key: "normal_dmg_" })
-const charged_atk_decrease = percent(.1, { key: "charged_dmg_" })
+const normal_atk_decrease = percent(-0.1, { key: "normal_dmg_" })
+const charged_atk_decrease = percent(-0.1, { key: "charged_dmg_" })
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -9,8 +9,7 @@ const asConst = true as const, pivot = true as const
 const allElements = allElementsWithPhy
 const allTalents = ["auto", "skill", "burst"] as const
 const allMoves = ["normal", "charged", "plunging", "skill", "burst", "elemental"] as const
-const allArtModStats = ["hp", "hp_", "atk", "atk_", "def", "def_", "eleMas", "enerRech_", "critRate_", "critDMG_"] as const
-const allArtNonModStats = ["physical_dmg_", "anemo_dmg_", "geo_dmg_", "electro_dmg_", "hydro_dmg_", "pyro_dmg_", "cryo_dmg_", "heal_"] as const
+const allArtModStats = ["hp", "hp_", "atk", "atk_", "def", "def_", "eleMas", "enerRech_", "critRate_", "critDMG_", "electro_dmg_", "hydro_dmg_", "pyro_dmg_", "cryo_dmg_", "physical_dmg_", "anemo_dmg_", "geo_dmg_", "heal_"] as const
 const allTransformative = ["overloaded", "shattered", "electrocharged", "superconduct", "swirl"] as const
 const allAmplifying = ["vaporize", "melt"] as const
 const allMisc = [
@@ -23,7 +22,6 @@ const allModStats = [
   ...(["all", "burning", ...allTransformative, ...allAmplifying, ...allMoves] as const).map(x => `${x}_dmg_` as const),
 ]
 const allNonModStats = [
-  ...allArtNonModStats,
   ...allElements.flatMap(x => [
     `${x}_dmgInc` as const,
     `${x}_critDMG_` as const,
@@ -46,8 +44,8 @@ for (const ele of allElements) {
   allNonModStatNodes[`${ele}_res_`].info!.variant = ele
   allNonModStatNodes[`${ele}_enemyRes_`].info!.variant = ele
   allNonModStatNodes[`${ele}_critDMG_`].info!.variant = ele
-  allNonModStatNodes[`${ele}_dmg_`].info!.variant = ele
   allNonModStatNodes[`${ele}_dmgInc`].info!.variant = ele
+  allModStatNodes[`${ele}_dmg_`].info!.variant = ele
 }
 for (const reaction of [...allTransformative, ...allAmplifying]) {
   allModStatNodes[`${reaction}_dmg_`].info!.variant = reaction
@@ -91,7 +89,6 @@ const input = setReadNodeKeys(deepClone({
 
   art: withDefaultInfo({ prefix: "art", asConst }, {
     ...objectKeyMap(allArtModStats, key => allModStatNodes[key]),
-    ...objectKeyMap(allArtNonModStats, key => allNonModStatNodes[key]),
     ...objectKeyMap(allSlotKeys, _ => ({ id: stringRead(), set: stringRead() })),
   }),
   artSet: objectKeyMap(allArtifactSets, set => read("add", { key: set })),
@@ -152,7 +149,7 @@ const common: Data = {
   premod: {
     ...objectKeyMap(allTalents, talent => bonus[talent]),
     ...objectKeyMap(allNonModStats, key => customBonus[key]),
-    ...objectKeyMap([...allModStats, ...allArtNonModStats] as const, key => {
+    ...objectKeyMap(allModStats, key => {
       const operands: NumNode[] = []
       switch (key) {
         case "atk": case "def": case "hp":


### PR DESCRIPTION
Fix Yae/Kazuha A4 to show the 2nd decimal point in the formula text
* There still needs to be another change for the NodeDisplay to show the 2nd decimal point. As of now, % values are defaulted to 1 decimal point

Fix Shenhe quills to be based on `total.atk` instead of `premod.atk`
* I did some in game testing for this with Shenhe+Bennett+Ayaka

Move Bennett bonus atk to `total` to match with Sara
Fix Barbara charged attack text
Move Kazuha C2 `eleMas` to `premod` since it is a fixed value
Move Kazuha A4 `ele_dmg_` to `total` since it is a percentage-based value
Fix Xingqiu's skill dmg reduction to use `premod` since it is a percentage-based value