### PR TITLE
Revert setting cryo contrast color to black

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -236,7 +236,7 @@ export const theme = createTheme({
       name: "hydro"
     }),
     cryo: defaultTheme.palette.augmentColor({
-      color: { main: "#77a2e6" },
+      color: { main: "#77a2e6", contrastText: "#fff" },
       name: "cryo"
     }),
     electro: defaultTheme.palette.augmentColor({


### PR DESCRIPTION
Cryo with black text looks out of place in certain UI elements. Longer term solution might be to increase saturation of cryo color.
![image](https://user-images.githubusercontent.com/1754901/180919488-b90c9fce-a7c3-4078-bcaa-7d02f297234a.png)
