### PR TITLE
8.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://frzyc.github.io/genshin-optimizer/",
   "name": "genshin-optimizer",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/public/locales/en/char_RaidenShogun.json
+++ b/public/locales/en/char_RaidenShogun.json
@@ -5,8 +5,8 @@
   },
   "burst": {
     "resolves": "Resolve Stacks",
-    "resolveInitial_": "<electro>Musou no Hitotachi Base DMG Bonus</electro",
-    "resolveInfused_": "<electro>Musou Isshin DMG Bonus</electro>"
+    "resolveInitial_": "<electro>Musou no Hitotachi Base DMG Bonus Scaling</electro",
+    "resolveInfused_": "<electro>Musou Isshin DMG Bonus Scaling</electro>"
   },
   "a4": {
     "enerRest": "Energy restoration from <strong>Musou Isshin</strong>",

--- a/public/locales/en/char_Yoimiya.json
+++ b/public/locales/en/char_Yoimiya.json
@@ -3,6 +3,6 @@
   "c2": "Crit from <pyro>Pyro DMG</pyro>",
   "p2": "Party ATK increase",
   "p2p": "Using <strong>Ryuukin Saxifrage</strong>",
-  "normMult": "Normal Att. DMG Multiplier",
+  "normMult_": "Normal Att. DMG Multiplier",
   "normPyroInfus": "<pyro>Normal Att. Pyro Infusion</pyro>"
 }

--- a/public/locales/en/sheet.json
+++ b/public/locales/en/sheet.json
@@ -137,5 +137,6 @@
   },
   "bonusScaling": {
     "skill_": "Ele. Skill Bonus Scaling"
-  }
+  },
+  "energy": "Energy"
 }

--- a/src/Components/StatEditorList.tsx
+++ b/src/Components/StatEditorList.tsx
@@ -7,8 +7,8 @@ import CustomNumberInput, { CustomNumberInputButtonGroupWrapper } from './Custom
 import DropdownButton from './DropdownMenu/DropdownButton';
 
 
-export default function StatEditorList({ statKeys, statFilters, setStatFilters, disabled = false }: {
-  statKeys: StatKey[], statFilters: Dict<StatKey, number>, setStatFilters: (statFilters: Dict<StatKey, number>) => void, disabled?: boolean
+export default function StatEditorList({ statKeys, statFilters, setStatFilters, disabled = false, wrapperFunc = (ele) => ele }: {
+  statKeys: StatKey[], statFilters: Dict<StatKey, number>, setStatFilters: (statFilters: Dict<StatKey, number>) => void, disabled?: boolean, wrapperFunc?: (ele: JSX.Element) => JSX.Element
 }) {
   const remainingKeys = useMemo(() => statKeys.filter(key => !(Object.keys(statFilters) as any).some(k => k === key)), [statKeys, statFilters])
   const setKey = useCallback(
@@ -36,9 +36,9 @@ export default function StatEditorList({ statKeys, statFilters, setStatFilters, 
 
   return <>
     {Object.entries(statFilters).map(([statKey, min]) =>
-      <StatFilterItem key={statKey} statKey={statKey} statKeys={remainingKeys} disabled={disabled} value={min} setValue={setFilter} setKey={setKey} delKey={delKey} />
+      wrapperFunc(<StatFilterItem key={statKey} statKey={statKey} statKeys={remainingKeys} disabled={disabled} value={min} setValue={setFilter} setKey={setKey} delKey={delKey} />)
     )}
-    <StatFilterItem statKeys={remainingKeys} setValue={setFilter} setKey={setKey} delKey={delKey} disabled={disabled} />
+    {wrapperFunc(<StatFilterItem statKeys={remainingKeys} setValue={setFilter} setKey={setKey} delKey={delKey} disabled={disabled} />)}
   </>
 }
 

--- a/src/Data/Characters/Keqing/index.tsx
+++ b/src/Data/Characters/Keqing/index.tsx
@@ -196,6 +196,7 @@ const sheet: ICharacterSheet = {
           text: sgt("cd"),
           value: datamine.skill.cd,
           unit: "s",
+          fixed: 1
         }]
       }, ct.conditionalTemplate("passive1", {
         value: condAfterRecast,

--- a/src/Data/Characters/KujouSara/index.tsx
+++ b/src/Data/Characters/KujouSara/index.tsx
@@ -194,7 +194,8 @@ const sheet: ICharacterSheet = {
       passive2: ct.talentTemplate("passive2", [ct.fieldsTemplate("passive2", {
         fields: [{
           text: trm("a4.enerRest"),
-          value: data => data.get(input.total.enerRech_).value * datamine.passive2.energyGen
+          value: data => data.get(input.total.enerRech_).value * datamine.passive2.energyGen,
+          fixed: 2
         }]
       })]),
       passive3: ct.talentTemplate("passive3"),

--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -82,7 +82,7 @@ const datamine = {
 
 const [condSkillEyePath, condSkillEye] = cond(key, "skillEye")
 const skillEye_ = equal("skillEye", condSkillEye,
-  prod(datamine.burst.enerCost, subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus.map(x => x), { key: '_' })))
+  prod(constant(datamine.burst.enerCost, { key: "sheet:energy" }), subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { fixed: 2, key: '_' })))
 
 function skillDmg(atkType: number[]) {
   // if Raiden is above or equal to C2, then account for DEF Ignore else not
@@ -94,19 +94,19 @@ function skillDmg(atkType: number[]) {
 const energyCosts = [40, 50, 60, 70, 80, 90]
 const [condSkillEyeTeamPath, condSkillEyeTeam] = cond(key, "skillEyeTeam")
 const skillEyeTeamBurstDmgInc = unequal(input.activeCharKey, input.charKey,
-  prod(lookup(condSkillEyeTeam, objectKeyMap(energyCosts, i => constant(i)), 0),
-    subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { key: '_' })))
+  prod(lookup(condSkillEyeTeam, objectKeyMap(energyCosts, i => constant(i, { key: "sheet:energy" })), 0),
+    subscript(input.total.skillIndex, datamine.skill.burstDmg_bonus, { fixed: 2, key: '_' })))
 
 const resolveStacks = [10, 20, 30, 40, 50, 60]
 const [condResolveStackPath, condResolveStack] = cond(key, "burstResolve")
 
-const resolveStackNode = lookup(condResolveStack, objectKeyMap(resolveStacks, i => constant(i)), 0)
+const resolveStackNode = lookup(condResolveStack, objectKeyMap(resolveStacks, i => constant(i)), 0, { key: `char_${key}:burst.resolves` })
 const resolveInitialBonus_ = prod(
-  subscript(input.total.burstIndex, datamine.burst.resolveBonus1, { key: "_" }),
+  subscript(input.total.burstIndex, datamine.burst.resolveBonus1, { key: `char_${key}:burst.resolveInitial_` }),
   resolveStackNode
 )
 const resolveInfusedBonus_ = prod(
-  subscript(input.total.burstIndex, datamine.burst.resolveBonus2, { key: "_" }),
+  subscript(input.total.burstIndex, datamine.burst.resolveBonus2, { key: `char_${key}:burst.resolveInfused_` }),
   resolveStackNode
 )
 function burstResolve(mvArr: number[], initial = false) {

--- a/src/Data/Characters/Sayu/index.tsx
+++ b/src/Data/Characters/Sayu/index.tsx
@@ -1,7 +1,7 @@
 import { CharacterData } from 'pipeline'
 import ColorText from '../../../Components/ColoredText'
 import { input } from '../../../Formula'
-import { constant, greaterEq, infoMut, lookup, min, naught, percent, prod, subscript, sum } from '../../../Formula/utils'
+import { constant, equal, greaterEq, infoMut, lookup, min, naught, percent, prod, subscript, sum } from '../../../Formula/utils'
 import { absorbableEle, CharacterKey, ElementKey } from '../../../Types/consts'
 import { range } from '../../../Util/Util'
 import { cond, sgt, st, trans } from '../../SheetUtil'
@@ -153,7 +153,11 @@ const dmgFormulas = {
     darumaHeal
   },
   passive1: {
-    heal: greaterEq(input.asc, 1, sum(datamine.passive1.baseHeal, prod(datamine.passive1.emHeal, input.total.eleMas)))
+    heal: greaterEq(input.asc, 1, equal(condActiveSwirl, "activeSwirl",
+      customHealNode(
+        sum(datamine.passive1.baseHeal, prod(datamine.passive1.emHeal, input.total.eleMas))
+      )
+    ))
   },
   passive2: {
     extraHeal: greaterEq(input.asc, 4, prod(darumaHeal, percent(datamine.passive2.nearHeal)))

--- a/src/Data/Characters/ShikanoinHeizou/index.tsx
+++ b/src/Data/Characters/ShikanoinHeizou/index.tsx
@@ -81,7 +81,7 @@ const declension_dmg_ = lookup(
     stacks,
     prod(
       subscript(input.total.skillIndex, datamine.skill.declension_dmg_, { key: "sheet:bonusScaling.skill_" }),
-      stacks
+      constant(stacks, { key: `char_${key}:declensionStacks` })
     )
   ])), naught, { key: "sheet:bonusScaling.skill_" })
 const conviction_dmg_ = equal(condDeclensionStacks, "4",
@@ -107,12 +107,15 @@ const c6_skill_critRate_ = greaterEq(input.constellation, 6, lookup(
   condDeclensionStacks,
   Object.fromEntries(stacksArr.map(stacks => [
     stacks,
-    prod(stacks, datamine.constellation6.hsCritRate_)
+    prod(
+      percent(datamine.constellation6.hsCritRate_),
+      constant(stacks, { key: `char_${key}:declensionStacks` })
+    )
   ])),
   naught
 ))
 const c6_skill_critDMG_ = greaterEq(input.constellation, 6,
-  equal(condDeclensionStacks, "4", datamine.constellation6.hsCritDmg_)
+  equal(condDeclensionStacks, "4", percent(datamine.constellation6.hsCritDmg_))
 )
 
 export const dmgFormulas = {
@@ -186,9 +189,9 @@ const sheet: ICharacterSheet = {
         fields: datamine.normal.hitArr.map((_, i) => ({
           node: infoMut(
             dmgFormulas.normal[i],
-            { key: `char_${key}_gen:auto.skillParams.${i > 3 ? (i < 6 ? 3 : 4) : i}` }
+            { key: `char_${key}_gen:auto.skillParams.${i > 2 ? (i < 6 ? 3 : 4) : i}` }
           ),
-          textSuffix: (i > 3 && i < 6) ? `(${i - 3})` : undefined,
+          textSuffix: (i > 2 && i < 6) ? `(${i - 2})` : undefined,
         }))
       }, {
         text: tr("auto.fields.charged"),

--- a/src/Data/Characters/Yoimiya/index.tsx
+++ b/src/Data/Characters/Yoimiya/index.tsx
@@ -86,7 +86,7 @@ const [condC1Path, condC1] = cond(characterKey, "c1")
 const [condC2Path, condC2] = cond(characterKey, "c2")
 const const3TalentInc = greaterEq(input.constellation, 3, 3)
 const const5TalentInc = greaterEq(input.constellation, 5, 3)
-const normal_dmgMult = matchFull(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: "_" }), one)
+const normal_dmgMult = matchFull(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: `char_${characterKey}:normMult_` }), one)
 const a1Stacks = lookup(condA1, Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i => [i, constant(i)])), 0)
 const pyro_dmg_ = greaterEq(input.asc, 1, equal(condSkill, "skill", infoMut(prod(percent(datamine.passive1.pyro_dmg_), a1Stacks), { key: 'pyro_dmg_', variant: elementKey })))
 const atk_ = greaterEq(input.asc, 4, equal(condBurst, "on", unequal(input.activeCharKey, characterKey,
@@ -198,10 +198,7 @@ const sheet: ICharacterSheet = {
         states: {
           skill: {
             fields: [{
-              text: trm("normMult"),
-              value: data => data.get(normal_dmgMult).value * 100,
-              fixed: 1,
-              unit: "%",
+              node: normal_dmgMult
             }, {
               text: trm("normPyroInfus"),
             }, {

--- a/src/Data/Weapons/Bow/Slingshot/index.tsx
+++ b/src/Data/Weapons/Bow/Slingshot/index.tsx
@@ -13,19 +13,18 @@ const key: WeaponKey = "Slingshot"
 const data_gen = data_gen_json as WeaponData
 const [, trm] = trans("weapon", key)
 
-const normal_atk_increase_s = [.46, .52, .58, .64, .70] // Increased by 10% to counteract the decrease
-const charged_atk_increase_s = [.46, .52, .58, .64, .70]
+const dmg_arr = [.36, .42, .48, .54, .60]
 
 const [condPassivePath, condPassive] = cond(key, "Slingshot")
-const normal_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, normal_atk_increase_s), { key: "normal_dmg_" })
-const charged_atk_increase = equal(condPassive, "on", subscript(input.weapon.refineIndex, charged_atk_increase_s), { key: "charged_dmg_" })
-const normal_atk_decrease = percent(-0.1, { key: "normal_dmg_" })
-const charged_atk_decrease = percent(-0.1, { key: "charged_dmg_" })
+const normal_dmg_inc = equal(condPassive, "on", subscript(input.weapon.refineIndex, dmg_arr), { key: "normal_dmg_" })
+const charged_dmg_inc = equal(condPassive, "on", subscript(input.weapon.refineIndex, dmg_arr), { key: "charged_dmg_" })
+const normal_dmg_dec = equal(condPassive, undefined, percent(-0.1, { key: "normal_dmg_" }))
+const charged_dmg_dec = equal(condPassive, undefined, percent(-0.1, { key: "charged_dmg_" }))
 
 const data = dataObjForWeaponSheet(key, data_gen, {
   premod: {
-    normal_dmg_: sum(normal_atk_increase, normal_atk_decrease),
-    charged_dmg_: sum(charged_atk_increase, normal_atk_decrease)
+    normal_dmg_: sum(normal_dmg_inc, normal_dmg_dec),
+    charged_dmg_: sum(charged_dmg_inc, charged_dmg_dec),
   }
 })
 
@@ -35,9 +34,9 @@ const sheet: IWeaponSheet = {
   document: [{
     header: headerTemplate(key, icon, iconAwaken, st("base")),
     fields: [{
-      node: normal_atk_decrease
+      node: normal_dmg_dec
     }, {
-      node: charged_atk_decrease
+      node: charged_dmg_dec
     }],
   }, {
     value: condPassive,
@@ -47,9 +46,9 @@ const sheet: IWeaponSheet = {
     states: {
       on: {
         fields: [{
-          node: normal_atk_increase
+          node: normal_dmg_inc
         }, {
-          node: charged_atk_increase
+          node: charged_dmg_inc
         }]
       }
     }

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -20,7 +20,7 @@ const allMisc = [
 const allModStats = [
   ...allArtModStats,
   ...(["all", "burning", ...allTransformative, ...allAmplifying, ...allMoves] as const).map(x => `${x}_dmg_` as const),
-]
+] as const
 const allNonModStats = [
   ...allElements.flatMap(x => [
     `${x}_dmgInc` as const,
@@ -34,7 +34,11 @@ const allNonModStats = [
   ...allEleEnemyResKeys,
   "enemyDefRed_" as const,
   ...allMisc,
-]
+] as const
+
+export const allInputPremodKeys = [...allModStats, ...allNonModStats] as const
+
+export type InputPremodKey = typeof allInputPremodKeys[number]
 
 const talent = objectKeyMap(allTalents, _ => read())
 const allModStatNodes = objectKeyMap(allModStats, key => read(undefined, { key }))

--- a/src/Formula/type.d.ts
+++ b/src/Formula/type.d.ts
@@ -24,6 +24,7 @@ interface Info {
   prefix?: KeyMapPrefix
   source?: CharacterKey | WeaponKey | ArtifactSetKey
   variant?: Variant
+  subVariant?: Variant
   asConst?: true
   pivot?: true
   fixed?: number

--- a/src/KeyMap/index.tsx
+++ b/src/KeyMap/index.tsx
@@ -1,9 +1,9 @@
+import ColorText from "../Components/ColoredText";
 import { Translate } from "../Components/Translate";
-import elementalData from "./ElementalData";
-import { amplifyingReactions, AmplifyingReactionsKey, HitMoveKey, hitMoves, transformativeReactions, TransformativeReactionsKey } from "./StatConstants";
 import { MainStatKey, SubstatKey } from "../Types/artifact";
 import { allElementsWithPhy, ElementKeyWithPhy } from "../Types/consts";
-import ColorText from "../Components/ColoredText";
+import elementalData from "./ElementalData";
+import { amplifyingReactions, AmplifyingReactionsKey, HitMoveKey, hitMoves, transformativeReactions, TransformativeReactionsKey } from "./StatConstants";
 
 const statMap = {
   hp: "HP", hp_: "HP", atk: "ATK", atk_: "ATK", def: "DEF", def_: "DEF",
@@ -66,14 +66,22 @@ export type Unit = "" | "%" | "s"
 
 export type BaseKeys = keyof typeof statMap
 
+/* Elemental extension keys */
+
 export type EleDmgKey = `${ElementKeyWithPhy}_dmg_`
 export const allEleDmgKeys = allElementsWithPhy.map(e => `${e}_dmg_`) as EleDmgKey[]
 
 export type EleResKey = `${ElementKeyWithPhy}_res_`
 export const allEleResKeys = allElementsWithPhy.map(e => `${e}_res_`) as EleResKey[]
 
+export type EleDmgIncKey = `${ElementKeyWithPhy}_dmgInc`
+export const allEleDmgIncKeys = allElementsWithPhy.map(ele => `${ele}_dmgInc` as const) as EleDmgIncKey[]
+
 export type EleEnemyResKey = `${ElementKeyWithPhy}_enemyRes_`
 export const allEleEnemyResKeys = allElementsWithPhy.map(e => `${e}_enemyRes_`) as EleEnemyResKey[]
+
+export type EleECritDmgKey = `${ElementKeyWithPhy}_critDMG_`
+export const allEleECritDmgKeys = allElementsWithPhy.map(e => `${e}_enemyRes_`) as EleEnemyResKey[]
 
 Object.entries(elementalData).forEach(([e, { name }]) => {
   statMap[`${e}_dmg_`] = `${name} DMG Bonus`
@@ -83,15 +91,12 @@ Object.entries(elementalData).forEach(([e, { name }]) => {
   statMap[`${e}_dmgInc`] = `${name} DMG Increase`
   statMap[`${e}_critDMG_`] = `${name} CRIT DMG Bonus`
 })
-for (const move in hitMoves) {
-  statMap[`${move}_dmgInc`] = `${hitMoves[move]} DMG Increase`
-}
 
+type ElementExtKey = EleDmgKey | EleResKey | EleEnemyResKey | EleDmgIncKey | EleECritDmgKey
+
+/* Hit move extension keys */
 export type HitMoveDmgKey = `${HitMoveKey}_dmg_`
 export const allHitMoveDmgKeys = Object.keys(hitMoves).map(h => `${h}_dmg_`) as HitMoveDmgKey[]
-
-export type EleDmgIncKey = `${ElementKeyWithPhy}_dmgInc`
-export const allEleDmgIncKeys = allElementsWithPhy.map(ele => `${ele}_dmgInc` as const) as EleDmgIncKey[]
 
 export type HitMoveDmgIncKey = `${HitMoveKey}_dmgInc`
 export const allHitMoveDmgIncKeys = Object.keys(hitMoves).map(ele => `${ele}_dmgInc` as const) as HitMoveDmgIncKey[]
@@ -99,13 +104,18 @@ export const allHitMoveDmgIncKeys = Object.keys(hitMoves).map(ele => `${ele}_dmg
 export type HitMoveCritRateKey = `${HitMoveKey}_critRate_`
 export const allHitMoveCritRateKeys = Object.keys(hitMoves).map(h => `${h}_critRate_`) as HitMoveCritRateKey[]
 
+export type HitMoveCritDmgKey = `${HitMoveKey}_critDMG_`
+export const allHitMoveCritDmgKeys = Object.keys(hitMoves).map(h => `${h}_critDMG_`) as HitMoveCritRateKey[]
+
 Object.entries(hitMoves).forEach(([move, moveName]) => {
   statMap[`${move}_dmgInc`] = `${moveName} DMG Increase`
   statMap[`${move}_dmg_`] = `${moveName} DMG Bonus`
   statMap[`${move}_critRate_`] = `${moveName} CRIT Rate Bonus`
   statMap[`${move}_critDMG_`] = `${moveName} CRIT DMG Bonus`
 })
+type MoveExtKey = HitMoveDmgKey | HitMoveDmgIncKey | HitMoveCritRateKey | HitMoveCritDmgKey
 
+/* Transformation extension keys */
 export type TransformativeReactionsDmgKey = `${TransformativeReactionsKey}_dmg_`
 export const allTransformativeReactionsDmgKeys = Object.keys(transformativeReactions).map(e => `${e}_dmg_`) as TransformativeReactionsDmgKey[]
 
@@ -133,7 +143,8 @@ Object.entries(amplifyingReactions).forEach(([reaction, { name }]) => {
   statMap[`${reaction}_dmg_`] = `${name} DMG Bonus`
 })
 
-export type StatKey = BaseKeys | EleDmgKey | EleResKey | EleEnemyResKey | HitMoveDmgKey | HitMoveCritRateKey | EleDmgIncKey | HitMoveDmgIncKey | TransformativeReactionsDmgKey | AmplifyingReactionsDmgKey
+/* EVERY stat key */
+export type StatKey = BaseKeys | ElementExtKey | MoveExtKey | TransformativeReactionsDmgKey | AmplifyingReactionsDmgKey
 
 export type KeyMapPrefix = 'default' | 'base' | 'total' | 'uncapped' | 'custom' | 'char' | 'art' | 'weapon' | 'teamBuff'
 const subKeyMap: StrictDict<KeyMapPrefix, string> = {

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabEquip/index.tsx
@@ -28,6 +28,7 @@ import { initCharMeta } from '../../../../stateInit';
 import { allSubstatKeys } from '../../../../Types/artifact';
 import { allSlotKeys, SlotKey, WeaponTypeKey } from '../../../../Types/consts';
 import { IFieldDisplay } from '../../../../Types/fieldDisplay';
+import { floatCompare } from '../../../../Util/Util';
 import useBuildSetting from '../TabOptimize/useBuildSetting';
 import ArtifactSwapModal from './ArtifactSwapModal';
 import WeaponSwapModal from './WeaponSwapModal';
@@ -188,13 +189,13 @@ function ArtifactSectionCard() {
     }, { currentEfficiency: 0, currentEfficiency_: 0, maxEfficiency: 0, maxEfficiency_: 0 })
     const rvField: IFieldDisplay = {
       text: t`artifact:editor.curSubEff`,
-      value: currentEfficiency === currentEfficiency_ ? <PercentBadge value={currentEfficiency} max={4500} valid /> :
+      value: !floatCompare(currentEfficiency, currentEfficiency_) ? <PercentBadge value={currentEfficiency} max={4500} valid /> :
         <span><PercentBadge value={currentEfficiency} max={4500} valid /> / <PercentBadge value={currentEfficiency_} max={4500} valid /></span>
     }
     const rvmField: IFieldDisplay = {
       text: t`artifact:editor.maxSubEff`,
-      canShow: () => currentEfficiency_ !== maxEfficiency_,
-      value: maxEfficiency === maxEfficiency_ ? <PercentBadge value={maxEfficiency} max={4500} valid /> :
+      canShow: () => !!floatCompare(currentEfficiency_, maxEfficiency_),
+      value: !floatCompare(maxEfficiency, maxEfficiency_) ? <PercentBadge value={maxEfficiency} max={4500} valid /> :
         <span><PercentBadge value={maxEfficiency} max={4500} valid /> / <PercentBadge value={maxEfficiency_} max={4500} valid /></span>
     }
     return { rvField, rvmField }
@@ -213,8 +214,8 @@ function ArtifactSectionCard() {
           </CardDark>
         </ModalWrapper>
         <FieldDisplayList >
-          < BasicFieldDisplay field={rvField} component={ListItem} />
-          < BasicFieldDisplay field={rvmField} component={ListItem} />
+          <BasicFieldDisplay field={rvField} component={ListItem} />
+          <BasicFieldDisplay field={rvmField} component={ListItem} />
         </FieldDisplayList>
       </CardDark>
       <Box display="flex" gap={1} flexDirection="column">

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -1,0 +1,62 @@
+import { Masonry } from "@mui/lab"
+import { CardContent, CardHeader, Divider, MenuItem, MenuList } from "@mui/material"
+import { useContext } from "react"
+import CardDark from "../../../../../Components/Card/CardDark"
+import CardLight from "../../../../../Components/Card/CardLight"
+import ColorText from "../../../../../Components/ColoredText"
+import ImgIcon from "../../../../../Components/Image/ImgIcon"
+import ModalWrapper from "../../../../../Components/ModalWrapper"
+import { DataContext } from "../../../../../Context/DataContext"
+import { getDisplayHeader, getDisplaySections } from "../../../../../Formula/DisplayUtil"
+import { DisplaySub } from "../../../../../Formula/type"
+import { NodeDisplay } from "../../../../../Formula/uiData"
+import KeyMap from "../../../../../KeyMap"
+import usePromise from "../../../../../ReactHooks/usePromise"
+
+export interface TargetSelectorModalProps {
+  show: boolean,
+  onClose: () => void,
+  setTarget: (target: string[]) => void,
+  useSubVariant?: boolean,
+  flatOnly?: boolean
+  excludeSections?: string[]
+}
+export function TargetSelectorModal({ show, onClose, setTarget, useSubVariant = false, flatOnly = false, excludeSections = [] }: TargetSelectorModalProps) {
+  const { data } = useContext(DataContext)
+  const sections = getDisplaySections(data).filter(([key]) => !excludeSections.includes(key))
+    // Determine if a section has all empty entries
+    .filter(([key, sectionObj]) =>
+      Object.values(sectionObj).some(n => !n.isEmpty && (!flatOnly || !(flatOnly && KeyMap.unit(n.info.key))))
+    )
+
+  return <ModalWrapper open={show} onClose={onClose}>
+    <CardDark >
+      <CardContent>
+        <Masonry columns={{ xs: 1, sm: 2, md: 3 }} spacing={1}>
+          {sections.map(([key, Nodes]) =>
+            <SelectorSection key={key} displayNs={Nodes} sectionKey={key} setTarget={setTarget} useSubVariant={useSubVariant} flatOnly={flatOnly} />)}
+        </Masonry >
+      </CardContent>
+    </CardDark>
+  </ModalWrapper>
+}
+function SelectorSection({ displayNs, sectionKey, setTarget, useSubVariant = false, flatOnly = false }: { displayNs: DisplaySub<NodeDisplay>, sectionKey: string, setTarget: (target: string[]) => void, useSubVariant?: boolean, flatOnly?: boolean }) {
+  const { data } = useContext(DataContext)
+  const header = usePromise(()=>getDisplayHeader(data, sectionKey), [data, sectionKey])
+  return <CardLight key={sectionKey as string}>
+    {header && <CardHeader avatar={header.icon && <ImgIcon size={2} sx={{ m: -1 }} src={header.icon} />} title={header.title} action={header.action} titleTypographyProps={{ variant: "subtitle1" }} />}
+    <Divider />
+    <MenuList>
+      {Object.entries(displayNs).map(([key, n]) =>
+        <TargetSelectorMenuItem key={key} node={n} onClick={() => setTarget([sectionKey, key])} useSubVariant={useSubVariant} flatOnly={flatOnly} />)}
+    </MenuList>
+  </CardLight>
+}
+
+function TargetSelectorMenuItem({ node, onClick, useSubVariant = false, flatOnly = false }: { node: NodeDisplay, onClick: () => void, useSubVariant?: boolean, flatOnly?: boolean }) {
+  if (node.isEmpty) return null
+  if (flatOnly && KeyMap.unit(node.info.key)) return null
+  return <MenuItem onClick={onClick} style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+    <ColorText color={useSubVariant ? node.info.subVariant : node.info.variant} >{KeyMap.get(node.info.key)}</ColorText>
+  </MenuItem>
+}

--- a/src/Types/character.d.ts
+++ b/src/Types/character.d.ts
@@ -1,5 +1,5 @@
 import { EleEnemyResKey, StatKey } from "../KeyMap";
-import { CharacterKey, ElementKey, HitModeKey, ReactionModeKey, SlotKey } from "./consts";
+import { CharacterKey, ElementKey, HitModeKey, InfusionAuraElements, ReactionModeKey, SlotKey } from "./consts";
 import { IConditionalValues } from "./IConditional";
 import { DocumentSection } from "./sheet";
 export interface ICharacter {
@@ -21,7 +21,7 @@ export interface ICharacter {
   conditional: IConditionalValues
   bonusStats: Partial<Record<StatKey, number>>
   enemyOverride: Partial<Record<EleEnemyResKey | "enemyLevel" | "enemyDefRed_" | "enemyDefIgn_", number>>
-  infusionAura: ElementKey | ""
+  infusionAura: InfusionAuraElements | ""
   compareData: boolean
 }
 export interface ICachedCharacter extends ICharacter {

--- a/src/Types/consts.ts
+++ b/src/Types/consts.ts
@@ -7,6 +7,7 @@ export const allArtifactRarities = [5, 4, 3] as const
 export const allSlotKeys = ["flower", "plume", "sands", "goblet", "circlet"] as const
 export const allElements = ['anemo', 'geo', 'electro', 'hydro', 'pyro', 'cryo'] as const
 export const allElementsWithPhy = ["physical", ...allElements] as const
+export const allInfusionAuraElements = ["pyro", 'cryo'] as const
 export const allWeaponTypeKeys = ['sword', 'claymore', 'polearm', 'bow', 'catalyst'] as const
 export const allArtifactSets = [
   "Adventurer",
@@ -277,6 +278,7 @@ export type ArtifactRarity = typeof allArtifactRarities[number]
 export type SlotKey = typeof allSlotKeys[number]
 export type ElementKey = typeof allElements[number]
 export type ElementKeyWithPhy = typeof allElementsWithPhy[number]
+export type InfusionAuraElements = typeof allInfusionAuraElements[number]
 export type ArtifactSetKey = typeof allArtifactSets[number]
 export type CharacterKey = typeof allCharacterKeys[number]
 export type WeaponTypeKey = typeof allWeaponTypeKeys[number]

--- a/src/Util/Util.ts
+++ b/src/Util/Util.ts
@@ -159,3 +159,9 @@ export function deepFreeze(obj: any, layers: number = 5) {
   if (typeof obj === "object")
     Object.values(Object.freeze(obj)).forEach(o => deepFreeze(o, layers--))
 }
+
+export function floatCompare(a: number, b: number, accuracy: number = 0.00001) {
+  const diff = a - b
+  if (Math.abs(diff) < accuracy) return 0
+  return diff
+}


### PR DESCRIPTION
## Enhancements
- Add additional key to Raiden's burst damage formula when using Resolve stacks.
- Add additional key to Raiden's skill's burst damage boost.
- Add additional key to Yoimiya's infused normal attacks.
- Add additional key to Heizou's declension stacks.
- Make Slingshot fields more intuitive.
- Add icons and context to optimization target selector.

## Fixes
- Fix Heizou's normal attack suffixes.
- Fix Heizou's values showing as decimals and not percents in the tooltip.
- Fix #494 - Fix Sara's A4 rounding incorrectly.
- Fix Sayu's A1 healing formula not using healing bonus.
- Fix Raiden's skill's burst damage bonus tooltip rounding incorrectly.
- Fix Keqing skill cooldown being rounded incorrectly.
- Fix Max Roll values showing in equip page when all arts are maxed.


## Technical
- Add an alternative variant to to `Node.info`.
- Add utility function to compare floats.