### PR TITLE
Fix resonance tooltip, adjust conditional tooltip

### DIFF
--- a/src/Components/Conditional/ConditionalDisplay.tsx
+++ b/src/Components/Conditional/ConditionalDisplay.tsx
@@ -1,6 +1,6 @@
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { CardContent, CardHeader, Divider, ListItem, Typography } from "@mui/material"
+import { Box, CardContent, CardHeader, Divider, ListItem, Typography } from "@mui/material"
 import { useContext } from "react"
 import { DataContext, dataContextObj } from "../../DataContext"
 import { Data } from "../../Formula/type"
@@ -31,9 +31,9 @@ export default function ConditionalDisplay({ conditional, hideHeader = false, hi
   let { icon, title, action } = conditional.header ?? {}
   icon = evalIfFunc(icon, data)
   const fields = condVal && conditional.states[condVal]?.fields
-  const displayTitle = hideDesc ? title : title && <BootstrapTooltip placement="top" title={<Typography>{description}</Typography>}>
-    <span>{title} <FontAwesomeIcon icon={faInfoCircle} /></span>
-  </BootstrapTooltip>
+  const displayTitle = hideDesc ? title : title && <span>{title} <BootstrapTooltip placement="top" title={<Typography>{description}</Typography>}>
+    <Box component="span" sx={{ cursor: "help" }}><FontAwesomeIcon icon={faInfoCircle} /></Box>
+  </BootstrapTooltip></span>
   return <CardDark>
     {!hideHeader && conditional.header && <CardHeader avatar={icon} title={displayTitle} action={action} titleTypographyProps={{ variant: "subtitle2" }} />}
     {!hideHeader && conditional.header && <Divider />}

--- a/src/Components/DocumentDisplay.tsx
+++ b/src/Components/DocumentDisplay.tsx
@@ -28,7 +28,6 @@ export default function DocumentDisplay({ sections, teamBuffOnly, hideDesc = fal
 function SectionDisplay({ section, teamBuffOnly, hideDesc = false }: { section: DocumentSection, teamBuffOnly?: boolean, hideDesc?: boolean, }) {
   const { data } = useContext(DataContext)
   const talentText = evalIfFunc(section.text, data)
-  const description = evalIfFunc(section.fieldsDescription, data)
   const fields = section.fields ?? []
   let { icon, title, action } = section.fieldsHeader ?? {}
   icon = evalIfFunc(icon, data)
@@ -38,7 +37,6 @@ function SectionDisplay({ section, teamBuffOnly, hideDesc = false }: { section: 
       {teamBuffOnly && talentText && <CardContent>{talentText}</CardContent>}
       {section.fieldsHeader && <CardHeader avatar={icon} title={title} action={action} titleTypographyProps={{ variant: "subtitle2" }} />}
       {section.fieldsHeader && <Divider />}
-      {teamBuffOnly && description && <CardContent>{description}</CardContent>}
       {fields.length > 0 && <FieldDisplayList>
         {fields?.map?.((field, i) => <FieldDisplay key={i} field={field} component={ListItem} />)}
       </FieldDisplayList>}

--- a/src/Data/Characters/CharacterSheet.tsx
+++ b/src/Data/Characters/CharacterSheet.tsx
@@ -95,9 +95,8 @@ export const talentTemplate = (talentKey: TalentSheetElementKey, tr: (string) =>
 TODO: refactor stage 1 this function to be
 sectionTemplate(docSection:DocumentSection): DocumentSection
 */
-export const sectionTemplate = (talentKey: TalentSheetElementKey, tr: (string) => Displayable, img: string, fields?: IFieldDisplay[], conditional?: IConditional, fieldsCanShow?: (data: UIData) => boolean, teamBuff?: boolean, showFieldsHeaderDesc?: boolean): DocumentSection => ({
-  fieldsHeader: showFieldsHeaderDesc ? conditionalHeader(talentKey, tr, img) : undefined,
-  fieldsDescription: showFieldsHeaderDesc ? tr(`${talentKey}.description`) : undefined,
+export const sectionTemplate = (talentKey: TalentSheetElementKey, tr: (string) => Displayable, img: string, fields?: IFieldDisplay[], conditional?: IConditional, fieldsCanShow?: (data: UIData) => boolean, teamBuff?: boolean, showFieldsHeader?: boolean): DocumentSection => ({
+  fieldsHeader: showFieldsHeader ? conditionalHeader(talentKey, tr, img) : undefined,
   fields,
   canShow: fieldsCanShow,
   teamBuff,

--- a/src/Data/Characters/Shenhe/index.tsx
+++ b/src/Data/Characters/Shenhe/index.tsx
@@ -297,7 +297,6 @@ const sheet: ICharacterSheet = {
         ...sectionTemplate("constellation6", tr, c6, [{
           text: tr("constellation6.description")
         }], undefined, data => data.get(input.constellation).value >= 6, true, true),
-        fieldsDescription: ""
       }]),
       burst: talentTemplate("burst", tr, burst, [{
         node: infoMut(dmgFormulas.burst.dmg, { key: `char_${key}_gen:burst.skillParams.0` }),

--- a/src/Data/Resonance.tsx
+++ b/src/Data/Resonance.tsx
@@ -13,6 +13,7 @@ const trm = (strKey: string) => <Translate ns="elementalResonance" key18={strKey
 
 type IResonance = {
   name: Displayable,
+  desc: Displayable,
   icon: Displayable,
   canShow: (data: UIData) => boolean
   sections: DocumentSection[]
@@ -24,11 +25,11 @@ greaterEq(sum(...allElementsWithPhy.map(i => min(1, tally[i]))), 4, percent(0.15
 
 const protectiveCanopy: IResonance = {
   name: tr("ProtectiveCanopy.name"),
+  desc: tr("ProtectiveCanopy.desc"),
   icon: <span>{StatIcon.anemo} {StatIcon.geo} {StatIcon.pyro} {StatIcon.hydro} {StatIcon.cryo} {StatIcon.electro} x4</span>,
   canShow: (data: UIData) => allElements.filter(e => data.get(tally[e]).value >= 1).length === 4,
   sections: [{
     teamBuff: true,
-    text: tr("ProtectiveCanopy.desc"),
     fields: Object.values(pcNodes).map(node => ({ node }))
   }]
 }
@@ -37,11 +38,11 @@ const protectiveCanopy: IResonance = {
 const ffNode = greaterEq(tally.pyro, 2, percent(0.25))
 const ferventFlames: IResonance = {
   name: tr("FerventFlames.name"),
+  desc: tr("FerventFlames.desc"),
   icon: <span>{StatIcon.pyro} {StatIcon.pyro}</span>,
   canShow: (data: UIData) => data.get(tally.pyro).value >= 2,
   sections: [{
     teamBuff: true,
-    text: tr("FerventFlames.desc"),
     fields: [{
       text: st("effectDuration.cryo"),
       value: -40,
@@ -56,11 +57,11 @@ const ferventFlames: IResonance = {
 const swNode = greaterEq(tally.hydro, 2, percent(0.25))
 const soothingWaters: IResonance = {
   name: tr("SoothingWater.name"),
+  desc: tr("SoothingWater.desc"),
   icon: <span>{StatIcon.hydro} {StatIcon.hydro}</span>,
   canShow: (data: UIData) => data.get(tally.hydro).value >= 2,
   sections: [{
     teamBuff: true,
-    text: tr("SoothingWater.desc"),
     fields: [{
       text: st("effectDuration.pyro"),
       value: -40,
@@ -77,11 +78,11 @@ const condSI = condReadNode(condSIPath)
 const siNode = greaterEq(tally.cryo, 2, equal(condSI, "on", percent(0.15)))
 const shatteringIce: IResonance = {
   name: tr("ShatteringIce.name"),
+  desc: tr("ShatteringIce.desc"),
   icon: <span>{StatIcon.cryo} {StatIcon.cryo}</span>,
   canShow: (data: UIData) => data.get(tally.cryo).value >= 2,
   sections: [{
     teamBuff: true,
-    text: tr("ShatteringIce.desc"),
     fields: [{
       text: st("effectDuration.electro"),
       value: -40,
@@ -110,11 +111,11 @@ const shatteringIce: IResonance = {
 // High Voltage
 const highVoltage: IResonance = {
   name: tr("HighVoltage.name"),
+  desc: tr("HighVoltage.desc"),
   icon: <span>{StatIcon.electro} {StatIcon.electro}</span>,
   canShow: (data: UIData) => data.get(tally.electro).value >= 2,
   sections: [{
     teamBuff: true,
-    text: tr("HighVoltage.desc"),
     fields: [{
       text: st("effectDuration.hydro"),
       value: -40,
@@ -129,11 +130,11 @@ const iwNodeMove = greaterEq(tally.anemo, 2, percent(0.1))
 const iwNodeCD = greaterEq(tally.anemo, 2, percent(-0.05))
 const impetuousWinds: IResonance = {
   name: tr("ImpetuousWinds.name"),
+  desc: tr("ImpetuousWinds.desc"),
   icon: <span>{StatIcon.anemo} {StatIcon.anemo}</span>,
   canShow: (data: UIData) => data.get(tally.anemo).value >= 2,
   sections: [{
     teamBuff: true,
-    text: tr("ImpetuousWinds.desc"),
     fields: [{
       node: iwNodeStam
     }, {
@@ -152,6 +153,7 @@ const erNodeDMG_ = greaterEq(tally.geo, 2, equal(condER, "on", percent(0.15)))
 const erNodeRes_ = greaterEq(tally.geo, 2, equal(condER, "on", percent(-0.2)))
 const enduringRock: IResonance = {
   name: tr("EnduringRock.name"),
+  desc: tr("EnduringRock.desc"),
   icon: <span>{StatIcon.geo} {StatIcon.geo}</span>,
   canShow: (data: UIData) => data.get(tally.geo).value >= 2,
   sections: [{

--- a/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
+++ b/src/PageCharacter/CharacterDisplay/CharacterTeamBuffsPane.tsx
@@ -1,7 +1,10 @@
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { PersonAdd } from "@mui/icons-material";
-import { CardContent, CardHeader, Divider, Grid } from "@mui/material";
+import { CardContent, CardHeader, Divider, Grid, Typography } from "@mui/material";
 import { Box } from "@mui/system";
 import React, { useContext, useMemo } from 'react';
+import BootstrapTooltip from "../../Components/BootstrapTooltip";
 import CardLight from "../../Components/Card/CardLight";
 import CharacterDropdownButton from "../../Components/Character/CharacterDropdownButton";
 import DocumentDisplay from "../../Components/DocumentDisplay";
@@ -59,15 +62,17 @@ export function TeamBuffDisplay() {
 function ResonanceDisplay() {
   const { data } = useContext(DataContext)
   return <>
-    {resonanceSheets.map((res, i) =>
-      <CardLight key={i} sx={{ opacity: res.canShow(data) ? 1 : 0.5, }}>
-        <CardHeader title={res.name} action={res.icon} titleTypographyProps={{ variant: "subtitle2" }} />
+    {resonanceSheets.map((res, i) => {
+      const icon = <BootstrapTooltip placement="top" title={<Typography>{res.desc}</Typography>}>{<Box component="span" sx={{ cursor: "help" }}><FontAwesomeIcon icon={faInfoCircle} /></Box>}</BootstrapTooltip>
+      const title = <span>{res.name} {icon}</span>
+      return <CardLight key={i} sx={{ opacity: res.canShow(data) ? 1 : 0.5, }}>
+        <CardHeader title={title} action={res.icon} titleTypographyProps={{ variant: "subtitle2" }} />
         {res.canShow(data) && <Divider />}
         {res.canShow(data) && <CardContent>
-          <DocumentDisplay sections={res.sections} teamBuffOnly={true} />
+          <DocumentDisplay sections={res.sections} teamBuffOnly hideDesc/>
         </CardContent>}
       </CardLight>
-    )}
+    })}
   </>
 }
 function TeammateDisplay({ index }: { index: number }) {

--- a/src/Types/sheet.ts
+++ b/src/Types/sheet.ts
@@ -10,7 +10,6 @@ export interface DocumentSection {
     icon?: Displayable | ((data: UIData) => Displayable);
     action?: Displayable;
   }
-  fieldsDescription?: Displayable | ((data: UIData) => Displayable);
   fields?: IFieldDisplay[]
   conditional?: IConditional
   teamBuff?: boolean


### PR DESCRIPTION
Didn't mean to publish this branch on the main repo, woops
Fix #233 - Move tooltip to the resonance card itself, so it is always visible
![chrome_1kseLE9Q18](https://user-images.githubusercontent.com/36019388/164573166-6492296d-b25b-4794-bcd9-cba90fc1cb6f.gif)

I also standardized the tooltip for conditionals to appear above the icon
