### PR TITLE
Fix and tweak various sheets

### DIFF
--- a/public/locales/en/char_RaidenShogun.json
+++ b/public/locales/en/char_RaidenShogun.json
@@ -5,8 +5,8 @@
   },
   "burst": {
     "resolves": "Resolve Stacks",
-    "resolveInitial_": "<electro>Musou no Hitotachi Base DMG Bonus</electro",
-    "resolveInfused_": "<electro>Musou Isshin DMG Bonus</electro>"
+    "resolveInitial_": "<electro>Musou no Hitotachi Base DMG Bonus Scaling</electro",
+    "resolveInfused_": "<electro>Musou Isshin DMG Bonus Scaling</electro>"
   },
   "a4": {
     "enerRest": "Energy restoration from <strong>Musou Isshin</strong>",

--- a/public/locales/en/char_Yoimiya.json
+++ b/public/locales/en/char_Yoimiya.json
@@ -3,6 +3,6 @@
   "c2": "Crit from <pyro>Pyro DMG</pyro>",
   "p2": "Party ATK increase",
   "p2p": "Using <strong>Ryuukin Saxifrage</strong>",
-  "normMult": "Normal Att. DMG Multiplier",
+  "normMult_": "Normal Att. DMG Multiplier",
   "normPyroInfus": "<pyro>Normal Att. Pyro Infusion</pyro>"
 }

--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -137,5 +137,6 @@
   },
   "bonusScaling": {
     "skill_": "Ele. Skill Bonus Scaling"
-  }
+  },
+  "energy": "Energy"
 }

--- a/src/Data/Characters/Keqing/index.tsx
+++ b/src/Data/Characters/Keqing/index.tsx
@@ -196,6 +196,7 @@ const sheet: ICharacterSheet = {
           text: sgt("cd"),
           value: datamine.skill.cd,
           unit: "s",
+          fixed: 1
         }]
       }, ct.conditionalTemplate("passive1", {
         value: condAfterRecast,

--- a/src/Data/Characters/KujouSara/index.tsx
+++ b/src/Data/Characters/KujouSara/index.tsx
@@ -194,7 +194,8 @@ const sheet: ICharacterSheet = {
       passive2: ct.talentTemplate("passive2", [ct.fieldsTemplate("passive2", {
         fields: [{
           text: trm("a4.enerRest"),
-          value: data => data.get(input.total.enerRech_).value * datamine.passive2.energyGen
+          value: data => data.get(input.total.enerRech_).value * datamine.passive2.energyGen,
+          fixed: 2
         }]
       })]),
       passive3: ct.talentTemplate("passive3"),

--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -100,13 +100,13 @@ const skillEyeTeamBurstDmgInc = unequal(input.activeCharKey, input.charKey,
 const resolveStacks = [10, 20, 30, 40, 50, 60]
 const [condResolveStackPath, condResolveStack] = cond(key, "burstResolve")
 
-const resolveStackNode = lookup(condResolveStack, objectKeyMap(resolveStacks, i => constant(i)), 0)
+const resolveStackNode = lookup(condResolveStack, objectKeyMap(resolveStacks, i => constant(i)), 0, { key: `char_${key}:burst.resolves` })
 const resolveInitialBonus_ = prod(
-  subscript(input.total.burstIndex, datamine.burst.resolveBonus1, { key: "_" }),
+  subscript(input.total.burstIndex, datamine.burst.resolveBonus1, { key: `char_${key}:burst.resolveInitial_` }),
   resolveStackNode
 )
 const resolveInfusedBonus_ = prod(
-  subscript(input.total.burstIndex, datamine.burst.resolveBonus2, { key: "_" }),
+  subscript(input.total.burstIndex, datamine.burst.resolveBonus2, { key: `char_${key}:burst.resolveInfused_` }),
   resolveStackNode
 )
 function burstResolve(mvArr: number[], initial = false) {

--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -82,7 +82,7 @@ const datamine = {
 
 const [condSkillEyePath, condSkillEye] = cond(key, "skillEye")
 const skillEye_ = equal("skillEye", condSkillEye,
-  prod(datamine.burst.enerCost, subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus.map(x => x), { key: '_' })))
+  prod(constant(datamine.burst.enerCost, { key: "sheet:energy" }), subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { fixed: 2, key: '_' })))
 
 function skillDmg(atkType: number[]) {
   // if Raiden is above or equal to C2, then account for DEF Ignore else not
@@ -94,8 +94,8 @@ function skillDmg(atkType: number[]) {
 const energyCosts = [40, 50, 60, 70, 80, 90]
 const [condSkillEyeTeamPath, condSkillEyeTeam] = cond(key, "skillEyeTeam")
 const skillEyeTeamBurstDmgInc = unequal(input.activeCharKey, input.charKey,
-  prod(lookup(condSkillEyeTeam, objectKeyMap(energyCosts, i => constant(i)), 0),
-    subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { key: '_' })))
+  prod(lookup(condSkillEyeTeam, objectKeyMap(energyCosts, i => constant(i, { key: "sheet:energy" })), 0),
+    subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { fixed: 2, key: '_' })))
 
 const resolveStacks = [10, 20, 30, 40, 50, 60]
 const [condResolveStackPath, condResolveStack] = cond(key, "burstResolve")

--- a/src/Data/Characters/Sayu/index.tsx
+++ b/src/Data/Characters/Sayu/index.tsx
@@ -1,7 +1,7 @@
 import { CharacterData } from 'pipeline'
 import ColorText from '../../../Components/ColoredText'
 import { input } from '../../../Formula'
-import { constant, greaterEq, infoMut, lookup, min, naught, percent, prod, subscript, sum } from '../../../Formula/utils'
+import { constant, equal, greaterEq, infoMut, lookup, min, naught, percent, prod, subscript, sum } from '../../../Formula/utils'
 import { absorbableEle, CharacterKey, ElementKey } from '../../../Types/consts'
 import { range } from '../../../Util/Util'
 import { cond, sgt, st, trans } from '../../SheetUtil'
@@ -153,7 +153,11 @@ const dmgFormulas = {
     darumaHeal
   },
   passive1: {
-    heal: greaterEq(input.asc, 1, sum(datamine.passive1.baseHeal, prod(datamine.passive1.emHeal, input.total.eleMas)))
+    heal: greaterEq(input.asc, 1, equal(condActiveSwirl, "activeSwirl",
+      customHealNode(
+        sum(datamine.passive1.baseHeal, prod(datamine.passive1.emHeal, input.total.eleMas))
+      )
+    ))
   },
   passive2: {
     extraHeal: greaterEq(input.asc, 4, prod(darumaHeal, percent(datamine.passive2.nearHeal)))

--- a/src/Data/Characters/ShikanoinHeizou/index.tsx
+++ b/src/Data/Characters/ShikanoinHeizou/index.tsx
@@ -81,7 +81,7 @@ const declension_dmg_ = lookup(
     stacks,
     prod(
       subscript(input.total.skillIndex, datamine.skill.declension_dmg_, { key: "sheet:bonusScaling.skill_" }),
-      stacks
+      constant(stacks, { key: `char_${key}:declensionStacks` })
     )
   ])), naught, { key: "sheet:bonusScaling.skill_" })
 const conviction_dmg_ = equal(condDeclensionStacks, "4",
@@ -107,12 +107,15 @@ const c6_skill_critRate_ = greaterEq(input.constellation, 6, lookup(
   condDeclensionStacks,
   Object.fromEntries(stacksArr.map(stacks => [
     stacks,
-    prod(stacks, datamine.constellation6.hsCritRate_)
+    prod(
+      percent(datamine.constellation6.hsCritRate_),
+      constant(stacks, { key: `char_${key}:declensionStacks` })
+    )
   ])),
   naught
 ))
 const c6_skill_critDMG_ = greaterEq(input.constellation, 6,
-  equal(condDeclensionStacks, "4", datamine.constellation6.hsCritDmg_)
+  equal(condDeclensionStacks, "4", percent(datamine.constellation6.hsCritDmg_))
 )
 
 export const dmgFormulas = {

--- a/src/Data/Characters/ShikanoinHeizou/index.tsx
+++ b/src/Data/Characters/ShikanoinHeizou/index.tsx
@@ -186,9 +186,9 @@ const sheet: ICharacterSheet = {
         fields: datamine.normal.hitArr.map((_, i) => ({
           node: infoMut(
             dmgFormulas.normal[i],
-            { key: `char_${key}_gen:auto.skillParams.${i > 3 ? (i < 6 ? 3 : 4) : i}` }
+            { key: `char_${key}_gen:auto.skillParams.${i > 2 ? (i < 6 ? 3 : 4) : i}` }
           ),
-          textSuffix: (i > 3 && i < 6) ? `(${i - 3})` : undefined,
+          textSuffix: (i > 2 && i < 6) ? `(${i - 2})` : undefined,
         }))
       }, {
         text: tr("auto.fields.charged"),

--- a/src/Data/Characters/Yoimiya/index.tsx
+++ b/src/Data/Characters/Yoimiya/index.tsx
@@ -86,7 +86,7 @@ const [condC1Path, condC1] = cond(characterKey, "c1")
 const [condC2Path, condC2] = cond(characterKey, "c2")
 const const3TalentInc = greaterEq(input.constellation, 3, 3)
 const const5TalentInc = greaterEq(input.constellation, 5, 3)
-const normal_dmgMult = matchFull(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: "_" }), one)
+const normal_dmgMult = matchFull(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: `char_${characterKey}:normMult_` }), one)
 const a1Stacks = lookup(condA1, Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i => [i, constant(i)])), 0)
 const pyro_dmg_ = greaterEq(input.asc, 1, equal(condSkill, "skill", infoMut(prod(percent(datamine.passive1.pyro_dmg_), a1Stacks), { key: 'pyro_dmg_', variant: elementKey })))
 const atk_ = greaterEq(input.asc, 4, equal(condBurst, "on", unequal(input.activeCharKey, characterKey,
@@ -198,10 +198,7 @@ const sheet: ICharacterSheet = {
         states: {
           skill: {
             fields: [{
-              text: trm("normMult"),
-              value: data => data.get(normal_dmgMult).value * 100,
-              fixed: 1,
-              unit: "%",
+              node: normal_dmgMult
             }, {
               text: trm("normPyroInfus"),
             }, {

--- a/src/Data/Weapons/Bow/Slingshot/index.tsx
+++ b/src/Data/Weapons/Bow/Slingshot/index.tsx
@@ -13,19 +13,18 @@ const key: WeaponKey = "Slingshot"
 const data_gen = data_gen_json as WeaponData
 const [, trm] = trans("weapon", key)
 
-const normal_atk_increase_s = [.46, .52, .58, .64, .70] // Increased by 10% to counteract the decrease
-const charged_atk_increase_s = [.46, .52, .58, .64, .70]
+const dmg_arr = [.36, .42, .48, .54, .60]
 
 const [condPassivePath, condPassive] = cond(key, "Slingshot")
-const normal_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, normal_atk_increase_s), { key: "normal_dmg_" })
-const charged_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, charged_atk_increase_s), { key: "charged_dmg_" })
-const normal_atk_decrease = percent(-0.1, { key: "normal_dmg_" })
-const charged_atk_decrease = percent(-0.1, { key: "charged_dmg_" })
+const normal_dmg_inc = equal(condPassive, "on", subscript(input.weapon.refineIndex, dmg_arr), { key: "normal_dmg_" })
+const charged_dmg_inc = equal(condPassive, "on", subscript(input.weapon.refineIndex, dmg_arr), { key: "charged_dmg_" })
+const normal_dmg_dec = equal(condPassive, undefined, percent(-0.1, { key: "normal_dmg_" }))
+const charged_dmg_dec = equal(condPassive, undefined, percent(-0.1, { key: "charged_dmg_" }))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
-    normal_dmg_: sum(normal_atk_increase, normal_atk_decrease),
-    charged_dmg_: sum(charged_atk_increase, normal_atk_decrease)
+    normal_dmg_: sum(normal_dmg_inc, normal_dmg_dec),
+    charged_dmg_: sum(charged_dmg_inc, charged_dmg_dec),
   }
 })
 
@@ -35,9 +34,9 @@ const sheet: IWeaponSheet = {
   document: [{
     header: headerTemplate(key, icon, iconAwaken, st("base")),
     fields: [{
-      node: normal_atk_decrease
+      node: normal_dmg_dec
     }, {
-      node: charged_atk_decrease
+      node: charged_dmg_dec
     }],
   }, {
     value: condPassive,
@@ -47,9 +46,9 @@ const sheet: IWeaponSheet = {
     states: {
       on: {
         fields: [{
-          node: normal_atk_increase
+          node: normal_dmg_inc
         }, {
-          node: charged_atk_increase
+          node: charged_dmg_inc
         }]
       }
     }


### PR DESCRIPTION
## Enhancements
* Add additional key to Raiden's burst damage formula when using Resolve stacks
* Add additional key to Raiden's skill's burst damage boost
* Add additional key to Yoimiya's infused normal attacks
* Add additional key to Heizou's declension stacks
* Make Slingshot fields more intuitive

## Fixes
* Fix Heizou's normal attack suffixes
* Fix Heizou's values showing as decimals and not percents in the tooltip
* Fix #494 - Fix Sara's A4 rounding incorrectly
* Fix Sayu's A1 healing formula not using healing bonus
* Fix Raiden's skill's burst damage bonus tooltip rounding incorrectly
* Fix Keqing skill cooldown being rounded incorrectly