### PR TITLE
Numerous fixes

### DIFF
--- a/public/locales/en/char_Diona.json
+++ b/public/locales/en/char_Diona.json
@@ -2,7 +2,5 @@
   "skillDuration" : "Duration per Paw",
   "pressShield" : "Shield DMG Absorption",
   "holdShield" : "Hold Shield DMG Absorption",
-  "a1shielded" : "Character shielded by <strong>Icy Paws</strong>",
-  "c6below" : "Active character within radius below or equal to 50% HP",
-  "c6above" : "Active character within radius above 50% HP"
+  "a1shielded" : "Character shielded by <strong>Icy Paws</strong>"
 }

--- a/public/locales/en/weapon_MistsplitterReforged.json
+++ b/public/locales/en/weapon_MistsplitterReforged.json
@@ -1,0 +1,3 @@
+{
+  "emblem": "Mistsplitter's Emblem"
+}

--- a/src/Components/Artifact/ArtifactCardPico.tsx
+++ b/src/Components/Artifact/ArtifactCardPico.tsx
@@ -47,7 +47,7 @@ export default function ArtifactCardPico({ artifactObj: art, slotKey: key }: { a
         maxHeight="100%"
       />
     </ArtifactSetSlotTooltip>
-    <Typography sx={{ position: "absolute", lineHeight: 1, pointerEvents: "none" }} variant="subtitle2"><SqBadge color={levelVariant as any}>+{level}</SqBadge></Typography>
+    <Typography sx={{ position: "absolute", m: -0.2, lineHeight: 1, pointerEvents: "none" }} variant="subtitle2"><SqBadge color={levelVariant as any}>+{level}</SqBadge></Typography>
     <Typography variant='h6' sx={{ position: "absolute", bottom: 0, right: 0, lineHeight: 1, }}>
       <BootstrapTooltip placement="top" title={<Typography>{cacheValueString(mainStatVal, KeyMap.unit(mainStatKey))}{KeyMap.unit(mainStatKey)} {KeyMap.getStr(mainStatKey)}</Typography>} disableInteractive>
         <SqBadge color={color} sx={{ p: 0.25 }}>{element ? uncoloredEleIcons[element] : StatIcon[mainStatKey]}</SqBadge>

--- a/src/Components/Character/CharacterCardPico.tsx
+++ b/src/Components/Character/CharacterCardPico.tsx
@@ -1,15 +1,15 @@
 import { Box, Skeleton, Typography } from '@mui/material';
 import { Suspense } from 'react';
 import Assets from '../../Assets/Assets';
-import BootstrapTooltip from '../BootstrapTooltip';
-import CardDark from '../Card/CardDark';
-import SqBadge from '../SqBadge';
-import StatIcon from '../StatIcon';
 import CharacterSheet from '../../Data/Characters/CharacterSheet';
 import { ascensionMaxLevel } from '../../Data/LevelData';
 import useCharacter from '../../ReactHooks/useCharacter';
 import usePromise from '../../ReactHooks/usePromise';
 import { CharacterKey } from '../../Types/consts';
+import BootstrapTooltip from '../BootstrapTooltip';
+import CardDark from '../Card/CardDark';
+import SqBadge from '../SqBadge';
+import StatIcon from '../StatIcon';
 
 export default function CharacterCardPico({ characterKey = "", index = -1 }: { characterKey: CharacterKey | "", index?: number }) {
   const teammateSheet = usePromise(CharacterSheet.get(characterKey), [characterKey])
@@ -31,7 +31,7 @@ export default function CharacterCardPico({ characterKey = "", index = -1 }: { c
           />
         </Box>
       </BootstrapTooltip>
-      <Typography variant='subtitle1' sx={{ position: "absolute", lineHeight: 1, pointerEvents: "none" }}>
+      <Typography variant='subtitle1' sx={{ position: "absolute", mt: -0.2, lineHeight: 1, pointerEvents: "none" }}>
         <SqBadge color="primary" >{character.level}/{ascensionMaxLevel[character.ascension]}</SqBadge>
       </Typography>
       <Typography variant='subtitle1' sx={{ position: "absolute", bottom: 0, right: 0, lineHeight: 1, pointerEvents: "none" }}>

--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -12,7 +12,7 @@ import { uncoloredEleIcons } from "./StatIcon";
 const infusionVals = {
   "": <span>No Team Melee Infusion</span>,
   "pyro": <span >{uncoloredEleIcons.pyro} <SqBadge>Bennett C6</SqBadge> Fire Ventures with Me</span>,
-  "cryo": <span >{uncoloredEleIcons.cryo} <SqBadge>Chongyun SKill</SqBadge> Spirit Blade: Chonghua's Layered Frost</span>,
+  "cryo": <span >{uncoloredEleIcons.cryo} <SqBadge>Chongyun Skill</SqBadge> Spirit Blade: Chonghua's Layered Frost</span>,
 }
 type InfusionAuraDropdownProps = Omit<DropdownButtonProps, "title" | "onChange" | "children">
 export function InfusionAuraDropdown(props: InfusionAuraDropdownProps) {
@@ -38,25 +38,25 @@ export function ReactionToggle(props: ReactionToggleProps) {
     {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value="pyro_vaporize"  >
       <ColorText color="vaporize">
         Vaporize(Pyro)
-        {<Chip sx={{ ml: 0.5 }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.hydro}+{uncoloredEleIcons.pyro}</span>} />}
+        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.hydro}+{uncoloredEleIcons.pyro}</span>} />}
       </ColorText>
     </ToggleButton >}
     {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value={"pyro_melt"}  >
       <ColorText color="melt">
         Melt(Pyro)
-        {<Chip sx={{ ml: 0.5 }} size="small" color="melt" label={<span>{uncoloredEleIcons.cryo}+{uncoloredEleIcons.pyro}</span>} />}
+        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="melt" label={<span>{uncoloredEleIcons.cryo}+{uncoloredEleIcons.pyro}</span>} />}
       </ColorText>
     </ToggleButton >}
     {(charEleKey === "hydro" || infusion === "hydro") && <ToggleButton value={"hydro_vaporize"}  >
       <ColorText color="vaporize">
         Vaporize(Hydro)
-        {<Chip sx={{ ml: 0.5 }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.hydro}</span>} />}
+        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.hydro}</span>} />}
         </ColorText>
     </ToggleButton >}
     {(charEleKey === "cryo" || infusion === "cryo") && <ToggleButton value={"cryo_melt"}  >
       <ColorText color="melt">
         Melt(Cryo)
-        {<Chip sx={{ ml: 0.5 }} size="small" color="melt" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.cryo}</span>} />}
+        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="melt" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.cryo}</span>} />}
         </ColorText>
     </ToggleButton >}
   </SolidToggleButtonGroup>

--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -1,4 +1,4 @@
-import { Chip, MenuItem, ToggleButton, ToggleButtonGroupProps } from "@mui/material";
+import { Box, MenuItem, ToggleButton, ToggleButtonGroupProps } from "@mui/material";
 import { useContext } from 'react';
 import { infusionNode } from "../Data/Characters/dataUtil";
 import { DataContext } from "../DataContext";
@@ -27,6 +27,7 @@ export function InfusionAuraDropdown(props: InfusionAuraDropdownProps) {
 }
 
 type ReactionToggleProps = Omit<ToggleButtonGroupProps, "color">
+const sqBadgeStyle = { mx: 0.25, px: 0.25, fontSize: "1em" }
 export function ReactionToggle(props: ReactionToggleProps) {
   const { data, character: { reactionMode }, characterDispatch } = useContext(DataContext)
   const charEleKey = data.get(input.charEle).value as ElementKey
@@ -38,26 +39,42 @@ export function ReactionToggle(props: ReactionToggleProps) {
     {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value="pyro_vaporize"  >
       <ColorText color="vaporize">
         Vaporize(Pyro)
-        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.hydro}+{uncoloredEleIcons.pyro}</span>} />}
       </ColorText>
+      <Box display="flex" alignItems="center">
+        <SqBadge sx={sqBadgeStyle} color="hydro">{uncoloredEleIcons.hydro}</SqBadge>
+        +
+        <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
+      </Box>
     </ToggleButton >}
     {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value={"pyro_melt"}  >
       <ColorText color="melt">
         Melt(Pyro)
-        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="melt" label={<span>{uncoloredEleIcons.cryo}+{uncoloredEleIcons.pyro}</span>} />}
       </ColorText>
+      <Box display="flex" alignItems="center">
+        <SqBadge sx={sqBadgeStyle} color="cryo">{uncoloredEleIcons.cryo}</SqBadge>
+        +
+        <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
+      </Box>
     </ToggleButton >}
     {(charEleKey === "hydro" || infusion === "hydro") && <ToggleButton value={"hydro_vaporize"}  >
       <ColorText color="vaporize">
         Vaporize(Hydro)
-        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="vaporize" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.hydro}</span>} />}
-        </ColorText>
+      </ColorText>
+      <Box display="flex" alignItems="center">
+        <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
+        +
+        <SqBadge sx={sqBadgeStyle} color="hydro">{uncoloredEleIcons.hydro}</SqBadge>
+      </Box>
     </ToggleButton >}
     {(charEleKey === "cryo" || infusion === "cryo") && <ToggleButton value={"cryo_melt"}  >
       <ColorText color="melt">
         Melt(Cryo)
-        {<Chip sx={{ ml: 0.5, cursor: "pointer" }} size="small" color="melt" label={<span>{uncoloredEleIcons.pyro}+{uncoloredEleIcons.cryo}</span>} />}
-        </ColorText>
+      </ColorText>
+      <Box display="flex" alignItems="center">
+        <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
+        +
+        <SqBadge sx={sqBadgeStyle} color="cryo">{uncoloredEleIcons.cryo}</SqBadge>
+      </Box>
     </ToggleButton >}
   </SolidToggleButtonGroup>
 }

--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -34,9 +34,9 @@ export function ReactionToggle(props: ReactionToggleProps) {
   const infusion = data.get(infusionNode).value as ElementKey
   if (!["pyro", "hydro", "cryo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusion)) return null
   return <SolidToggleButtonGroup exclusive baseColor="secondary"
-    value={reactionMode} onChange={(e, reactionMode) => characterDispatch({ reactionMode })} {...props}>
-    <ToggleButton value="" >No Reactions</ToggleButton >
-    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value="pyro_vaporize"  >
+    value={reactionMode} onChange={(_, reactionMode) => characterDispatch({ reactionMode })} {...props}>
+    <ToggleButton value="" disabled={reactionMode === ""} >No Reactions</ToggleButton >
+    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value="pyro_vaporize" disabled={reactionMode === "pyro_vaporize"}>
       <ColorText color="vaporize">
         Vaporize(Pyro)
       </ColorText>
@@ -46,7 +46,7 @@ export function ReactionToggle(props: ReactionToggleProps) {
         <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
       </Box>
     </ToggleButton >}
-    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value={"pyro_melt"}  >
+    {(charEleKey === "pyro" || infusion === "pyro") && <ToggleButton value={"pyro_melt"} disabled={reactionMode === "pyro_melt"}>
       <ColorText color="melt">
         Melt(Pyro)
       </ColorText>
@@ -56,7 +56,7 @@ export function ReactionToggle(props: ReactionToggleProps) {
         <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
       </Box>
     </ToggleButton >}
-    {(charEleKey === "hydro" || infusion === "hydro") && <ToggleButton value={"hydro_vaporize"}  >
+    {(charEleKey === "hydro" || infusion === "hydro") && <ToggleButton value={"hydro_vaporize"} disabled={reactionMode === "hydro_vaporize"}>
       <ColorText color="vaporize">
         Vaporize(Hydro)
       </ColorText>
@@ -66,7 +66,7 @@ export function ReactionToggle(props: ReactionToggleProps) {
         <SqBadge sx={sqBadgeStyle} color="hydro">{uncoloredEleIcons.hydro}</SqBadge>
       </Box>
     </ToggleButton >}
-    {(charEleKey === "cryo" || infusion === "cryo") && <ToggleButton value={"cryo_melt"}  >
+    {(charEleKey === "cryo" || infusion === "cryo") && <ToggleButton value={"cryo_melt"} disabled={reactionMode === "cryo_melt"}>
       <ColorText color="melt">
         Melt(Cryo)
       </ColorText>
@@ -82,9 +82,9 @@ type HitModeToggleProps = Omit<ToggleButtonGroupProps, "color">
 export function HitModeToggle(props: HitModeToggleProps) {
   const { character: { hitMode }, characterDispatch } = useContext(DataContext)
   return <SolidToggleButtonGroup exclusive baseColor="secondary"
-    value={hitMode} onChange={(e, hitMode) => characterDispatch({ hitMode })} {...props} >
-    <ToggleButton value="avgHit">Avg. DMG</ToggleButton>
-    <ToggleButton value="hit">Non Crit DMG</ToggleButton>
-    <ToggleButton value="critHit">Crit Hit DMG</ToggleButton>
+    value={hitMode} onChange={(_, hitMode) => characterDispatch({ hitMode })} {...props} >
+    <ToggleButton value="avgHit" disabled={hitMode === "avgHit"}>Avg. DMG</ToggleButton>
+    <ToggleButton value="hit" disabled={hitMode === "hit"}>Non Crit DMG</ToggleButton>
+    <ToggleButton value="critHit" disabled={hitMode === "critHit"}>Crit Hit DMG</ToggleButton>
   </SolidToggleButtonGroup>
 }

--- a/src/Components/SolidToggleButtonGroup.tsx
+++ b/src/Components/SolidToggleButtonGroup.tsx
@@ -16,6 +16,7 @@ const SolidToggleButtonGroup = styled(ToggleButtonGroup, {
     },
     '&:hover': {
       backgroundColor: theme.palette[baseColor].dark,
+      transition: "background-color 0.25s ease",
     },
     '&.Mui-selected': {
       backgroundColor: theme.palette[selectedColor].main,

--- a/src/Components/Weapon/WeaponCardPico.tsx
+++ b/src/Components/Weapon/WeaponCardPico.tsx
@@ -36,7 +36,7 @@ export default function WeaponCardPico({ weaponId }: { weaponId: string }) {
         />
       </WeaponNameTooltip>
     </Box>
-    <Typography variant='subtitle1' sx={{ position: "absolute", lineHeight: 1, pointerEvents: "none" }}>
+    <Typography variant='subtitle1' sx={{ position: "absolute", mt: -0.2, lineHeight: 1, pointerEvents: "none" }}>
       <SqBadge color="primary">{WeaponSheet.getLevelString(weapon)}</SqBadge>
     </Typography>
     {weaponSheet.hasRefinement && <Typography variant='subtitle1' sx={{ position: "absolute", bottom: 0, right: 0, lineHeight: 1, pointerEvents: "none" }}>

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -195,17 +195,19 @@ const sheet: ICharacterSheet = {
             node: infoMut(dmgFormulas.burst[eleKey], { key: `char_${key}_gen:burst.skillParams.1` }),
           }]
         }]))
-      }), ct.conditionalTemplate("constellation6", {
+      }), ct.conditionalTemplate("constellation6", { // Absorption teambuff for C6
+        teamBuff: true,
+        canShow: unequal(target.charKey, input.activeCharKey, 1),
         value: condAbsorption,
         path: condAbsorptionPath,
         name: st("eleAbsor"),
-        teamBuff: true,
         states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
           name: <ColorText color={eleKey}>{sgt(`element.${eleKey}`)}</ColorText>,
-          fields: [{
-            node: c6Bonus[`${eleKey}_dmg_`],
-          }],
+          fields: Object.values(c6Bonus).map(n => ({ node: n }))
         }]))
+      }), ct.headerTemplate("constellation6", {
+        canShow: unequal(condAbsorption, undefined, 1),
+        fields: Object.values(c6Bonus).map(n => ({ node: n }))
       })]),
 
       passive1: ct.talentTemplate("passive1", [ct.conditionalTemplate("passive1", {

--- a/src/Data/Resonance.tsx
+++ b/src/Data/Resonance.tsx
@@ -54,7 +54,7 @@ const ferventFlames: IResonance = {
 }
 
 // Soothing Waters
-const swNode = greaterEq(tally.hydro, 2, percent(0.25))
+const swNode = greaterEq(tally.hydro, 2, percent(0.30))
 const soothingWaters: IResonance = {
   name: tr("SoothingWater.name"),
   desc: tr("SoothingWater.desc"),

--- a/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
+++ b/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
@@ -14,7 +14,7 @@ const data_gen = data_gen_json as WeaponData
 
 const atk = [0.28, 0.35, 0.42, 0.49, 0.56]
 const atkMax = [0.8, 0.9, 1, 1.1, 1.2]
-const atk_ = min(prod(subscript(input.weapon.refineIndex, atk), sum(input.total.enerRech_, percent(-1))), subscript(input.weapon.refineIndex, atkMax))
+const atk_ = min(prod(subscript(input.weapon.refineIndex, atk), sum(input.premod.enerRech_, percent(-1))), subscript(input.weapon.refineIndex, atkMax))
 
 const enerRech = [0.3, 0.35, 0.40, 0.45, 0.5, 0.55]
 const [condPassivePath, condPassive] = cond(key, "TimelessDream")

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetConditional.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetConditional.tsx
@@ -55,7 +55,7 @@ function ArtConditionalModal({ open, onClose, artifactCondCount }: {
           <Typography variant="h6">Default Artifact Set Effects {!!artifactCondCount && <SqBadge color="success">{artifactCondCount} Selected</SqBadge>}</Typography>
         </Grid>
         <Grid item>
-          <Button onClick={resetArtConds} startIcon={<Replay />}>Reset All</Button>
+          <Button onClick={resetArtConds} color="error" startIcon={<Replay />}>Reset All</Button>
         </Grid>
         <Grid item>
           <CloseButton onClick={onClose} />

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -12,6 +12,7 @@ import BootstrapTooltip from '../../../../Components/BootstrapTooltip';
 import CardLight from '../../../../Components/Card/CardLight';
 import CharacterCard from '../../../../Components/Character/CharacterCard';
 import DropdownButton from '../../../../Components/DropdownMenu/DropdownButton';
+import { HitModeToggle, ReactionToggle } from '../../../../Components/HitModeEditor';
 import SolidToggleButtonGroup from '../../../../Components/SolidToggleButtonGroup';
 import StatFilterCard from '../../../../Components/StatFilterCard';
 import CharacterSheet from '../../../../Data/Characters/CharacterSheet';
@@ -440,15 +441,24 @@ export default function TabBuild() {
                 : <span>Select a character to generate builds.</span>}
             </Typography>
             <Button disabled={!builds.length} color="error" onClick={() => buildSettingsDispatch({ builds: [], buildDate: 0 })} >Clear Builds</Button>
-            <SolidToggleButtonGroup exclusive value={compareData} onChange={(e, v) => characterDispatch({ compareData: v })} size="small">
+          </Box>
+        </CardContent>
+      </CardLight>
+      <CardLight>
+        <CardContent>
+          <Grid container display="flex" spacing={1}>
+            <Grid item><HitModeToggle size="small" /></Grid>
+            <Grid item><ReactionToggle size="small" /></Grid>
+            <Grid item flexGrow={1} />
+            <Grid item><SolidToggleButtonGroup exclusive value={compareData} onChange={(e, v) => characterDispatch({ compareData: v })} size="small">
               <ToggleButton value={false} disabled={!compareData}>
                 <small>Show New artifact Stats</small>
               </ToggleButton>
               <ToggleButton value={true} disabled={compareData}>
                 <small>Compare against equipped artifacts</small>
               </ToggleButton>
-            </SolidToggleButtonGroup>
-          </Box>
+            </SolidToggleButtonGroup></Grid>
+          </Grid>
         </CardContent>
       </CardLight>
       <BuildList {...{ buildsArts, character, characterKey, characterSheet, data, compareData, mainStatAssumptionLevel, characterDispatch, disabled: !!generatingBuilds }} />

--- a/src/PageCharacter/CharacterDisplay/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/index.tsx
@@ -28,8 +28,8 @@ import usePromise from '../../ReactHooks/usePromise';
 import useTeamData from '../../ReactHooks/useTeamData';
 import { allCharacterKeys, CharacterKey } from '../../Types/consts';
 import { clamp } from '../../Util/Util';
-import TabBuild from './Tabs/TabOptimize';
 import TabEquip from './Tabs/TabEquip';
+import TabBuild from './Tabs/TabOptimize';
 import TabOverview from './Tabs/TabOverview';
 import TabTalent from './Tabs/TabTalent';
 import TabTeambuffs from './Tabs/TabTeambuffs';
@@ -119,7 +119,7 @@ function TabNav({ tab }: { tab: string }) {
     allowScrollButtonsMobile
     sx={{
       "& .MuiTab-root:hover": {
-        transition: "background-color 0.5s ease",
+        transition: "background-color 0.25s ease",
         backgroundColor: "rgba(255,255,255,0.1)"
       },
     }}

--- a/src/ReactHooks/useTeamData.tsx
+++ b/src/ReactHooks/useTeamData.tsx
@@ -99,9 +99,11 @@ async function getCharDataBundle(database: ArtCharDatabase, characterKey: Charac
   if (!character) return
   const weapon = database._getWeapon(character.equippedWeapon)
   if (!weapon) return
-  const characterSheet = await CharacterSheet.get(characterKey)
-  const weaponSheet = await WeaponSheet.get(weapon.key)
-  const artifactSheetsData = await ArtifactSheet.getAllData
+  const [characterSheet, weaponSheet, artifactSheetsData] = await Promise.all([
+    CharacterSheet.get(characterKey),
+    WeaponSheet.get(weapon.key),
+    ArtifactSheet.getAllData
+  ])
   if (!characterSheet || !weaponSheet || !artifactSheetsData) return
   const artifacts = (overrideArt ?? Object.values(character.equippedArtifacts).map(a => database._getArt(a))).filter(a => a) as ICachedArtifact[]
   const data = [


### PR DESCRIPTION
Fix capitalization mistake with team melee infusion dropdown
Fix Sucrose C6 - resolves #358 
Fix hydro resonance field - resolves #360 
Change Diona C6 to exclusive dropdown - resolves #355 
Change reset button for artifact conditional modal - resolves #354 
Adjust `ReactionToggle` element display to have more color
Add/adjust hover transition to a couple components
Fix 1px error on `Weapon`/`CharacterCardPico`
Add hitmode/reaction toggle bar to lower portion of the optimize tab - This is probably temporary while I figure out best way to do sticky bar for all platforms
Fix Engulfing Lightning using `total` ER instead of `premod`
Standardize how `togglebuttons` will `disable` themselves
Fix Mistsplitter conditional text - resolves #362 
Change a block of `await`s to use `Promise.all`