### PR TITLE
Update ArtifactDisplay

### DIFF
--- a/src/Components/Artifact/ArtifactCardNano.tsx
+++ b/src/Components/Artifact/ArtifactCardNano.tsx
@@ -85,5 +85,5 @@ function SubstatDisplay({ stat }: { stat: ICachedSubstat }) {
 }
 function LocationIcon({ location }) {
   const characterSheet = usePromise(CharacterSheet.get(location ?? ""), [location])
-  return characterSheet ? <ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /> : <BusinessCenter />
+  return characterSheet ? <BootstrapTooltip placement="top" title={<Typography>{characterSheet.name}</Typography>}><ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /></BootstrapTooltip> : <BusinessCenter />
 }

--- a/src/Components/Artifact/SlotNameWIthIcon.tsx
+++ b/src/Components/Artifact/SlotNameWIthIcon.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { useTranslation } from "react-i18next"
 import { faCirclet, faFlower, faGoblet, faPlume, faSands } from '../faIcons'
 import { SlotKey } from "../../Types/consts"
+import { SizeProp } from "@fortawesome/fontawesome-svg-core"
 
 export const SlotIconSVG: StrictDict<SlotKey, any> = {
   flower: faFlower,
@@ -11,8 +12,8 @@ export const SlotIconSVG: StrictDict<SlotKey, any> = {
   circlet: faCirclet
 }
 
-export function artifactSlotIcon(slotKey: SlotKey) {
-  return <FontAwesomeIcon icon={SlotIconSVG[slotKey]} key={slotKey} className="fa-fw" />
+export function artifactSlotIcon(slotKey: SlotKey, size?: SizeProp) {
+  return <FontAwesomeIcon icon={SlotIconSVG[slotKey]} key={slotKey} className="fa-fw" size={size} />
 }
 
 export default function SlotNameWithIcon({ slotKey }: { slotKey: SlotKey }) {

--- a/src/PageBuild/BuildDisplay.tsx
+++ b/src/PageBuild/BuildDisplay.tsx
@@ -8,6 +8,7 @@ import { Link as RouterLink } from 'react-router-dom';
 // eslint-disable-next-line
 import Worker from "worker-loader!./BackgroundWorker";
 import ArtifactLevelSlider from '../Components/Artifact/ArtifactLevelSlider';
+import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';
 import CharacterDropdownButton from '../Components/Character/CharacterDropdownButton';
@@ -487,11 +488,13 @@ export default function BuildDisplay({ location: { characterKey: propCharacterKe
                   {maxBuildsToShowList.map(v => <MenuItem key={v}
                     onClick={() => buildSettingsDispatch({ maxBuildsToShow: v })}>{v} {v === 1 ? "Build" : "Builds"}</MenuItem>)}
                 </DropdownButton>
-                <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
-                  title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
-                  {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
-                    onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
-                </DropdownButton>
+                <BootstrapTooltip title={<Typography>Increasing the number of threads will speed up build time, but will use more CPU power.</Typography>}>
+                  <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
+                    title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
+                    {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
+                      onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
+                  </DropdownButton>
+                </BootstrapTooltip>
                 {/* </Tooltip> */}
                 <Button
                   disabled={!generatingBuilds}

--- a/src/PageBuild/BuildDisplay.tsx
+++ b/src/PageBuild/BuildDisplay.tsx
@@ -8,7 +8,6 @@ import { Link as RouterLink } from 'react-router-dom';
 // eslint-disable-next-line
 import Worker from "worker-loader!./BackgroundWorker";
 import ArtifactLevelSlider from '../Components/Artifact/ArtifactLevelSlider';
-import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';
 import CharacterDropdownButton from '../Components/Character/CharacterDropdownButton';
@@ -488,13 +487,17 @@ export default function BuildDisplay({ location: { characterKey: propCharacterKe
                   {maxBuildsToShowList.map(v => <MenuItem key={v}
                     onClick={() => buildSettingsDispatch({ maxBuildsToShow: v })}>{v} {v === 1 ? "Build" : "Builds"}</MenuItem>)}
                 </DropdownButton>
-                <BootstrapTooltip title={<Typography>Increasing the number of threads will speed up build time, but will use more CPU power.</Typography>}>
-                  <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
-                    title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
-                    {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
-                      onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
-                  </DropdownButton>
-                </BootstrapTooltip>
+                <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
+                  title={<span><b>{maxWorkers}</b> {maxWorkers === 1 ? "Thread" : "Threads"}</span>}>
+                  <MenuItem>
+                    <Typography variant="caption" color="info.main">
+                      Increasing the number of threads will speed up build time, but will use more CPU power.
+                    </Typography>
+                  </MenuItem>
+                  <Divider />
+                  {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
+                    onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
+                </DropdownButton>
                 {/* </Tooltip> */}
                 <Button
                   disabled={!generatingBuilds}

--- a/src/PageBuild/Components/ArtifactBuildDisplayItem.tsx
+++ b/src/PageBuild/Components/ArtifactBuildDisplayItem.tsx
@@ -52,6 +52,14 @@ export default function ArtifactBuildDisplayItem({ index, compareBuild, disabled
     const newBuild = Object.fromEntries(allSlotKeys.map(s => [s, data.get(input.art[s].id).value])) as Record<SlotKey, string>
     database.equipArtifacts(character.key, newBuild)
   }, [character, data, database])
+  const excludeArts = useCallback(() => {
+    if (!window.confirm("Do you want to exclude these artifacts from future builds?")) return
+    allSlotKeys.map(s => {
+      let id = data.get(input.art[s].id).value
+      typeof id === "string" && database.updateArt({ exclude: true }, id)
+    })
+  }, [data, database])
+
   if (!character || !artifactSheets || !oldData) return null
   const currentlyEquipped = allSlotKeys.every(slotKey => data.get(input.art[slotKey].id).value === oldData.get(input.art[slotKey].id).value)
   const statProviderContext = { ...dataContext }
@@ -86,6 +94,7 @@ export default function ArtifactBuildDisplayItem({ index, compareBuild, disabled
           </Box>
           <Button size='small' color="info" onClick={openModal} disabled={disabled || currentlyEquipped}>Build Details</Button>
           <Button size='small' color="success" onClick={equipArts} disabled={disabled || currentlyEquipped}>Equip Artifacts</Button>
+          <Button size='small' color="success" onClick={excludeArts} disabled={disabled}>Exclude Artifacts</Button>
         </Box>
         <Grid container spacing={1} sx={{ pb: 1 }}>
           {allSlotKeys.map(slotKey =>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -1,6 +1,6 @@
 import { Box, CardActionArea, CardContent, Chip, Grid, Skeleton, Stack, Typography } from '@mui/material';
 import { Suspense, useCallback, useContext, useMemo } from 'react';
-import { SlotIconSVG } from '../Components/Artifact/SlotNameWIthIcon';
+import { artifactSlotIcon } from '../Components/Artifact/SlotNameWIthIcon';
 import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';
@@ -26,7 +26,6 @@ import { allSlotKeys, CharacterKey, ElementKey, SlotKey } from '../Types/consts'
 import { ICachedWeapon } from '../Types/weapon';
 import { NodeDisplay } from '../Formula/uiData'
 import { theme } from '../Theme';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 type CharacterCardProps = {
   characterKey: CharacterKey | "",
@@ -203,7 +202,7 @@ function ArtifactDisplay() {
       if (!art) return <Grid item key={key} xs={1}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>
           <Box sx={{ pl: 1, pr: 1, pt: 1, pb: 1, textAlign: "center" }}>
-            <FontAwesomeIcon icon={SlotIconSVG[key]} key={key} className="fa-fw" size="3x" />
+            {artifactSlotIcon(key, "3x")}
           </Box>
         </CardDark>
       </Grid>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -62,7 +62,7 @@ export default function CharacterCard({ characterKey, artifactChildren, weaponCh
       <CardLight sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
         <ConditionalWrapper condition={!!onClick} wrapper={actionWrapperFunc} >
           <Header onClick={!onClick ? onClickHeader : undefined} />
-          <CardContent sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1, flexGrow: 1 }}>
+          <CardContent sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1, flexGrow: 1, pl: 0.5, pr: 0.5 }}>
             <Weapon weaponId={character.equippedWeapon} />
             {weaponChildren}
             {/* will grow to fill the 100% height */}
@@ -197,24 +197,10 @@ function ArtifactDisplay() {
   const setEffects = useMemo(() => artifactSheets && ArtifactSheet.setEffects(artifactSheets, data), [artifactSheets, data])
   if (!artifactSheets) return null
 
-  return <Grid direction="row" container spacing={1} rowSpacing={0.5}>
-    {/* Set effect box */}
-    <Grid item key={"setEffects"} xs={4}>
-      <CardDark variant="outlined" sx={{ height: "100%" }}>
-        <Grid container>
-          {setEffects && Object.entries(setEffects).map(([setKey, setNumKeyArr]) =>
-            <Grid key={setKey} display="flex" alignItems="center" item xs={12} sx={{ pl: 1, pr: 1 }}>
-              <ImgIcon src={artifactSheets[setKey].slotIcons.flower ?? artifactSheets[setKey].slotIcons.circlet} sx={{ height: "2.5em", pt: 0.5 }} />
-              <SqBadge color="success">{setNumKeyArr.at(-1)}-Set</SqBadge>
-            </Grid>
-          )}
-        </Grid>
-      </CardDark>
-    </Grid>
-
+  return <Grid direction="row" container spacing={0.5} columns={5}>
     {/* Artifact 5 piece meal */}
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
-      if (!art) return <Grid item key={key} xs={4}>
+      if (!art) return <Grid item key={key} xs={1}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>
           <Box sx={{ pl: 1, pr: 1, pt: 1, pb: 1, textAlign: "center" }}>
             <FontAwesomeIcon icon={SlotIconSVG[key]} key={key} className="fa-fw" size="3x" />
@@ -223,16 +209,16 @@ function ArtifactDisplay() {
       </Grid>
 
       const { setKey, slotKey, mainStatKey, rarity, level, mainStatVal } = art
-      return <Grid item key={key} xs={4}>
+      return <Grid item key={key} xs={1}>
         <CardDark variant="outlined" sx={{ borderColor: theme.palette[`star${rarity}`].main }}>
-          <Box sx={{ pl: 1, pr: 1, pt: 0.25, pb: 1, textAlign: "center" }}>
-            <ImgIcon src={artifactSheets?.[setKey].slotIcons[slotKey]} sx={{ height: "3.5em" }} />
-            <Typography variant='subtitle1' sx={{ display: "flex", gap: 1, mb: 0.5 }} >
+          <Box sx={{ pl: 0.5, pr: 0.5, pt: 0.25, pb: 1, textAlign: "center" }}>
+            <ImgIcon src={artifactSheets?.[setKey].slotIcons[slotKey]} sx={{ height: "3em" }} />
+            <Typography variant='subtitle1' sx={{ display: "flex", mb: 0.5 }} >
               <SqBadge color="primary">Lv. {level}</SqBadge>
             </Typography>
-            <Typography variant='subtitle1' sx={{ display: "flex", gap: 1 }} >
-              <BootstrapTooltip placement="top" title={<Typography>{KeyMap.getArtStr(mainStatKey)}</Typography>}>
-                  <SqBadge color="secondary">{StatIcon[mainStatKey]} {cacheValueString(mainStatVal, KeyMap.unit(mainStatKey))}{KeyMap.unit(mainStatKey)}</SqBadge>
+            <Typography variant='subtitle1' sx={{ display: "flex" }} >
+              <BootstrapTooltip placement="top" title={<Typography>{cacheValueString(mainStatVal, KeyMap.unit(mainStatKey))}{KeyMap.unit(mainStatKey)} {KeyMap.getStr(mainStatKey)}</Typography>}>
+                  <SqBadge color="secondary" sx={{ width: "100%" }}>{StatIcon[mainStatKey]}</SqBadge>
               </BootstrapTooltip>
             </Typography>
           </Box>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -1,6 +1,6 @@
 import { Box, CardActionArea, CardContent, Chip, Grid, Skeleton, Typography } from '@mui/material';
 import { Suspense, useCallback, useContext, useMemo } from 'react';
-import { artifactSlotIcon, SlotIconSVG } from '../Components/Artifact/SlotNameWIthIcon';
+import { SlotIconSVG } from '../Components/Artifact/SlotNameWIthIcon';
 import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -196,11 +196,11 @@ function ArtifactDisplay() {
     [data, database]) as Array<[SlotKey, ICachedArtifact | undefined]>;
   if (!artifactSheets) return null
 
-  return <Grid container spacing={1}>
+  return <Grid container spacing={0.25}>
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
       if (!art) return <Grid item key={key} flexGrow={1}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>
-          <Box sx={{ pl: 0.4, pr: 0.4, pt: 1, pb: 1, textAlign: "center" }}>
+          <Box sx={{ pl: 0.3, pr: 0.3, pt: 1, pb: 1, textAlign: "center" }}>
             <FontAwesomeIcon icon={SlotIconSVG[key]} key={key} className="fa-fw" size="3x" />
           </Box>
         </CardDark>
@@ -209,7 +209,7 @@ function ArtifactDisplay() {
       const { setKey, slotKey, mainStatKey, rarity, level, mainStatVal } = art
       return <Grid item key={key} flexGrow={1}>
         <CardDark variant="outlined" sx={{ borderColor: theme.palette[`star${rarity}`].main }}>
-          <Box sx={{ pl: 0.4, pr: 0.4, pt: 0.25, pb: 1, textAlign: "center" }}>
+          <Box sx={{ pl: 0.3, pr: 0.3, pt: 0.25, pb: 1, textAlign: "center" }}>
             <ImgIcon src={artifactSheets?.[setKey].slotIcons[slotKey]} sx={{ height: "3.5em" }} />
             <Typography variant='subtitle1' sx={{ display: "flex", gap: 1, mb: 0.5 }} >
               <SqBadge color="primary">Lv. {level}</SqBadge>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -200,7 +200,7 @@ function ArtifactDisplay() {
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
       if (!art) return <Grid item key={key} flexGrow={1}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>
-          <Box sx={{ pl: 0.4, pr: 0.4, pt: 1, pb: 1 }}>
+          <Box sx={{ pl: 0.4, pr: 0.4, pt: 1, pb: 1, textAlign: "center" }}>
             <FontAwesomeIcon icon={SlotIconSVG[key]} key={key} className="fa-fw" size="3x" />
           </Box>
         </CardDark>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -203,7 +203,7 @@ function ArtifactDisplay() {
       <CardDark variant="outlined" sx={{ height: "100%" }}>
         <Grid container>
           {setEffects && Object.entries(setEffects).map(([setKey, setNumKeyArr]) =>
-            <Grid display="flex" alignItems="center" item xs={12} sx={{ pl: 1, pr: 1 }}>
+            <Grid key={setKey} display="flex" alignItems="center" item xs={12} sx={{ pl: 1, pr: 1 }}>
               <ImgIcon src={artifactSheets[setKey].slotIcons.flower ?? artifactSheets[setKey].slotIcons.circlet} sx={{ height: "2.5em", pt: 0.5 }} />
               <SqBadge color="success">{setNumKeyArr.at(-1)}-Set</SqBadge>
             </Grid>
@@ -212,7 +212,7 @@ function ArtifactDisplay() {
       </CardDark>
     </Grid>
 
-    {/* Artifact piece box */}
+    {/* Artifact 5 piece meal */}
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
       if (!art) return <Grid item key={key} xs={4}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -1,4 +1,4 @@
-import { Box, CardActionArea, CardContent, Chip, Grid, Skeleton, Typography } from '@mui/material';
+import { Box, CardActionArea, CardContent, Chip, Grid, Skeleton, Stack, Typography } from '@mui/material';
 import { Suspense, useCallback, useContext, useMemo } from 'react';
 import { SlotIconSVG } from '../Components/Artifact/SlotNameWIthIcon';
 import BootstrapTooltip from '../Components/BootstrapTooltip';
@@ -62,11 +62,11 @@ export default function CharacterCard({ characterKey, artifactChildren, weaponCh
       <CardLight sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
         <ConditionalWrapper condition={!!onClick} wrapper={actionWrapperFunc} >
           <Header onClick={!onClick ? onClickHeader : undefined} />
-          <CardContent sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1, flexGrow: 1, pl: 1, pr: 1 }}>
+          <CardContent sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1, flexGrow: 1 }}>
             <Weapon weaponId={character.equippedWeapon} />
             {weaponChildren}
             {/* will grow to fill the 100% height */}
-            <Box flexGrow={1} display="flex" flexDirection="column" gap={0.5}>
+            <Box flexGrow={1} display="flex" flexDirection="column" gap={1}>
               <ArtifactDisplay />
               {artifactChildren}
             </Box>
@@ -194,22 +194,38 @@ function ArtifactDisplay() {
   const artifacts = useMemo(() =>
     allSlotKeys.map(k => [k, database._getArt(data.get(input.art[k].id).value ?? "")]),
     [data, database]) as Array<[SlotKey, ICachedArtifact | undefined]>;
+  const setEffects = useMemo(() => artifactSheets && ArtifactSheet.setEffects(artifactSheets, data), [artifactSheets, data])
   if (!artifactSheets) return null
 
-  return <Grid container spacing={0.25}>
+  return <Grid direction="row" container spacing={1} rowSpacing={0.5}>
+    {/* Set effect box */}
+    <Grid item key={"setEffects"} xs={4}>
+      <CardDark variant="outlined" sx={{ height: "100%" }}>
+        <Grid container>
+          {setEffects && Object.entries(setEffects).map(([setKey, setNumKeyArr]) =>
+            <Grid display="flex" alignItems="center" item xs={12} sx={{ pl: 1, pr: 1 }}>
+              <ImgIcon src={artifactSheets[setKey].slotIcons.flower ?? artifactSheets[setKey].slotIcons.circlet} sx={{ height: "2.5em", pt: 0.5 }} />
+              <SqBadge color="success">{setNumKeyArr.at(-1)}-Set</SqBadge>
+            </Grid>
+          )}
+        </Grid>
+      </CardDark>
+    </Grid>
+
+    {/* Artifact piece box */}
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
-      if (!art) return <Grid item key={key} flexGrow={1}>
+      if (!art) return <Grid item key={key} xs={4}>
         <CardDark variant="outlined" sx={{ height: "100%" }}>
-          <Box sx={{ pl: 0.3, pr: 0.3, pt: 1, pb: 1, textAlign: "center" }}>
+          <Box sx={{ pl: 1, pr: 1, pt: 1, pb: 1, textAlign: "center" }}>
             <FontAwesomeIcon icon={SlotIconSVG[key]} key={key} className="fa-fw" size="3x" />
           </Box>
         </CardDark>
       </Grid>
 
       const { setKey, slotKey, mainStatKey, rarity, level, mainStatVal } = art
-      return <Grid item key={key} flexGrow={1}>
+      return <Grid item key={key} xs={4}>
         <CardDark variant="outlined" sx={{ borderColor: theme.palette[`star${rarity}`].main }}>
-          <Box sx={{ pl: 0.3, pr: 0.3, pt: 0.25, pb: 1, textAlign: "center" }}>
+          <Box sx={{ pl: 1, pr: 1, pt: 0.25, pb: 1, textAlign: "center" }}>
             <ImgIcon src={artifactSheets?.[setKey].slotIcons[slotKey]} sx={{ height: "3.5em" }} />
             <Typography variant='subtitle1' sx={{ display: "flex", gap: 1, mb: 0.5 }} >
               <SqBadge color="primary">Lv. {level}</SqBadge>

--- a/src/PageCharacter/CharacterDisplay/CharacterArtifactPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterArtifactPane.tsx
@@ -40,6 +40,14 @@ function CharacterArtifactPane({ newBuild = false }: { newBuild?: boolean }) {
     database.equipArtifacts(character.key, newBuild)
   }, [character, data, database])
 
+  const excludeArts = useCallback(() => {
+    if (!window.confirm("Do you want to exclude these artifacts from future builds?")) return
+    allSlotKeys.map(s => {
+      let id = data.get(input.art[s].id).value
+      typeof id === "string" && database.updateArt({ exclude: true }, id)
+    })
+  }, [data, database])
+
   const unequipArts = useCallback(() => {
     if (!character) return
     if (!window.confirm("Do you want to move all currently equipped artifacts to inventory?")) return
@@ -57,6 +65,7 @@ function CharacterArtifactPane({ newBuild = false }: { newBuild?: boolean }) {
         <Grid container spacing={1}>
           <Grid item>
             {newBuild ? <Button onClick={equipArts} className="mr-2">Equip artifacts</Button> : <Button color="error" onClick={unequipArts}>Unequip all artifacts</Button>}
+            <Button onClick={excludeArts} sx={{ ml: 1 }}>Exclude all artifacts</Button>
           </Grid>
           <Grid item flexGrow={1}></Grid>
           <Grid item>{!!mainStatAssumptionLevel && <Card sx={{ p: 1, bgcolor: t => t.palette.warning.dark }}><Typography><strong>Assume Main Stats are Level {mainStatAssumptionLevel}</strong></Typography></Card>}</Grid>

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -30,6 +30,11 @@ declare module '@mui/material/styles' {
     swirl: Palette['primary'];
     burning: Palette['primary'];
     crystallize: Palette['primary'];
+    star1: Palette['primary'];
+    star2: Palette['primary'];
+    star3: Palette['primary'];
+    star4: Palette['primary'];
+    star5: Palette['primary'];
   }
   interface PaletteOptions {
     warning?: PaletteOptions['primary'];
@@ -59,6 +64,11 @@ declare module '@mui/material/styles' {
     swirl?: PaletteOptions['primary'];
     burning?: PaletteOptions['primary'];
     crystallize?: PaletteOptions['primary'];
+    star1?: PaletteOptions['primary'];
+    star2?: PaletteOptions['primary'];
+    star3?: PaletteOptions['primary'];
+    star4?: PaletteOptions['primary'];
+    star5?: PaletteOptions['primary'];
   }
 }
 
@@ -99,6 +109,11 @@ declare module "@mui/material/Chip" {
     electro: true;
     anemo: true;
     physical: true;
+    star1: true;
+    star2: true;
+    star3: true;
+    star4: true;
+    star5: true;
   }
 }
 
@@ -246,6 +261,26 @@ export const theme = createTheme({
       color: { main: "#f8ba4e", },
       name: "crystallize"
     }),
+    star1: defaultTheme.palette.augmentColor({
+      color: { main: "#838f99", },
+      name: "star1"
+    }),
+    star2: defaultTheme.palette.augmentColor({
+      color: { main: "#5e966c", },
+      name: "star2"
+    }),
+    star3: defaultTheme.palette.augmentColor({
+      color: { main: "#499fb3", },
+      name: "star3"
+    }),
+    star4: defaultTheme.palette.augmentColor({
+      color: { main: "#b886ca", },
+      name: "star4"
+    }),
+    star5: defaultTheme.palette.augmentColor({
+      color: { main: "#e6ac54", },
+      name: "star5"
+    })
   },
   typography: {
     button: {


### PR DESCRIPTION
Change `ArtifactDisplay` in `CharacterCard` to display artifacts in one row.
Also shows rarity, level and main stat value. Can also hover the main stat value to get the main stat name. Placeholder icons are used when an artifact slot is missing

Venti is triple EM, which used to take 3 rows. Border indicates rarity. Placeholder icons are not properly centered because the SVGs are not aligned 
![image](https://user-images.githubusercontent.com/36019388/161882672-dba804bb-1c61-4457-b43a-03e610e321c7.png)

Also added a couple tooltips. One for the inventory icon in `ArtifactCardNano` and one for the "# of threads" dropdown to explain what the option does.
![image](https://user-images.githubusercontent.com/36019388/161882921-bb967f39-6569-43c5-ae6b-4f5c19f0c02a.png)
![image](https://user-images.githubusercontent.com/36019388/161883721-9f6a6f05-5d92-4a99-b0c2-17527a6d21b0.png)

Also added an "Exclude Artifacts" button in the Character > Artifacts page, and in `ArtifactBuildDisplayItem`. If you don't agree with this button, I can remove it, but it is pretty handy.
![image](https://user-images.githubusercontent.com/36019388/161882850-455bd282-5e88-46b6-bc27-243da71b9e1d.png)
![image](https://user-images.githubusercontent.com/36019388/161882895-ac232c5a-e701-4762-831e-31f4b9fb1f0e.png)
