### PR TITLE
8.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://frzyc.github.io/genshin-optimizer/",
   "name": "genshin-optimizer",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/src/Components/Artifact/ArtifactFilterDisplay.tsx
+++ b/src/Components/Artifact/ArtifactFilterDisplay.tsx
@@ -21,7 +21,12 @@ const slotHandler = handleMultiSelect([...allSlotKeys])
 const exclusionHandler = handleMultiSelect([...exclusionValues])
 const lockedHandler = handleMultiSelect([...lockedValues])
 
-export default function ArtifactFilterDisplay({ filterOption, filterOptionDispatch, }: { filterOption: FilterOption, filterOptionDispatch: (any) => void }) {
+interface ArtifactFilterDisplayProps {
+  filterOption: FilterOption
+  filterOptionDispatch: (option: any) => void
+  disableSlotFilter?: boolean
+}
+export default function ArtifactFilterDisplay({ filterOption, filterOptionDispatch, disableSlotFilter = false }: ArtifactFilterDisplayProps) {
   const { t } = useTranslation(["artifact", "ui"]);
 
   const { artSetKeys = [], mainStatKeys = [], rarity = [], slotKeys = [], levelLow, levelHigh, substats = [],
@@ -35,7 +40,7 @@ export default function ArtifactFilterDisplay({ filterOption, filterOptionDispat
         {allArtifactRarities.map(star => <ToggleButton key={star} value={star} onClick={() => filterOptionDispatch({ rarity: rarityHandler(rarity, star) })}><Stars stars={star} /></ToggleButton>)}
       </SolidToggleButtonGroup>
       {/* Artifact Slot */}
-      <SolidToggleButtonGroup fullWidth value={slotKeys} size="small">
+      <SolidToggleButtonGroup fullWidth value={slotKeys} size="small" disabled={disableSlotFilter}>
         {allSlotKeys.map(slotKey => <ToggleButton key={slotKey} value={slotKey} onClick={() => filterOptionDispatch({ slotKeys: slotHandler(slotKeys, slotKey) })}>{artifactSlotIcon(slotKey)}</ToggleButton>)}
       </SolidToggleButtonGroup>
       {/* exclusion + locked */}

--- a/src/Data/Weapons/Bow/Messenger/index.tsx
+++ b/src/Data/Weapons/Bow/Messenger/index.tsx
@@ -16,7 +16,7 @@ const data_gen = data_gen_json as WeaponData
 const dmg_s = [1, 1.25, 1.5, 1.75, 2]
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_s), input.total.atk), "elemental", { hit: { ele: constant("physical") } })
 
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmg })
 
 const sheet: IWeaponSheet = {
   icon,

--- a/src/Data/Weapons/Bow/RecurveBow/index.tsx
+++ b/src/Data/Weapons/Bow/RecurveBow/index.tsx
@@ -16,7 +16,7 @@ const data_gen = data_gen_json as WeaponData
 const healing_s = [.08, .10, .12, .14, .16]
 const healing = customHealNode(prod(input.total.hp, subscript(input.weapon.refineIndex, healing_s)))
 
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { healing })
 
 const sheet: IWeaponSheet = {
   icon,

--- a/src/Data/Weapons/Bow/SkywardHarp/index.tsx
+++ b/src/Data/Weapons/Bow/SkywardHarp/index.tsx
@@ -21,7 +21,9 @@ const dmg = customDmgNode(prod(dmgPerc, input.total.atk), "elemental", { hit: { 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     critDMG_
-  }
+  },
+}, {
+  dmg
 })
 
 const sheet: IWeaponSheet = {

--- a/src/Data/Weapons/Bow/TheViridescentHunt/index.tsx
+++ b/src/Data/Weapons/Bow/TheViridescentHunt/index.tsx
@@ -16,7 +16,7 @@ const data_gen = data_gen_json as WeaponData
 const dmgPerc_s = [.4, .5, .6, .7, .8]
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc_s), input.total.atk), "elemental", { hit: { ele: constant("physical") } })
 
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmg })
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Catalyst/EyeOfPerception/index.tsx
+++ b/src/Data/Weapons/Catalyst/EyeOfPerception/index.tsx
@@ -14,12 +14,12 @@ const key: WeaponKey = "EyeOfPerception"
 const data_gen = data_gen_json as WeaponData
 
 const dmg_Src = [2.4, 2.7, 3, 3.3, 3.6]
-const dmg_ = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
+const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
 
 const data = dataObjForWeaponSheet(key, data_gen, undefined, {
-  dmg_
+  dmg_: dmg
 })
 
 const sheet: IWeaponSheet = {
@@ -27,7 +27,7 @@ const sheet: IWeaponSheet = {
   iconAwaken,
   document: [{
     header: headerTemplate(key, icon, iconAwaken, st("base")),
-    fields: [{ node: infoMut(dmg_, { key: "sheet:dmg" }) }],
+    fields: [{ node: infoMut(dmg, { key: "sheet:dmg" }) }],
   }]
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Catalyst/HakushinRing/index.tsx
+++ b/src/Data/Weapons/Catalyst/HakushinRing/index.tsx
@@ -44,78 +44,73 @@ const sheet: IWeaponSheet = {
   iconAwaken,
   document: [{
     value: condPassive,
-      path: condPassivePath,
-      name: trm("afterElectroReaction"),
-      canShow: unequal(input.activeCharKey, input.charKey, 1),
-      teamBuff: true,
-      header: headerTemplate(key, icon, iconAwaken, st("conditional")),
-      states: {
-        anemo: {
-          name: <ColorText color="swirl">{sgt("reaction.swirl")}</ColorText>,
-          fields: [{
-            node: anemo_dmg_
-          }, {
-            node: electro_dmg_
-          }, {
-            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
-            text: sgt("duration"),
-            value: 6,
-            unit: "s"
-          }]
-        },
-        cryo: {
-          name: <ColorText color="superconduct">{sgt("reaction.Superconduct")}</ColorText>,
-          fields: [{
-            node: cryo_dmg_
-          }, {
-            node: electro_dmg_
-          }, {
-            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
-            text: sgt("duration"),
-            value: 6,
-            unit: "s"
-          }]
-        },
-        geo: {
-          name: <ColorText color="crystallize">{sgt("reaction.crystallize")}</ColorText>,
-          fields: [{
-            node: geo_dmg_
-          }, {
-            node: electro_dmg_
-          }, {
-            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
-            text: sgt("duration"),
-            value: 6,
-            unit: "s"
-          }]
-        },
-        pyro: {
-          name: <ColorText color="overload">{sgt("reaction.overloaded")}</ColorText>,
-          fields: [{
-            node: pyro_dmg_
-          }, {
-            node: electro_dmg_
-          }, {
-            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
-            text: sgt("duration"),
-            value: 6,
-            unit: "s"
-          }]
-        },
-        hydro: {
-          name: <ColorText color="electrocharged">{sgt("reaction.electrocharged")}</ColorText>,
-          fields: [{
-            node: hydro_dmg_
-          }, {
-            node: electro_dmg_
-          }, {
-            canShow: (data) => data.get(input.activeCharKey).value !== data.get(input.charKey).value,
-            text: sgt("duration"),
-            value: 6,
-            unit: "s"
-          }]
-        }
+    path: condPassivePath,
+    name: trm("afterElectroReaction"),
+    canShow: unequal(input.activeCharKey, input.charKey, 1),
+    teamBuff: true,
+    header: headerTemplate(key, icon, iconAwaken, st("conditional")),
+    states: {
+      anemo: {
+        name: <ColorText color="swirl">{sgt("reaction.swirl")}</ColorText>,
+        fields: [{
+          node: anemo_dmg_
+        }, {
+          node: electro_dmg_
+        }, {
+          text: sgt("duration"),
+          value: 6,
+          unit: "s"
+        }]
+      },
+      cryo: {
+        name: <ColorText color="superconduct">{sgt("reaction.Superconduct")}</ColorText>,
+        fields: [{
+          node: cryo_dmg_
+        }, {
+          node: electro_dmg_
+        }, {
+          text: sgt("duration"),
+          value: 6,
+          unit: "s"
+        }]
+      },
+      geo: {
+        name: <ColorText color="crystallize">{sgt("reaction.crystallize")}</ColorText>,
+        fields: [{
+          node: geo_dmg_
+        }, {
+          node: electro_dmg_
+        }, {
+          text: sgt("duration"),
+          value: 6,
+          unit: "s"
+        }]
+      },
+      pyro: {
+        name: <ColorText color="overloaded">{sgt("reaction.overloaded")}</ColorText>,
+        fields: [{
+          node: pyro_dmg_
+        }, {
+          node: electro_dmg_
+        }, {
+          text: sgt("duration"),
+          value: 6,
+          unit: "s"
+        }]
+      },
+      hydro: {
+        name: <ColorText color="electrocharged">{sgt("reaction.electrocharged")}</ColorText>,
+        fields: [{
+          node: hydro_dmg_
+        }, {
+          node: electro_dmg_
+        }, {
+          text: sgt("duration"),
+          value: 6,
+          unit: "s"
+        }]
       }
+    }
   }],
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
+++ b/src/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
@@ -1,5 +1,5 @@
 import { WeaponData } from 'pipeline'
-import { input, target } from '../../../../Formula'
+import { input } from '../../../../Formula'
 import { equal, infoMut, subscript, unequal } from '../../../../Formula/utils'
 import { WeaponKey } from '../../../../Types/consts'
 import { cond, sgt, st, trans } from '../../../SheetUtil'
@@ -17,7 +17,7 @@ const atkSrc = [0.24, 0.3, 0.36, 0.42, 0.48]
 
 const [condPassivePath, condPassive] = cond(key, "Heritage")
 const atk_Disp = equal("on", condPassive, subscript(input.weapon.refineIndex, atkSrc))
-const atk_ = equal(input.activeCharKey, target.charKey, atk_Disp)
+const atk_ = unequal(input.activeCharKey, input.charKey, atk_Disp)
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   teamBuff: {

--- a/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
+++ b/src/Data/Weapons/Claymore/LuxuriousSeaLord/index.tsx
@@ -17,7 +17,7 @@ const burst_dmg_Src = [0.12, 0.15, 0.18, 0.21, 0.24]
 const dmg_Src = [1, 1.25, 1.5, 1.75, 2]
 const burst_dmg_ = subscript(input.weapon.refineIndex, burst_dmg_Src)
 const [condPassivePath, condPassive] = cond(key, "OceanicVictory")
-const dmg_ = equal(condPassive, 'on',
+const dmg = equal(condPassive, 'on',
   customDmgNode(prod(
     subscript(
       input.weapon.refineIndex, dmg_Src, { key: "_" }),
@@ -31,6 +31,8 @@ const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     burst_dmg_
   },
+}, {
+  dmg
 })
 const sheet: IWeaponSheet = {
   icon,
@@ -46,7 +48,7 @@ const sheet: IWeaponSheet = {
     states: {
       on: {
         fields: [{
-          node: infoMut(dmg_, { key: "sheet:dmg" })
+          node: infoMut(dmg, { key: "sheet:dmg" })
         }, {
           text: sgt("cd"),
           value: 15,

--- a/src/Data/Weapons/Claymore/PrototypeArchaic/index.tsx
+++ b/src/Data/Weapons/Claymore/PrototypeArchaic/index.tsx
@@ -14,17 +14,17 @@ const key: WeaponKey = "PrototypeArchaic"
 const data_gen = data_gen_json as WeaponData
 
 const dmg_Src = [2.4, 3, 3.6, 4.2, 4.8]
-const dmg_ = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
+const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmg_Src, { key: "_" }), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
 
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmg })
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,
   document: [{
     header: headerTemplate(key, icon, iconAwaken, st("base")),
-    fields: [{ node: infoMut(dmg_, { key: "sheet:dmg" }) }],
+    fields: [{ node: infoMut(dmg, { key: "sheet:dmg" }) }],
   }],
 }
 export default new WeaponSheet(key, sheet, data_gen, data)

--- a/src/Data/Weapons/Claymore/SkywardPride/index.tsx
+++ b/src/Data/Weapons/Claymore/SkywardPride/index.tsx
@@ -23,8 +23,11 @@ const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc, { ke
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     all_dmg_
-  }
+  },
+}, {
+  dmg
 })
+
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Claymore/SnowTombedStarsilver/index.tsx
+++ b/src/Data/Weapons/Claymore/SnowTombedStarsilver/index.tsx
@@ -22,7 +22,7 @@ const dmgOnCryoOp = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgCr
   hit: { ele: constant("physical") }
 })
 
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmgAoe, dmgOnCryoOp })
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Data/Weapons/Polearm/DragonspineSpear/index.tsx
+++ b/src/Data/Weapons/Polearm/DragonspineSpear/index.tsx
@@ -21,7 +21,7 @@ const dmgAoe = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgAoePerc
 const dmgOnCryoOp = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgCryoPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmgAoe, dmgOnCryoOp })
 
 const sheet: IWeaponSheet = {
   icon,

--- a/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
+++ b/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
@@ -25,6 +25,8 @@ export const data = dataObjForWeaponSheet(key, data_gen, {
     atk_,
     enerRech_
   },
+}, {
+  atk_
 })
 const sheet: IWeaponSheet = {
   icon,

--- a/src/Data/Weapons/Polearm/Halberd/index.tsx
+++ b/src/Data/Weapons/Polearm/Halberd/index.tsx
@@ -17,7 +17,7 @@ const dmgPerc = [1.6, 2, 2.4, 2.8, 3.2]
 const dmg = customDmgNode(prod(subscript(input.weapon.refineIndex, dmgPerc, { key: "_" }), input.total.atk), "elemental", {
   hit: { ele: constant("physical") }
 })
-const data = dataObjForWeaponSheet(key, data_gen)
+const data = dataObjForWeaponSheet(key, data_gen, undefined, { dmg })
 
 const sheet: IWeaponSheet = {
   icon,

--- a/src/Data/Weapons/Polearm/SkywardSpine/index.tsx
+++ b/src/Data/Weapons/Polearm/SkywardSpine/index.tsx
@@ -25,6 +25,8 @@ const data = dataObjForWeaponSheet(key, data_gen, {
     critRate_,
     atkSPD_
   }
+}, {
+  dmg
 })
 
 const sheet: IWeaponSheet = {

--- a/src/Data/Weapons/Polearm/StaffOfHoma/index.tsx
+++ b/src/Data/Weapons/Polearm/StaffOfHoma/index.tsx
@@ -17,15 +17,17 @@ const atkInc = [0.008, 0.01, 0.012, 0.014, 0.016]
 const lowHpAtkInc = [0.01, 0.012, 0.014, 0.016, 0.018]
 const hp_ = subscript(input.weapon.refineIndex, hpInc, { key: "_" })
 const [condPassivePath, condPassive] = cond(key, "RecklessCinnabar")
-const atk1_ = prod(subscript(input.weapon.refineIndex, atkInc, { key: "_" }), input.premod.hp)
-const atk2_ = equal("on", condPassive, prod(subscript(input.weapon.refineIndex, lowHpAtkInc, { key: "_" }), input.premod.hp), { key: "atk" })
+const atk1 = prod(subscript(input.weapon.refineIndex, atkInc, { key: "_" }), input.premod.hp)
+const atk2 = equal("on", condPassive, prod(subscript(input.weapon.refineIndex, lowHpAtkInc, { key: "_" }), input.premod.hp), { key: "atk" })
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
     hp_,
   },
   total: {
-    atk: sum(atk1_, atk2_)
+    atk: sum(atk1, atk2)
   }
+}, {
+  atk2_: atk2
 })
 
 const sheet: IWeaponSheet = {
@@ -36,7 +38,7 @@ const sheet: IWeaponSheet = {
     fields: [{
       node: hp_
     }, {
-      node: infoMut(atk1_, { key: "atk" })
+      node: infoMut(atk1, { key: "atk" })
     }],
   }, {
     value: condPassive,
@@ -46,7 +48,7 @@ const sheet: IWeaponSheet = {
     states: {
       on: {
         fields: [{
-          node: atk2_,
+          node: atk2,
         }]
       }
     }

--- a/src/Data/Weapons/Sword/PrimordialJadeCutter/index.tsx
+++ b/src/Data/Weapons/Sword/PrimordialJadeCutter/index.tsx
@@ -24,7 +24,10 @@ const data = dataObjForWeaponSheet(key, data_gen, {
   total: {
     atk
   }
+}, {
+  atk
 })
+
 const sheet: IWeaponSheet = {
   icon,
   iconAwaken,

--- a/src/Database/Data/ArtifactData.ts
+++ b/src/Database/Data/ArtifactData.ts
@@ -11,9 +11,10 @@ export class ArtifactDataManager extends DataManager<string, string, ICachedArti
     super(database)
     for (const key of this.database.storage.keys) {
       if (key.startsWith("artifact_")) {
-        const flex = parseArtifact(this.database.storage.get(key))
+        const obj = this.database.storage.get(key)
+        const flex = parseArtifact(obj)
         if (!flex) {
-          // Non-recoverable
+          console.error("Entry", key, "is unrecoverable.", obj)
           this.database.storage.remove(key)
           continue
         }

--- a/src/Database/Data/BuildsettingData.ts
+++ b/src/Database/Data/BuildsettingData.ts
@@ -38,10 +38,10 @@ export class BuildsettingDataManager extends DataManager<CharacterKey, string, B
     for (const key of this.database.storage.keys) {
       if (key.startsWith("buildSetting_")) {
         const [, charKey] = key.split("buildSetting_")
-        // TODO Parse the object and check if it is valid
+        // TODO: Parse the object and check if it is valid
         const buildSettingsObj = this.database.storage.get(key)
         if (!buildSettingsObj) {
-          // Non-recoverable
+          console.error("Entry", key, "is unrecoverable.", buildSettingsObj)
           this.database.storage.remove(key)
           continue
         }

--- a/src/Database/Data/CharacterData.ts
+++ b/src/Database/Data/CharacterData.ts
@@ -12,9 +12,10 @@ export class CharacterDataManager extends DataManager<CharacterKey, string, ICac
     super(database)
     for (const key of this.database.storage.keys) {
       if (key.startsWith("char_")) {
-        const flex = parseCharacter(this.database.storage.get(key))
+        const obj = this.database.storage.get(key)
+        const flex = parseCharacter(obj)
         if (!flex || key !== `char_${flex.key}`) {
-          // Non-recoverable
+          console.error("CharacterData", key, "is unrecoverable.", obj)
           this.database.storage.remove(key)
           continue
         }

--- a/src/Database/Data/StateData.ts
+++ b/src/Database/Data/StateData.ts
@@ -9,7 +9,7 @@ export class StateDataManager extends DataManager<string, string, object, object
         const [, stateKey] = key.split("state_")
         const stateObj = this.database.storage.get(key)
         if (!stateObj) {
-          // Non-recoverable
+          console.error("StateData", key, "is unrecoverable.", stateObj)
           this.database.storage.remove(key)
           continue
         }

--- a/src/Database/Data/WeaponData.ts
+++ b/src/Database/Data/WeaponData.ts
@@ -13,7 +13,7 @@ export class WeaponDataManager extends DataManager<string, string, ICachedWeapon
       if (key.startsWith("weapon_")) {
         const flex = parseWeapon(this.database.storage.get(key))
         if (!flex) {
-          // Non-recoverable
+          console.error("WeaponData", key, "is unrecoverable.")
           this.database.storage.remove(key)
           continue
         }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/ArtifactSwapModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/ArtifactSwapModal.tsx
@@ -50,7 +50,7 @@ export default function ArtifactSwapModal({ onChangeId, slotKey, show, onClose }
       <Divider />
       <CardContent>
         <Suspense fallback={<Skeleton variant="rectangular" width="100%" height={200} />}>
-          <ArtifactFilterDisplay filterOption={filterOption} filterOptionDispatch={filterOptionDispatch} />
+          <ArtifactFilterDisplay filterOption={filterOption} filterOptionDispatch={filterOptionDispatch} disableSlotFilter />
         </Suspense>
         <Box mt={1}>
           <Suspense fallback={<Skeleton variant="rectangular" width="100%" height={300} />}>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/index.tsx
@@ -69,7 +69,7 @@ function TabEquip() {
         </Grid>
       </CardContent>
     </CardLight>), [artifactSheets, setEffects])
-  const weaponDoc = useMemo(() => weaponSheet && weaponSheet.document.length > 0 && <CardLight><CardContent><DocumentDisplay sections={weaponSheet.document} /></CardContent></CardLight>, [weaponSheet])
+  const weaponDoc = useMemo(() => weaponSheet && weaponSheet.document.length > 0 && <DocumentDisplay sections={weaponSheet.document} />, [weaponSheet])
   return <Box display="flex" flexDirection="column" gap={1}>
     <Suspense fallback={false}>
       <WeaponEditor
@@ -86,7 +86,7 @@ function TabEquip() {
     </CardLight>
     <Grid container spacing={1}>
       {grxl && <Grid item xs={12} md={12} xl={3} sx={{ display: "flex", flexDirection: "column", gap: 1 }} >
-        {weaponDoc}
+        {weaponDoc && <CardLight><CardContent>{weaponDoc}</CardContent></CardLight>}
         {hasEquipped && <Button color="error" onClick={unequipArts} fullWidth>{t`tabEquip.unequipArts`}</Button>}
         {artifactFields}
       </Grid>}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
@@ -98,7 +98,7 @@ function TeammateDisplay({ index }: { index: number }) {
     <CardContent>
       <CharacterAutocomplete fullWidth value={characterKey}
         onChange={charKey => activeCharacterDispatch({ type: "team", index, charKey })}
-        disable={ck => ck === activeCharacterKey || active.team.includes(ck)}
+        disable={ck => ck === activeCharacterKey || (ck !== "" && active.team.includes(ck))}
         labelText={t("teammate", { count: index + 1 })}
         defaultText={t("none")}
         defaultIcon={<PersonAdd />}

--- a/src/PageSettings/DatabaseCard.tsx
+++ b/src/PageSettings/DatabaseCard.tsx
@@ -46,6 +46,9 @@ function ExtraDatabaseWrapper({ index, children }) {
     const storage = new ExtraStorage(dbName)
     const dbObj = JSON.parse(localStorage.getItem(dbName) ?? `{ "dbIndex": "${index}" }`)
     storage.setStorage(dbObj)
+
+    // A bit of preventive programming
+    storage.removeForKeys(k => k.startsWith("extraDatabase_"))
     const db = new ArtCharDatabase(storage)
     storage.saveStorage()
     return db
@@ -114,9 +117,10 @@ function DataCard({ index, databaseContextObj }: { index: number, databaseContex
     // save current database to appropriate slot
     const dbIndex = parseInt(databaseContextObj.database.storage.getString("dbIndex") || "1")
     const tempStorage = new ExtraStorage(`extraDatabase_${dbIndex}`, databaseContextObj.database.storage)
+    tempStorage.removeForKeys(k => k.startsWith("extraDatabase_"))
     tempStorage.saveStorage()
 
-    // clear current slot database
+    // clear this slot database
     const storage = database.storage as ExtraStorage
     const dbName = storage.databaseName
     localStorage.removeItem(dbName)

--- a/src/ReactHooks/useDBState.tsx
+++ b/src/ReactHooks/useDBState.tsx
@@ -3,11 +3,12 @@ import { DatabaseContext } from "../Database/Database";
 
 export default function useDBState<O extends object>(key: string, init: () => O): [O, (value: Partial<O>) => void] {
   const { database } = useContext(DatabaseContext)
-  const [state, setState] = useState(database.states.getWithInit<O>(key, init))
+  const [state, setState] = useState(() => database.states.getWithInit<O>(key, init))
 
   useEffect(() =>
     key ? database.states.follow(key, setState as any) : undefined,
     [key, setState, database])
+  useEffect(() => setState(database.states.getWithInit<O>(key, init)), [database, init, key])
   const updateState = useCallback(
     value => database.states.set(key, value),
     [database, key],


### PR DESCRIPTION
## Fixes
- Fix #474 - Resolves database encapsulation within other databases
- Fix #475 - Fix TC mode not updating when swapping databases
- Fix blank card showing for certain weapon conditionals in Equipment tab
- Fix #471 - Fix TTDS being applied to the holding character
- Fix being unable to select "None" as a teammate
- Fix Hakushin Ring's bonus damage coloring
- Fix #434 - Add missing optimization targets for numerous weapons
  - Messenger, Recurve Bow, Skyward Harp, The Viridescent Hunt, Eye of Perception, Luxurious Sea Lord, Prototype Archaic, Skyward Pride, Snow-Tombed Starsilver, Dragonspine Spear, Engulfing Lightning, Halberd, Skyward Spine, Staff of Homa, Primordial Jade Cutter
- Resolve #369 - Disable slot filter in swap artifact modal

## Technical
- Remove multiple extraneous `canShow` from Hakushin Ring sheet 