### PR TITLE
Update artifact display, add teammate display

### DIFF
--- a/src/Components/Artifact/SlotNameWIthIcon.tsx
+++ b/src/Components/Artifact/SlotNameWIthIcon.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { useTranslation } from "react-i18next"
 import { faCirclet, faFlower, faGoblet, faPlume, faSands } from '../faIcons'
 import { SlotKey } from "../../Types/consts"
+import { SizeProp } from "@fortawesome/fontawesome-svg-core"
 
 export const SlotIconSVG: StrictDict<SlotKey, any> = {
   flower: faFlower,
@@ -11,8 +12,8 @@ export const SlotIconSVG: StrictDict<SlotKey, any> = {
   circlet: faCirclet
 }
 
-export function artifactSlotIcon(slotKey: SlotKey) {
-  return <FontAwesomeIcon icon={SlotIconSVG[slotKey]} key={slotKey} className="fa-fw" />
+export function artifactSlotIcon(slotKey: SlotKey, size?: SizeProp) {
+  return <FontAwesomeIcon icon={SlotIconSVG[slotKey]} key={slotKey} className="fa-fw" size={size} />
 }
 
 export default function SlotNameWithIcon({ slotKey }: { slotKey: SlotKey }) {

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -34,9 +34,9 @@ type CharacterCardProps = {
   weaponChildren?: Displayable,
   characterChildren?: Displayable,
   footer?: Displayable,
-  hideTeammates?: boolean,
+  isTeammateCard?: boolean,
 }
-export default function CharacterCard({ characterKey, artifactChildren, weaponChildren, characterChildren, onClick, onClickHeader, footer, hideTeammates }: CharacterCardProps) {
+export default function CharacterCard({ characterKey, artifactChildren, weaponChildren, characterChildren, onClick, onClickHeader, footer, isTeammateCard }: CharacterCardProps) {
   const { teamData: teamDataContext } = useContext(DataContext)
   const teamData = useTeamData(teamDataContext ? "" : characterKey) ?? (teamDataContext as TeamData | undefined)
   const { character, characterSheet, target: data } = teamData?.[characterKey] ?? {}
@@ -63,16 +63,16 @@ export default function CharacterCard({ characterKey, artifactChildren, weaponCh
           <Header onClick={!onClick ? onClickHeader : undefined} />
           <CardContent sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 1, flexGrow: 1 }}>
             <Artifacts />
-            {artifactChildren}
-            {!hideTeammates && <Grid container columns={4} spacing={0.5}>
+            {!isTeammateCard && <Grid container columns={4} spacing={0.75}>
               <Weapon weaponId={character.equippedWeapon} />
               <Teammate teammate={character.team[0]} />
               <Teammate teammate={character.team[1]} />
               <Teammate teammate={character.team[2]} />
             </Grid>}
-            {hideTeammates && <WeaponFullCard weaponId={character.equippedWeapon} />}
+            {isTeammateCard && <WeaponFullCard weaponId={character.equippedWeapon} />}
+            {!isTeammateCard && <Stats />}
             {weaponChildren}
-            <Stats />
+            {artifactChildren}
             {characterChildren}
           </CardContent>
         </ConditionalWrapper>
@@ -161,7 +161,7 @@ function Artifacts() {
     [data, database]) as Array<[SlotKey, ICachedArtifact | undefined]>;
   if (!artifactSheets) return null
 
-  return <Grid direction="row" container spacing={0.5} columns={5}>
+  return <Grid direction="row" container spacing={0.75} columns={5}>
     {artifacts.map(([key, art]: [SlotKey, ICachedArtifact | undefined]) => {
       // Blank artifact slot icon
       if (!art) return <Grid item key={key} xs={1}>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -254,12 +254,12 @@ function TeammateDisplay({ team }) {
                   className={`grad-${teammateSheet.rarity}star`}
                 />
               </Grid>
-              <Grid item xs={1} pl={0.5} pt={0.25} sx={{ backgroundColor: theme.palette.contentDark.main }}>
-                <Grid container direction="column" columns={2}>
-                  <Typography variant='subtitle1' sx={{ display: "flex", mb: 0.25 }} >
+              <Grid item xs={1} sx={{ backgroundColor: theme.palette.contentDark.main }}>
+                <Grid container direction="column" columns={2} p={1}>
+                  <Typography variant='subtitle1' gutterBottom sx={{ display: "flex", gap: 1 }} >
                     <SqBadge color="primary">Lv. {teammates[i]?.level}</SqBadge>
                   </Typography>
-                  <Typography variant='subtitle1' sx={{ display: "flex" }} >
+                  <Typography variant='subtitle1' sx={{ display: "flex", gap: 1 }} >
                     <SqBadge color="secondary">C{teammates[i]?.constellation}</SqBadge>
                   </Typography>
                 </Grid>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -25,7 +25,6 @@ import { ICachedArtifact } from '../Types/artifact';
 import { allSlotKeys, CharacterKey, ElementKey, SlotKey } from '../Types/consts';
 import { ICachedWeapon } from '../Types/weapon';
 import { NodeDisplay } from '../Formula/uiData'
-import { theme } from '../Theme';
 
 type CharacterCardProps = {
   characterKey: CharacterKey | "",
@@ -35,8 +34,9 @@ type CharacterCardProps = {
   weaponChildren?: Displayable,
   characterChildren?: Displayable,
   footer?: Displayable,
+  hideTeammates?: boolean,
 }
-export default function CharacterCard({ characterKey, artifactChildren, weaponChildren, characterChildren, onClick, onClickHeader, footer }: CharacterCardProps) {
+export default function CharacterCard({ characterKey, artifactChildren, weaponChildren, characterChildren, onClick, onClickHeader, footer, hideTeammates }: CharacterCardProps) {
   const { teamData: teamDataContext } = useContext(DataContext)
   const teamData = useTeamData(teamDataContext ? "" : characterKey) ?? (teamDataContext as TeamData | undefined)
   const { character, characterSheet, target: data } = teamData?.[characterKey] ?? {}
@@ -66,7 +66,7 @@ export default function CharacterCard({ characterKey, artifactChildren, weaponCh
             {weaponChildren}
             <ArtifactDisplay />
             {artifactChildren}
-            <TeammateDisplay team={character.team} />
+            {!hideTeammates && <TeammateDisplay team={character.team} />}
             <Stats />
             {characterChildren}
           </CardContent>
@@ -254,7 +254,7 @@ function TeammateDisplay({ team }) {
                   sx={{ transform: "scale(1.5) translate(-5%, 3%)", transformOrigin: "bottom" }}
                 />
               </Grid>
-              <Grid item xs={1} sx={{ backgroundColor: theme.palette.contentDark.main }}>
+              <Grid item xs={1}>
                 <Grid container direction="column" columns={2} pt={0.25} pl={0.25}>
                   <Typography variant='subtitle1' gutterBottom sx={{ display: "flex", gap: 1 }} >
                     <SqBadge color="primary">Lv. {teammates[i]?.level}</SqBadge>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -245,21 +245,21 @@ function TeammateDisplay({ team }) {
         return <Grid item key={team[i]} xs={1}>
           <CardDark>
             <Grid container columns={2}>
-              <Grid item xs={1} mb={-0.5} mr={1.25} ml={-2} mt={-2.5}>
+              <Grid item xs={1} mb={-0.5} className={`grad-${teammateSheet.rarity}star`}>
                 <Box
                   component="img"
                   src={teammateSheet.thumbImgSide}
-                  width="150%"
+                  width="100%"
                   height="auto"
-                  className={`grad-${teammateSheet.rarity}star`}
+                  sx={{ transform: "scale(1.5) translate(-5%, 3%)", transformOrigin: "bottom" }}
                 />
               </Grid>
               <Grid item xs={1} sx={{ backgroundColor: theme.palette.contentDark.main }}>
-                <Grid container direction="column" columns={2} p={1}>
+                <Grid container direction="column" columns={2} pt={1} pl={1}>
                   <Typography variant='subtitle1' gutterBottom sx={{ display: "flex", gap: 1 }} >
                     <SqBadge color="primary">Lv. {teammates[i]?.level}</SqBadge>
                   </Typography>
-                  <Typography variant='subtitle1' sx={{ display: "flex", gap: 1 }} >
+                  <Typography variant='subtitle1' sx={{ display: "flex" }} >
                     <SqBadge color="secondary">C{teammates[i]?.constellation}</SqBadge>
                   </Typography>
                 </Grid>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -208,7 +208,7 @@ function ArtifactDisplay() {
       return <Grid item key={key} xs={1}>
         <CardDark>
           <Box sx={{ textAlign: "center" }}>
-            <Box mb={-2.75}>
+            <Box mb={-3}>
               <Box
                 component="img"
                 src={artifactSheets?.[setKey].slotIcons[slotKey]}
@@ -219,11 +219,11 @@ function ArtifactDisplay() {
             </Box>
             <Typography variant='subtitle1' sx={{ display: "flex" }} >
               <BootstrapTooltip placement="top" title={<Typography>{cacheValueString(mainStatVal, KeyMap.unit(mainStatKey))}{KeyMap.unit(mainStatKey)} {KeyMap.getStr(mainStatKey)}</Typography>}>
-                <SqBadge color="secondary" sx={{ ml: "auto", mr: 0, mb: -0.2 }}>{StatIcon[mainStatKey]}</SqBadge>
+                <SqBadge color="secondary" sx={{ ml: "auto", mr: 0, mb: -0.1, borderRadius: "0.25em 0.25em 0em 0.25em" }}>{StatIcon[mainStatKey]}</SqBadge>
               </BootstrapTooltip>
             </Typography>
             <Typography variant='subtitle1' sx={{ display: "flex", mb: 0 }} >
-              <SqBadge color={levelVariant as any} sx={{ width: "100%" }}>+{level}</SqBadge>
+              <SqBadge color={levelVariant as any} sx={{ width: "100%", borderRadius: 0 }}>+{level}</SqBadge>
             </Typography>
           </Box>
         </CardDark>

--- a/src/PageCharacter/CharacterCard.tsx
+++ b/src/PageCharacter/CharacterCard.tsx
@@ -255,7 +255,7 @@ function TeammateDisplay({ team }) {
                 />
               </Grid>
               <Grid item xs={1} sx={{ backgroundColor: theme.palette.contentDark.main }}>
-                <Grid container direction="column" columns={2} pt={1} pl={1}>
+                <Grid container direction="column" columns={2} pt={0.25} pl={0.25}>
                   <Typography variant='subtitle1' gutterBottom sx={{ display: "flex", gap: 1 }} >
                     <SqBadge color="primary">Lv. {teammates[i]?.level}</SqBadge>
                   </Typography>

--- a/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
@@ -103,7 +103,7 @@ function TeammateDisplay({ index }: { index: number }) {
         artifactChildren={<CharArtifactCondDisplay />}
         weaponChildren={<CharWeaponCondDisplay />}
         characterChildren={<CharTalentCondDisplay />}
-        hideTeammates
+        isTeammateCard
       />
     </DataContext.Provider>}
   </CardLight>
@@ -123,6 +123,7 @@ function CharArtifactCondDisplay() {
 function CharWeaponCondDisplay() {
   const { teamData, character: { key: charKey } } = useContext(DataContext)
   const weaponSheet = teamData[charKey]!.weaponSheet
+  if (!weaponSheet.document) return null
   return <DocumentDisplay sections={weaponSheet.document} teamBuffOnly={true} />
 }
 function CharTalentCondDisplay() {
@@ -130,5 +131,6 @@ function CharTalentCondDisplay() {
   const characterSheet = teamData[charKey]!.characterSheet
   const talent = characterSheet.getTalent(data.get(input.charEle).value as ElementKey)!
   const sections = Object.values(talent.sheets).flatMap(sts => sts.sections)
+  if (!sections) return null
   return <DocumentDisplay sections={sections} teamBuffOnly={true} />
 }

--- a/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
@@ -103,6 +103,7 @@ function TeammateDisplay({ index }: { index: number }) {
         artifactChildren={<CharArtifactCondDisplay />}
         weaponChildren={<CharWeaponCondDisplay />}
         characterChildren={<CharTalentCondDisplay />}
+        hideTeammates
       />
     </DataContext.Provider>}
   </CardLight>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36019388/163518918-bbeb65c0-5b95-4e4a-b1ff-c841681eb11d.png)
![image](https://user-images.githubusercontent.com/36019388/163518936-91bf0051-759b-4fbb-855b-41e407f9286d.png)

New scaling demo: https://youtu.be/ZjMqw_P0tFI

One thing I forgot to show in the video is hovering the main stat icon for the value
![chrome_nyQzUWgZ5Q](https://user-images.githubusercontent.com/36019388/163519475-6fe2686c-719c-4caa-88bf-cb148e07b80f.gif)

1 small issue
The side profiles are a bit low resolution when scaled up, since they are 128x128 (vs the 256x256 of the full portrait)
![image](https://user-images.githubusercontent.com/36019388/163519411-e831b710-f80c-4ae7-b6aa-aa2091eaed3a.png)

In team buffs, I've opted to keep the original weapon card to make better use of the space
![image](https://user-images.githubusercontent.com/36019388/163518993-b60e1183-61ed-41f0-a2cf-ea8e5349fe87.png)

Before/after comparison GIFs of the height of the card: https://discord.com/channels/785153694478893126/961187969736265778/964342545398267915