### PR TITLE
Fix small issues, refactor reactions display

### DIFF
--- a/public/locales/en/char_Chongyun.json
+++ b/public/locales/en/char_Chongyun.json
@@ -1,8 +1,8 @@
 {
-  "activeCharField": "Sword, Claymore, and Polearm wielding characters within the Frost Field",
   "infusion": "Sword, Claymore and Polearm Cryo Infusion",
   "passive2": "Summoned Sword DMG",
-  "asc4Cond": "Opponents hit by Rimechase Blade",
-  "constellation1":"Ice Blade DMG",
-  "constellation6":"Enemy with a lower percentage of their Max HP remaining "
+  "asc4Cond": "Opponents hit by Rimechaser Blade",
+  "constellation1": "Ice Blade DMG",
+  "constellation6": "Enemy with a lower percentage of their Max HP remaining",
+  "blades": "Spirit Blades summoned"
 }

--- a/src/Data/Artifacts/OceanHuedClam/index.tsx
+++ b/src/Data/Artifacts/OceanHuedClam/index.tsx
@@ -1,17 +1,17 @@
 import { input } from '../../../Formula'
 import { Data } from '../../../Formula/type'
-import { constant, infoMut, percent, prod, greaterEq } from '../../../Formula/utils'
+import { infoMut, percent, prod, greaterEq } from '../../../Formula/utils'
 import { ArtifactSetKey } from '../../../Types/consts'
-import { customDmgNode } from '../../Characters/dataUtil'
 import { ArtifactSheet, IArtifactSheet } from '../ArtifactSheet'
 import { dataObjForArtifactSheet } from '../dataUtil'
 import icons from './icons'
 const key: ArtifactSetKey = "OceanHuedClam"
 const set2 = greaterEq(input.artSet.OceanHuedClam, 2, percent(0.15))
 const heal = greaterEq(input.artSet.OceanHuedClam, 4,
-  customDmgNode(prod(percent(0.9), 30000), "elemental", {
-    hit: { ele: constant("physical"), hitMode: constant("hit") }
-  })
+  prod(
+    prod(percent(0.9), 30000),
+    input.enemy.physical_resMulti
+  )
 )
 
 export const data: Data = dataObjForArtifactSheet(key, {

--- a/src/Data/Artifacts/ThunderingFury/index.tsx
+++ b/src/Data/Artifacts/ThunderingFury/index.tsx
@@ -8,14 +8,16 @@ import icons from './icons'
 const key: ArtifactSetKey = "ThunderingFury"
 
 const set2 = greaterEq(input.artSet.ThunderingFury, 2, percent(0.15))
-const set4 = greaterEq(input.artSet.ThunderingFury, 4, percent(0.40))
+const overloaded_dmg_ = greaterEq(input.artSet.ThunderingFury, 4, percent(0.40))
+const electrocharged_dmg_ = { ...overloaded_dmg_ }
+const superconduct_dmg_ = { ...overloaded_dmg_ }
 
 export const data: Data = dataObjForArtifactSheet(key, {
   premod: {
     electro_dmg_: set2,
-    overloaded_dmg_: set4,
-    electrocharged_dmg_: set4,
-    superconduct_dmg_: set4
+    overloaded_dmg_,
+    electrocharged_dmg_,
+    superconduct_dmg_,
   },
 })
 
@@ -27,7 +29,11 @@ const sheet: IArtifactSheet = {
     4: {
       document: [{
         fields: [{
-          node: set4,
+          node: overloaded_dmg_,
+        }, {
+          node: electrocharged_dmg_,
+        }, {
+          node: superconduct_dmg_,
         }]
       }]
     }

--- a/src/Data/Characters/Chongyun/index.tsx
+++ b/src/Data/Characters/Chongyun/index.tsx
@@ -2,7 +2,7 @@ import { CharacterData } from 'pipeline'
 import { input, target } from '../../../Formula'
 import { constant, equal, equalStr, greaterEq, infoMut, lookup, percent, prod } from '../../../Formula/utils'
 import { CharacterKey, ElementKey, WeaponTypeKey } from '../../../Types/consts'
-import { cond, trans } from '../../SheetUtil'
+import { cond, st, trans } from '../../SheetUtil'
 import CharacterSheet, { conditionalHeader, ICharacterSheet, normalSrc, talentTemplate } from '../CharacterSheet'
 import { customDmgNode, dataObjForCharacterSheet, dmgNode } from '../dataUtil'
 import { banner, burst, c1, c2, c3, c4, c5, c6, card, passive1, passive2, passive3, skill, thumb, thumbSide } from './assets'
@@ -99,13 +99,15 @@ const dmgFormulas = {
   }
 }
 
-const nodeAsc1 = greaterEq(input.asc, 1, percent(0.08))
 const nodeAsc4 = greaterEq(input.asc, 4,
   equal(condAsc4, "hit",
     -0.10
   )
 )
 const activeInArea = equal("activeInArea", condSkill, equal(input.activeCharKey, target.charKey, 1))
+
+const nodeAsc1Disp = greaterEq(input.asc, 1, percent(0.08))
+const nodeAsc1 = equal(activeInArea, 1, nodeAsc1Disp)
 
 const correctWep =
   lookup(target.weaponType,
@@ -199,10 +201,9 @@ const sheet: ICharacterSheet = {
         teamBuff: true,
         value: condSkill,
         path: condSkillPath,
-        name: trm("activeCharField"),
+        name: st("activeCharField"),
         states: {
           activeInArea: {
-            name: "Frost Field",
             fields: [{
               text: trm("infusion"),
               variant: elementKey
@@ -211,7 +212,7 @@ const sheet: ICharacterSheet = {
               value: datamine.skill.infusionDuration,
               unit: "s"
             }, {
-              node: nodeAsc1
+              node: infoMut(nodeAsc1Disp, { key: "atkSPD_" })
             }]
           },
         }
@@ -231,7 +232,7 @@ const sheet: ICharacterSheet = {
             text: tr("burst.skillParams.2"),
             value: datamine.burst.enerCost,
           }, {
-            text: "Spirit Blades Summoned",
+            text: trm("blades"),
             value: data => data.get(input.constellation).value < 6 ? 3 : 4
           }]
         }]

--- a/src/Data/Characters/SangonomiyaKokomi/index.tsx
+++ b/src/Data/Characters/SangonomiyaKokomi/index.tsx
@@ -180,9 +180,9 @@ const sheet: ICharacterSheet = {
         }, {
           text: tr("auto.fields.charged"),
           fields: [{
-            node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.4` })
+            node: infoMut(dmgFormulas.charged.dmg, { key: `char_${key}_gen:auto.skillParams.3` })
           }, {
-            text: tr("auto.skillParams.5"),
+            text: tr("auto.skillParams.4"),
             value: datamine.charged.stamina,
           }]
         }, {

--- a/src/Data/Characters/SangonomiyaKokomi/index.tsx
+++ b/src/Data/Characters/SangonomiyaKokomi/index.tsx
@@ -119,7 +119,7 @@ const dmgFormulas = {
     dmg: dmgNode("atk", datamine.skill.dmg, "skill")
   },
   burst: {
-    dmg: dmgNode("atk", datamine.burst.dmg, "burst"),
+    dmg: dmgNode("hp", datamine.burst.dmg, "burst"),
     heal: customHealNode(sum(
       prod(sum(
         subscript(input.total.burstIndex, datamine.burst.heal_, { key: '_' }),

--- a/src/PageCharacter/CharacterDisplay/CharacterTalentPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterTalentPane.tsx
@@ -9,6 +9,7 @@ import ColorText from "../../Components/ColoredText";
 import ConditionalWrapper from "../../Components/ConditionalWrapper";
 import DocumentDisplay from "../../Components/DocumentDisplay";
 import DropdownButton from "../../Components/DropdownMenu/DropdownButton";
+import { NodeFieldDisplay } from "../../Components/FieldDisplay";
 import StatIcon from "../../Components/StatIcon";
 import useCharacterReducer from "../../ReactHooks/useCharacterReducer";
 import { TalentSheetElementKey } from "../../Types/character";
@@ -93,14 +94,6 @@ export default function CharacterTalentPane() {
     </Grid>
   </>
 }
-const ReactionComponents = {
-  superconduct: SuperConductCard,
-  electrocharged: ElectroChargedCard,
-  overloaded: OverloadedCard,
-  pyroSwirl: SwirlCard,// TODO: Assumes if character can pyro swirl, it can swirl every element. This behaviour will need to be changed for characters that can only swirl specific elements.
-  shattered: ShatteredCard,
-  crystallize: CrystallizeCard,
-}
 function ReactionDisplay() {
   const { data } = useContext(DataContext)
   const reaction = data.getDisplay().reaction as { [key: string]: NodeDisplay }
@@ -108,77 +101,15 @@ function ReactionDisplay() {
     <CardContent>
       <Grid container spacing={1}>
         {Object.entries(reaction).map(([key, node]) => {
-          const Ele = ReactionComponents[key]
-          if (!Ele) return null
-          return <Grid item key={key}><Ele node={node} /></Grid>
+          return <Grid item key={key}>
+            <CardDark><CardContent sx={{ p: 1, "&:last-child": { pb: 1 } }}>
+              <NodeFieldDisplay node={node} />
+            </CardContent></CardDark>
+          </Grid>
         })}
       </Grid>
     </CardContent>
   </CardLight>
-}
-function SuperConductCard({ node }: { node: NodeDisplay }) {
-  return <CardDark><CardContent sx={{ p: 1 }}>
-    <Typography color="superconduct.main">{KeyMap.get(node.info.key!)} {StatIcon.electro}+{StatIcon.cryo} <strong>{valueString(node.value, node.unit)}</strong></Typography>
-  </CardContent></CardDark>
-}
-function ElectroChargedCard({ node }: { node: NodeDisplay }) {
-  return <CardDark><CardContent sx={{ p: 1 }}>
-    <Typography color="electrocharged.main">{KeyMap.get(node.info.key!)} {StatIcon.electro}+{StatIcon.hydro} <strong>{valueString(node.value, node.unit)}</strong></Typography>
-  </CardContent></CardDark>
-}
-function OverloadedCard({ node }: { node: NodeDisplay }) {
-  return <CardDark><CardContent sx={{ p: 1 }}>
-    <Typography color="overloaded.main" >{KeyMap.get(node.info.key!)} {StatIcon.electro}+{StatIcon.pyro} <strong>{valueString(node.value, node.unit)}</strong></Typography>
-  </CardContent></CardDark>
-}
-
-const swirlEleToDisplay = {
-  "pyro": <span><ColorText color="pyro">{KeyMap.get("pyro_swirl_hit")}</ColorText> {StatIcon.pyro} + {StatIcon.anemo}</span>,
-  "electro": <span><ColorText color="electro">{KeyMap.get("electro_swirl_hit")}</ColorText> {StatIcon.electro}+{StatIcon.anemo}</span>,
-  "cryo": <span><ColorText color="cryo">{KeyMap.get("cryo_swirl_hit")}</ColorText> {StatIcon.cryo} + {StatIcon.anemo}</span>,
-  "hydro": <span><ColorText color="hydro">{KeyMap.get("hydro_swirl_hit")}</ColorText> {StatIcon.hydro} + {StatIcon.anemo}</span>
-} as const
-
-function SwirlCard() {
-  const [ele, setele] = useState(Object.keys(swirlEleToDisplay)[0])
-  const { data } = useContext(DataContext)
-  const node = data.getDisplay().reaction![`${ele}Swirl`]!
-  return <CardDark sx={{ display: "flex" }}>
-    <DropdownButton size="small" title={swirlEleToDisplay[ele]} color="success">
-      {Object.entries(swirlEleToDisplay).map(([key, element]) => <MenuItem key={key} selected={ele === key} disabled={ele === key} onClick={() => setele(key)}>{element}</MenuItem>)}
-    </DropdownButton>
-    <Box sx={{ color: `${ele}.main`, p: 1 }}><strong>{valueString(node.value, node.unit)}</strong></Box>
-  </CardDark>
-}
-
-function ShatteredCard({ node }: { node: NodeDisplay }) {
-  const information = <BootstrapTooltip placement="top" title={<Typography>Claymores, Plunging Attacks and <ColorText color="geo">Geo DMG</ColorText></Typography>}>
-    <Box component="span" sx={{ cursor: "help" }}><FontAwesomeIcon icon={faQuestionCircle} /></Box>
-  </BootstrapTooltip>
-
-  return <CardDark><CardContent sx={{ p: 1 }}>
-    <ColorText color="shattered">{KeyMap.get(node.info.key!)} {StatIcon.hydro}+{StatIcon.cryo}+ <ColorText color="physical"><small>Heavy Attack{information} </small></ColorText> <strong>{valueString(node.value, node.unit)}</strong></ColorText>
-  </CardContent></CardDark>
-}
-
-const crystallizeEleToDisplay = {
-  "geo": <ColorText color="crystallize">{KeyMap.get("crystallize")} {StatIcon.electro}/{StatIcon.hydro}/{StatIcon.pyro}/{StatIcon.cryo}+{StatIcon.geo}</ColorText>,
-  "pyro": <span><ColorText color="pyro">{KeyMap.get("pyro_crystallize")}</ColorText> {StatIcon.pyro}+{StatIcon.geo}</span>,
-  "electro": <span><ColorText color="electro">{KeyMap.get("electro_crystallize")}</ColorText> {StatIcon.electro}+{StatIcon.geo}</span>,
-  "cryo": <span><ColorText color="cryo">{KeyMap.get("cryo_crystallize")}</ColorText> {StatIcon.cryo}+{StatIcon.geo}</span>,
-  "hydro": <span><ColorText color="hydro">{KeyMap.get("hydro_crystallize")}</ColorText> {StatIcon.hydro}+{StatIcon.geo}</span>
-} as const
-
-function CrystallizeCard() {
-  const [ele, setele] = useState(Object.keys(crystallizeEleToDisplay)[0])
-  const { data } = useContext(DataContext)
-  const node = ele === "geo" ? data.getDisplay().reaction!.crystallize! : data.getDisplay().reaction![`${ele}Crystallize`]!
-  return <CardDark sx={{ display: "flex" }}>
-    <DropdownButton size="small" title={crystallizeEleToDisplay[ele]} color="success">
-      {Object.entries(crystallizeEleToDisplay).map(([key, element]) => <MenuItem key={key} selected={ele === key} disabled={ele === key} onClick={() => setele(key)}>{element}</MenuItem>)}
-    </DropdownButton>
-    <Box sx={{ color: `${ele}.main`, p: 1 }}><strong>{valueString(node.value, node.unit)}</strong></Box>
-  </CardDark>
 }
 
 const talentLimits = [1, 1, 2, 4, 6, 8, 10]

--- a/src/PageCharacter/CharacterDisplayCard.tsx
+++ b/src/PageCharacter/CharacterDisplayCard.tsx
@@ -257,6 +257,7 @@ function FormulaCalc({ sectionKey, displayNs }: { displayNs: DisplaySub<NodeDisp
   const { data } = useContext(DataContext)
   const header = usePromise(getDisplayHeader(data, sectionKey), [data, sectionKey])
   if (!header) return null
+  if (Object.entries(displayNs).every(([_, node]) => node.isEmpty)) return null
   const { title, icon, action } = header
   return <CardDark sx={{ mb: 1 }}>
     <CardHeader avatar={icon && <ImgIcon size={2} sx={{ m: -1 }} src={icon} />} title={title} action={action} titleTypographyProps={{ variant: "subtitle1" }} />


### PR DESCRIPTION
Fix Kokomi burst scaling - Fixes #230
Fix Kokomi charged attack text - Fixes #230
Fix OHC damage calculation - Fixes #238
Fix blank formula cards showing in formula dropdown
Fix Thundering Fury 4p not showing all fields, and showing incorrectly in formulas
Refactor reaction fields to use NodeFieldDisplay
- With this change, we lose the dropdown for Crystallize+element and Swirl+element. And we also lose the elemental icons, but I feel like those weren't necessary
![image](https://user-images.githubusercontent.com/36019388/163699452-83449329-a5dc-41ae-ade3-fe5f7543a169.png)
It gets more bulky in worst-case scenario, if that is a dealbreaker
![image](https://user-images.githubusercontent.com/36019388/163699461-37c6beab-f01f-438c-8d6e-58542b44b647.png)

Fix Chongyun A1 always applying,
Fix some Chongyun strings

Trying a 2nd PR to hopefully automatically link the issues. If this doesn't work, then the issues will have to be manually linked