### PR TITLE
Add tooltips

### DIFF
--- a/src/Components/Artifact/ArtifactCardNano.tsx
+++ b/src/Components/Artifact/ArtifactCardNano.tsx
@@ -85,5 +85,5 @@ function SubstatDisplay({ stat }: { stat: ICachedSubstat }) {
 }
 function LocationIcon({ location }) {
   const characterSheet = usePromise(CharacterSheet.get(location ?? ""), [location])
-  return characterSheet ? <BootstrapTooltip placement="top" title={<Typography>{characterSheet.name}</Typography>}><ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /></BootstrapTooltip> : <BusinessCenter />
+  return characterSheet ? <BootstrapTooltip placement="right-end" title={<Typography>{characterSheet.name}</Typography>}><ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /></BootstrapTooltip> : <BusinessCenter />
 }

--- a/src/Components/Artifact/ArtifactCardNano.tsx
+++ b/src/Components/Artifact/ArtifactCardNano.tsx
@@ -85,5 +85,5 @@ function SubstatDisplay({ stat }: { stat: ICachedSubstat }) {
 }
 function LocationIcon({ location }) {
   const characterSheet = usePromise(CharacterSheet.get(location ?? ""), [location])
-  return characterSheet ? <ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /> : <BusinessCenter />
+  return characterSheet ? <BootstrapTooltip placement="top" title={<Typography>{characterSheet.name}</Typography>}><ImgIcon src={characterSheet.thumbImgSide} sx={{ height: "3em", marginTop: "-1.5em", marginLeft: "-0.5em" }} /></BootstrapTooltip> : <BusinessCenter />
 }

--- a/src/PageBuild/BuildDisplay.tsx
+++ b/src/PageBuild/BuildDisplay.tsx
@@ -8,6 +8,7 @@ import { Link as RouterLink } from 'react-router-dom';
 // eslint-disable-next-line
 import Worker from "worker-loader!./BackgroundWorker";
 import ArtifactLevelSlider from '../Components/Artifact/ArtifactLevelSlider';
+import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';
 import CharacterDropdownButton from '../Components/Character/CharacterDropdownButton';
@@ -487,11 +488,13 @@ export default function BuildDisplay({ location: { characterKey: propCharacterKe
                   {maxBuildsToShowList.map(v => <MenuItem key={v}
                     onClick={() => buildSettingsDispatch({ maxBuildsToShow: v })}>{v} {v === 1 ? "Build" : "Builds"}</MenuItem>)}
                 </DropdownButton>
-                <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
-                  title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
-                  {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
-                    onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
-                </DropdownButton>
+                <BootstrapTooltip title={<Typography>Increasing the number of threads will speed up build time, but will use more CPU power.</Typography>}>
+                  <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
+                    title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
+                    {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
+                      onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
+                  </DropdownButton>
+                </BootstrapTooltip>
                 {/* </Tooltip> */}
                 <Button
                   disabled={!generatingBuilds}

--- a/src/PageBuild/BuildDisplay.tsx
+++ b/src/PageBuild/BuildDisplay.tsx
@@ -8,7 +8,6 @@ import { Link as RouterLink } from 'react-router-dom';
 // eslint-disable-next-line
 import Worker from "worker-loader!./BackgroundWorker";
 import ArtifactLevelSlider from '../Components/Artifact/ArtifactLevelSlider';
-import BootstrapTooltip from '../Components/BootstrapTooltip';
 import CardDark from '../Components/Card/CardDark';
 import CardLight from '../Components/Card/CardLight';
 import CharacterDropdownButton from '../Components/Character/CharacterDropdownButton';
@@ -488,13 +487,17 @@ export default function BuildDisplay({ location: { characterKey: propCharacterKe
                   {maxBuildsToShowList.map(v => <MenuItem key={v}
                     onClick={() => buildSettingsDispatch({ maxBuildsToShow: v })}>{v} {v === 1 ? "Build" : "Builds"}</MenuItem>)}
                 </DropdownButton>
-                <BootstrapTooltip title={<Typography>Increasing the number of threads will speed up build time, but will use more CPU power.</Typography>}>
-                  <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
-                    title={<span><b>{maxWorkers}</b> {maxBuildsToShow === 1 ? "Thread" : "Threads"}</span>}>
-                    {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
-                      onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
-                  </DropdownButton>
-                </BootstrapTooltip>
+                <DropdownButton disabled={generatingBuilds || !characterKey} color="info"
+                  title={<span><b>{maxWorkers}</b> {maxWorkers === 1 ? "Thread" : "Threads"}</span>}>
+                  <MenuItem>
+                    <Typography variant="caption" color="info.main">
+                      Increasing the number of threads will speed up build time, but will use more CPU power.
+                    </Typography>
+                  </MenuItem>
+                  <Divider />
+                  {range(1, navigator.hardwareConcurrency || 4).reverse().map(v => <MenuItem key={v}
+                    onClick={() => setMaxWorkers(v)}>{v} {v === 1 ? "Thread" : "Threads"}</MenuItem>)}
+                </DropdownButton>
                 {/* </Tooltip> */}
                 <Button
                   disabled={!generatingBuilds}


### PR DESCRIPTION
Added a couple tooltips. One for the inventory icon in `ArtifactCardNano` and one for the "# of threads" dropdown to explain what the option does.
![image](https://user-images.githubusercontent.com/36019388/162112654-1881cac4-5410-4550-bbeb-74cb87cca433.png)
![image](https://user-images.githubusercontent.com/36019388/161883721-9f6a6f05-5d92-4a99-b0c2-17527a6d21b0.png)

Below is now removed, keeping text for history-keeping
~~Also added an "Exclude Artifacts" button in the Character > Artifacts page, and in `ArtifactBuildDisplayItem`. If you don't agree with this button, I can remove it, but it is pretty handy.
![image](https://user-images.githubusercontent.com/36019388/161882850-455bd282-5e88-46b6-bc27-243da71b9e1d.png)
![image](https://user-images.githubusercontent.com/36019388/161882895-ac232c5a-e701-4762-831e-31f4b9fb1f0e.png)~~
