### PR TITLE
Add support for swirl amp reaction

### DIFF
--- a/public/locales/en/page_character.json
+++ b/public/locales/en/page_character.json
@@ -22,10 +22,9 @@
     "critHit": "Crit Hit DMG"
   },
   "ampReaction": {
-    "pyro_vaporize": "Vaporize(Pyro)",
-    "pyro_melt": "Melt(Pyro)",
-    "hydro_vaporize": "Vaporize(Hydro)",
-    "cryo_melt": "Melt(Cryo)"
+    "noReaction": "No Reactions",
+    "vaporize": "Vaporize",
+    "melt": "Melt"
   },
   "tabEquip": {
     "swapWeapon": "Swap Weapon",

--- a/src/Components/AmpReactionModeText.tsx
+++ b/src/Components/AmpReactionModeText.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { Variant } from "../Formula/type";
+import { AmpReactionKey } from "../Types/consts";
+import ColorText from "./ColoredText";
+import SqBadge from "./SqBadge";
+import { uncoloredEleIcons } from "./StatIcon";
+
+export const ampReactionMap = {
+  melt: {
+    cryo: ["pyro", "cryo"],
+    pyro: ["cryo", "pyro"],
+  },
+  vaporize: {
+    hydro: ["pyro", "hydro"],
+    pyro: ["hydro", "pyro"],
+  }
+} as const
+const sqBadgeStyle = { mx: 0.25, px: 0.25 }
+export default function AmpReactionModeText({ reaction, subvariant }: { reaction: AmpReactionKey, subvariant: Variant }) {
+  const { t } = useTranslation("page_character")
+  const eles = ampReactionMap[reaction][subvariant]
+  if (!eles) return null;
+  const [base, trigger] = eles
+
+  return <Box display="flex" alignItems="center">
+    <ColorText color="melt">{t(`ampReaction.${reaction}`)}</ColorText>
+    <SqBadge sx={sqBadgeStyle} color={base}>{uncoloredEleIcons[base]}</SqBadge>
+    {`+`}
+    <SqBadge sx={sqBadgeStyle} color={trigger}>{uncoloredEleIcons[trigger]}</SqBadge>
+  </Box>
+}

--- a/src/Components/FieldDisplay.tsx
+++ b/src/Components/FieldDisplay.tsx
@@ -1,12 +1,15 @@
 import { Groups } from "@mui/icons-material";
-import { Box, List, ListItem, ListProps, Palette, PaletteColor, Skeleton, styled, Typography } from "@mui/material";
+import { Box, Divider, List, ListItem, ListProps, Palette, PaletteColor, Skeleton, styled, Typography } from "@mui/material";
 import React, { Suspense, useCallback, useContext, useMemo } from 'react';
 import { DataContext } from "../Context/DataContext";
 import { FormulaDataContext } from "../Context/FormulaDataContext";
 import { NodeDisplay } from "../Formula/api";
+import { Variant } from "../Formula/type";
 import KeyMap, { valueString } from "../KeyMap";
+import { allAmpReactions, AmpReactionKey } from "../Types/consts";
 import { IBasicFieldDisplay, IFieldDisplay } from "../Types/fieldDisplay";
 import { evalIfFunc } from "../Util/Util";
+import AmpReactionModeText from "./AmpReactionModeText";
 import ColorText from "./ColoredText";
 import QuestionTooltip from "./QuestionTooltip";
 import StatIcon from "./StatIcon";
@@ -64,7 +67,13 @@ export function NodeFieldDisplay({ node, oldValue, suffix, component, emphasize 
     fieldVal = <span>{valueString(oldValue, node.unit)}{diff > 0.0001 || diff < -0.0001 ? <ColorText color={diff > 0 ? "success" : "error"}> {diff > 0 ? "+" : ""}{valueString(diff, node.unit)}</ColorText> : ""}</span>
   } else fieldVal = valueString(node.value, node.unit)
 
-  const formulaTextOverlay = !!node.formula && <QuestionTooltip onClick={onClick} title={<Typography><Suspense fallback={<Skeleton variant="rectangular" width={300} height={30} />}>{fieldFormulaText}</Suspense></Typography>} />
+  const formulaTextOverlay = !!node.formula && <QuestionTooltip onClick={onClick} title={<Typography><Suspense fallback={<Skeleton variant="rectangular" width={300} height={30} />}>
+    {allAmpReactions.includes(node.info.variant as any) && <Box sx={{ display: "inline-flex", gap: 1, mr: 1 }}>
+      <Box><AmpReactionModeText reaction={node.info.variant as AmpReactionKey} subvariant={node.info.subVariant as Variant} /></Box>
+      <Divider orientation="vertical" flexItem />
+    </Box>}
+    <span>{fieldFormulaText}</span>
+  </Suspense></Typography>} />
   return <Box width="100%" sx={{ display: "flex", justifyContent: "space-between", gap: 1, boxShadow: emphasize ? "0px 0px 0px 2px red inset" : undefined }} component={component} >
     <Typography color={`${node.info.variant}.main`} sx={{ display: "flex", gap: 1, alignItems: "center" }}>{!!isTeamBuff && <Groups />}{icon}{fieldText}{suffix}</Typography>
     <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
@@ -73,7 +82,6 @@ export function NodeFieldDisplay({ node, oldValue, suffix, component, emphasize 
     </Box>
   </Box>
 }
-
 export interface FieldDisplayListProps extends ListProps {
   light?: keyof Palette,
   dark?: keyof Palette,

--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -1,12 +1,12 @@
-import { Box, MenuItem, ToggleButton, ToggleButtonGroupProps } from "@mui/material";
+import { MenuItem, ToggleButton, ToggleButtonGroupProps } from "@mui/material";
 import { useContext } from 'react';
 import { useTranslation } from "react-i18next";
 import { CharacterContext } from "../Context/CharacterContext";
-import { infusionNode } from "../Data/Characters/dataUtil";
 import { DataContext } from "../Context/DataContext";
+import { infusionNode } from "../Data/Characters/dataUtil";
 import { uiInput as input } from "../Formula";
-import { allHitModes, allReactionModes, ElementKey } from "../Types/consts";
-import ColorText from "./ColoredText";
+import { allAmpReactions, allHitModes, ElementKey } from "../Types/consts";
+import AmpReactionModeText, { ampReactionMap } from "./AmpReactionModeText";
 import DropdownButton, { DropdownButtonProps } from "./DropdownMenu/DropdownButton";
 import SolidToggleButtonGroup from "./SolidToggleButtonGroup";
 import SqBadge from "./SqBadge";
@@ -28,48 +28,19 @@ export function InfusionAuraDropdown(props: InfusionAuraDropdownProps) {
   </DropdownButton>
 }
 
-const sqBadgeStyle = { mx: 0.25, px: 0.25, fontSize: "1em" }
-export const reactionModeText = {
-  pyro_vaporize: (t) => <Box display="flex" alignItems="center">
-    <ColorText color="vaporize">{t`ampReaction.pyro_vaporize`}</ColorText>
-    <SqBadge sx={sqBadgeStyle} color="hydro">{uncoloredEleIcons.hydro}</SqBadge>
-    {`+`}
-    <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
-  </Box>,
-  pyro_melt: (t) => <Box display="flex" alignItems="center">
-    <ColorText color="melt">{t`ampReaction.pyro_melt`}</ColorText>
-    <SqBadge sx={sqBadgeStyle} color="cryo">{uncoloredEleIcons.cryo}</SqBadge>
-    {`+`}
-    <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
-  </Box>,
-  hydro_vaporize: (t) => <Box display="flex" alignItems="center">
-    <ColorText color="vaporize">{t`ampReaction.hydro_vaporize`}</ColorText>
-    <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
-    {`+`}
-    <SqBadge sx={sqBadgeStyle} color="hydro">{uncoloredEleIcons.hydro}</SqBadge>
-  </Box>,
-  cryo_melt: (t) => <Box display="flex" alignItems="center">
-    <ColorText color="melt">{t`ampReaction.cryo_melt`}</ColorText>
-    <SqBadge sx={sqBadgeStyle} color="pyro">{uncoloredEleIcons.pyro}</SqBadge>
-    {`+`}
-    <SqBadge sx={sqBadgeStyle} color="cryo">{uncoloredEleIcons.cryo}</SqBadge>
-  </Box>
-
-} as const
-
 type ReactionToggleProps = Omit<ToggleButtonGroupProps, "color">
 export function ReactionToggle(props: ReactionToggleProps) {
   const { t } = useTranslation("page_character")
-  const { character: { reactionMode }, characterDispatch } = useContext(CharacterContext)
+  const { character: { reaction }, characterDispatch } = useContext(CharacterContext)
   const { data } = useContext(DataContext)
   const charEleKey = data.get(input.charEle).value as ElementKey
   const infusion = data.get(infusionNode).value as ElementKey
   if (!["pyro", "hydro", "cryo", "anemo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusion)) return null
   return <SolidToggleButtonGroup exclusive baseColor="secondary"
-    value={reactionMode} onChange={(_, reactionMode) => characterDispatch({ reactionMode })} {...props}>
-    <ToggleButton value="" disabled={reactionMode === ""} >No Reactions</ToggleButton >
-    {allReactionModes.map(rm => (charEleKey === "anemo" || charEleKey === rm.split("_")[0] || infusion === rm.split("_")[0]) && <ToggleButton key={rm} value={rm} disabled={reactionMode === rm}>
-      {reactionModeText[rm](t)}
+    value={reaction} onChange={(_, reaction) => characterDispatch({ reaction })} {...props}>
+    <ToggleButton value="" disabled={!reaction} >{t`ampReaction.noReaction`}</ToggleButton >
+    {allAmpReactions.map(rm => (charEleKey === "anemo" || charEleKey === rm.split("_")[0] || infusion === rm.split("_")[0]) && <ToggleButton key={rm} value={rm} disabled={reaction === rm}>
+      <AmpReactionModeText reaction={rm} subvariant={Object.keys(ampReactionMap[rm])[0]} />
     </ToggleButton >)}
   </SolidToggleButtonGroup>
 }

--- a/src/Components/HitModeEditor.tsx
+++ b/src/Components/HitModeEditor.tsx
@@ -64,11 +64,11 @@ export function ReactionToggle(props: ReactionToggleProps) {
   const { data } = useContext(DataContext)
   const charEleKey = data.get(input.charEle).value as ElementKey
   const infusion = data.get(infusionNode).value as ElementKey
-  if (!["pyro", "hydro", "cryo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusion)) return null
+  if (!["pyro", "hydro", "cryo", "anemo"].includes(charEleKey) && !["pyro", "hydro", "cryo"].includes(infusion)) return null
   return <SolidToggleButtonGroup exclusive baseColor="secondary"
     value={reactionMode} onChange={(_, reactionMode) => characterDispatch({ reactionMode })} {...props}>
     <ToggleButton value="" disabled={reactionMode === ""} >No Reactions</ToggleButton >
-    {allReactionModes.map(rm => (charEleKey === rm.split("_")[0] || infusion === rm.split("_")[0]) && <ToggleButton key={rm} value={rm} disabled={reactionMode === rm}>
+    {allReactionModes.map(rm => (charEleKey === "anemo" || charEleKey === rm.split("_")[0] || infusion === rm.split("_")[0]) && <ToggleButton key={rm} value={rm} disabled={reactionMode === rm}>
       {reactionModeText[rm](t)}
     </ToggleButton >)}
   </SolidToggleButtonGroup>

--- a/src/Data/Characters/Aloy/index.tsx
+++ b/src/Data/Characters/Aloy/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input } from '../../../Formula'
-import { constant, equal, greaterEq, infoMut, lookup, matchFull, naught, percent, subscript, unequal } from '../../../Formula/utils'
+import { compareEq, constant, equal, greaterEq, infoMut, lookup, naught, percent, subscript, unequal } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { range } from '../../../Util/Util'
 import { cond, sgt, st, trans } from '../../SheetUtil'
@@ -85,7 +85,7 @@ const dmgFormulas = {
   normal: Object.fromEntries(datamine.normal.hitArr.map((arr, i) =>
     [i, dmgNode("atk", arr, "normal", {
       hit: {
-        ele: matchFull("rush", condCoil, constant(elementKey), constant("physical"))
+        ele: compareEq("rush", condCoil, elementKey, "physical")
       }
     })])),
   charged: {

--- a/src/Data/Characters/KukiShinobu/index.tsx
+++ b/src/Data/Characters/KukiShinobu/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input } from '../../../Formula'
-import { constant, equal, greaterEq, infoMut, matchFull, percent, prod } from '../../../Formula/utils'
+import { compareEq, constant, equal, greaterEq, infoMut, percent, prod } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
 import CharacterSheet, { charTemplates, ICharacterSheet } from '../CharacterSheet'
@@ -106,7 +106,7 @@ const dmgFormulas = {
   },
   burst: {
     singleDmg: dmgNode("hp", datamine.burst.singleDmg, "burst"),
-    totalDmg: matchFull(condUnderHP, "on",
+    totalDmg: compareEq(condUnderHP, "on",
       dmgNode("hp", datamine.burst.maxDmgExtend, "burst"),
       dmgNode("hp", datamine.burst.maxDmgBase, "burst")
     )

--- a/src/Data/Characters/Qiqi/index.tsx
+++ b/src/Data/Characters/Qiqi/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input } from '../../../Formula'
-import { constant, equal, greaterEq, infoMut } from '../../../Formula/utils'
+import { equal, greaterEq, infoMut } from '../../../Formula/utils'
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, sgt, st, trans } from '../../SheetUtil'
 import CharacterSheet, { charTemplates, ICharacterSheet } from '../CharacterSheet'

--- a/src/Data/Characters/Qiqi/index.tsx
+++ b/src/Data/Characters/Qiqi/index.tsx
@@ -59,9 +59,9 @@ const [condA1Path, condA1] = cond(key, "QiqiA1")
 const [condC2Path, condC2] = cond(key, "QiqiC2")
 
 // Values here doesn't exist in skillParam_gen
-const nodeA1HealingBonus = equal(condA1, "on", greaterEq(input.asc, 1, constant(0.2)))
-const nodeC2ChargedDmgInc = equal(condC2, "on", greaterEq(input.constellation, 2, constant(0.15)))
-const nodeC2NormalDmgInc = equal(condC2, "on", greaterEq(input.constellation, 2, constant(0.15)))
+const nodeA1HealingBonus = equal(condA1, "on", greaterEq(input.asc, 1, 0.2))
+const nodeC2ChargedDmgInc = equal(condC2, "on", greaterEq(input.constellation, 2, 0.15))
+const nodeC2NormalDmgInc = equal(condC2, "on", greaterEq(input.constellation, 2, 0.15))
 
 const dmgFormulas = {
   normal: Object.fromEntries(datamine.normal.hitArr.map((arr, i) =>

--- a/src/Data/Characters/SangonomiyaKokomi/index.tsx
+++ b/src/Data/Characters/SangonomiyaKokomi/index.tsx
@@ -108,8 +108,8 @@ const c2BurstHeal = greaterEq(input.constellation, 2,
     prod(percent(datamine.c2.nc_heal_), input.total.hp)
   )
 )
-const c4AtkSpd_ = greaterEq(input.constellation, 4, constant(datamine.c4.atkSPD_))
-const c6Hydro_ = greaterEq(input.constellation, 6, equal(condC6, "on", constant(datamine.c6.hydro_)))
+const c4AtkSpd_ = greaterEq(input.constellation, 4, datamine.c4.atkSPD_)
+const c6Hydro_ = greaterEq(input.constellation, 6, equal(condC6, "on", datamine.c6.hydro_))
 
 const dmgFormulas = {
   normal: Object.fromEntries(datamine.normal.hitArr.map((arr, i) =>

--- a/src/Data/Characters/Venti/index.tsx
+++ b/src/Data/Characters/Venti/index.tsx
@@ -104,7 +104,7 @@ const [condC6Path, condC6] = cond(key, "c6")
 const c6_anemo_enemyRes_ = greaterEq(input.constellation, 6, equal(condC6, "takeDmg", datamine.constellation6.res_))
 const c6_ele_enemyRes_arr = Object.fromEntries(absorbableEle.map(ele => [
   `${ele}_enemyRes_`,
-  greaterEq(input.constellation, 6, equal(condC6, "takeDmg", equal(ele, condBurstAbsorption, constant(datamine.constellation6.res_))))
+  greaterEq(input.constellation, 6, equal(condC6, "takeDmg", equal(ele, condBurstAbsorption, datamine.constellation6.res_)))
 ]))
 
 const dmgFormulas = {

--- a/src/Data/Characters/Yoimiya/index.tsx
+++ b/src/Data/Characters/Yoimiya/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input } from '../../../Formula'
-import { constant, equal, greaterEq, infoMut, lookup, matchFull, percent, prod, subscript, sum, unequal, one, compareEq } from "../../../Formula/utils"
+import { compareEq, constant, equal, greaterEq, infoMut, lookup, one, percent, prod, subscript, sum, unequal } from "../../../Formula/utils"
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { INodeFieldDisplay } from '../../../Types/fieldDisplay'
 import { range } from '../../../Util/Util'

--- a/src/Data/Characters/Yoimiya/index.tsx
+++ b/src/Data/Characters/Yoimiya/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input } from '../../../Formula'
-import { constant, equal, greaterEq, infoMut, lookup, matchFull, percent, prod, subscript, sum, unequal, one } from "../../../Formula/utils"
+import { constant, equal, greaterEq, infoMut, lookup, matchFull, percent, prod, subscript, sum, unequal, one, compareEq } from "../../../Formula/utils"
 import { CharacterKey, ElementKey } from '../../../Types/consts'
 import { INodeFieldDisplay } from '../../../Types/fieldDisplay'
 import { range } from '../../../Util/Util'
@@ -86,7 +86,7 @@ const [condC1Path, condC1] = cond(characterKey, "c1")
 const [condC2Path, condC2] = cond(characterKey, "c2")
 const const3TalentInc = greaterEq(input.constellation, 3, 3)
 const const5TalentInc = greaterEq(input.constellation, 5, 3)
-const normal_dmgMult = matchFull(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: `char_${characterKey}:normMult_` }), one)
+const normal_dmgMult = compareEq(condSkill, "skill", subscript(input.total.skillIndex, datamine.skill.dmg_, { key: `char_${characterKey}:normMult_` }), one)
 const a1Stacks = lookup(condA1, Object.fromEntries(range(1, datamine.passive1.maxStacks).map(i => [i, constant(i)])), 0)
 const pyro_dmg_ = greaterEq(input.asc, 1, equal(condSkill, "skill", infoMut(prod(percent(datamine.passive1.pyro_dmg_), a1Stacks), { key: 'pyro_dmg_', variant: elementKey })))
 const atk_ = greaterEq(input.asc, 4, equal(condBurst, "on", unequal(input.activeCharKey, characterKey,
@@ -100,7 +100,7 @@ const normalEntries = datamine.normal.hitArr.map((arr, i) => [
     prod(subscript(input.total.autoIndex, arr, { key: "_" }), input.total.atk, normal_dmgMult),
     "normal", {
     hit: {
-      ele: matchFull(condSkill, "skill", constant(elementKey), constant("physical"))
+      ele: compareEq(condSkill, "skill", elementKey, "physical")
     }
   }
   )

--- a/src/Data/Weapons/Bow/Predator/index.tsx
+++ b/src/Data/Weapons/Bow/Predator/index.tsx
@@ -1,6 +1,6 @@
 import type { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
-import { constant, equal, lookup, naught, percent, prod } from "../../../../Formula/utils"
+import { equal, lookup, naught, percent, prod } from "../../../../Formula/utils"
 import { WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, sgt, st } from '../../../SheetUtil'

--- a/src/Data/Weapons/Bow/Predator/index.tsx
+++ b/src/Data/Weapons/Bow/Predator/index.tsx
@@ -22,7 +22,7 @@ const normal_dmg_ = lookup(condPassive, {
 const charged_dmg_ = lookup(condPassive, {
   ...objectKeyMap(range(1, 2), i => prod(chargedInc, i))
 }, naught)
-const atk = equal(input.activeCharKey, "Aloy", constant(66))
+const atk = equal(input.activeCharKey, "Aloy", 66)
 
 
 const data = dataObjForWeaponSheet(key, data_gen, {

--- a/src/Data/Weapons/Polearm/CalamityQueller/index.tsx
+++ b/src/Data/Weapons/Polearm/CalamityQueller/index.tsx
@@ -1,6 +1,6 @@
 import type { WeaponData } from 'pipeline'
 import { input } from '../../../../Formula'
-import { constant, lookup, matchFull, prod, subscript } from "../../../../Formula/utils"
+import { compareEq, constant, lookup, prod, subscript } from "../../../../Formula/utils"
 import { allElements, WeaponKey } from '../../../../Types/consts'
 import { objectKeyMap, range } from '../../../../Util/Util'
 import { cond, st, trans } from '../../../SheetUtil'
@@ -23,7 +23,7 @@ const atk_ = [0.032, 0.04, 0.048, 0.056, 0.064]
 
 const dmg_Nodes = Object.fromEntries(allElements.map(e => [`${e}_dmg_`, subscript(input.weapon.refineIndex, dmg_)]))
 const atkInc = prod(
-  matchFull(input.activeCharKey, input.charKey,
+  compareEq(input.activeCharKey, input.charKey,
     constant(1, { /* TODO: Add key for active char */ }),
     constant(2, { /* TODO: Add key for inactive char */ })),
   lookup(condStack, objectKeyMap(range(1, 6), i => constant(i)), 0), // TODO: Add key for stack

--- a/src/Data/Weapons/Sword/SwordOfDescension/index.tsx
+++ b/src/Data/Weapons/Sword/SwordOfDescension/index.tsx
@@ -13,7 +13,7 @@ import icon from './Icon.png'
 const key: WeaponKey = "SwordOfDescension"
 const data_gen = data_gen_json as WeaponData
 
-const atk = equal("Traveler", input.charKey, constant(66))
+const atk = equal("Traveler", input.charKey, 66)
 const dmg_ = customDmgNode(prod(percent(2), input.premod.atk), "elemental", {
   hit: { ele: constant("physical") }
 })

--- a/src/Database/Data/CharacterData.ts
+++ b/src/Database/Data/CharacterData.ts
@@ -44,12 +44,12 @@ export class CharacterDataManager extends DataManager<CharacterKey, string, ICac
   }
   deCache(char: ICachedCharacter): ICharacter {
     const {
-      key: characterKey, level, ascension, hitMode, elementKey, reactionMode, conditional,
+      key: characterKey, level, ascension, hitMode, elementKey, reaction, conditional,
       bonusStats, enemyOverride, talent, infusionAura, constellation, team,
       compareData
     } = char
     const result: ICharacter = {
-      key: characterKey, level, ascension, hitMode, reactionMode, conditional,
+      key: characterKey, level, ascension, hitMode, reaction, conditional,
       bonusStats, enemyOverride, talent, infusionAura, constellation, team,
       compareData
     }

--- a/src/Database/imports/parse.ts
+++ b/src/Database/imports/parse.ts
@@ -2,7 +2,7 @@ import Artifact from "../../Data/Artifacts/Artifact";
 import { ascensionMaxLevel } from "../../Data/LevelData";
 import { allMainStatKeys, allSubstatKeys, IArtifact, ISubstat } from "../../Types/artifact";
 import { ICharacter } from "../../Types/character";
-import { allArtifactRarities, allArtifactSets, allCharacterKeys, allElements, allHitModes, allReactionModes, allSlotKeys, allWeaponKeys } from "../../Types/consts";
+import { allArtifactRarities, allArtifactSets, allCharacterKeys, allElements, allHitModes, allAmpReactions, allSlotKeys, allWeaponKeys } from "../../Types/consts";
 import { IWeapon } from "../../Types/weapon";
 
 // MIGRATION STEP:
@@ -70,7 +70,7 @@ export function parseCharacter(obj: any): ICharacter | undefined {
   if (typeof obj !== "object") return
 
   let {
-    key: characterKey, level, ascension, hitMode, elementKey, reactionMode, conditional,
+    key: characterKey, level, ascension, hitMode, elementKey, reaction, conditional,
     bonusStats, enemyOverride, talent, infusionAura, constellation, team,
     compareData
   } = obj
@@ -82,7 +82,7 @@ export function parseCharacter(obj: any): ICharacter | undefined {
   if (!allHitModes.includes(hitMode)) hitMode = "avgHit"
   if (characterKey !== "Traveler") elementKey = undefined
   else if (!allElements.includes(elementKey)) elementKey = "anemo"
-  if (!allReactionModes.includes(reactionMode)) reactionMode = ""
+  if (!allAmpReactions.includes(reaction)) reaction = undefined
   if (!allElements.includes(infusionAura)) infusionAura = ""
   if (typeof constellation !== "number" && constellation < 0 && constellation > 6) constellation = 0
   if (typeof ascension !== "number" ||
@@ -110,7 +110,7 @@ export function parseCharacter(obj: any): ICharacter | undefined {
   if (typeof bonusStats !== "object" || !Object.entries(bonusStats).map(([_, num]) => typeof num === "number")) bonusStats = {}
   if (typeof enemyOverride !== "object" || !Object.entries(enemyOverride).map(([_, num]) => typeof num === "number")) enemyOverride = {}
   const result: ICharacter = {
-    key: characterKey, level, ascension, hitMode, reactionMode, conditional,
+    key: characterKey, level, ascension, hitMode, reaction, conditional,
     bonusStats, enemyOverride, talent, infusionAura, constellation, team,
     compareData
   }

--- a/src/Formula/api.tsx
+++ b/src/Formula/api.tsx
@@ -65,7 +65,7 @@ function dataObjForCharacter(char: ICachedCharacter): Data {
     },
     hit: {
       hitMode: constant(char.hitMode),
-      reaction: constant(undefined), // TODO: Convert to "vape", "melt", or undefined
+      reaction: constant(char.reaction),
     },
     customBonus: {},
   }

--- a/src/Formula/api.tsx
+++ b/src/Formula/api.tsx
@@ -59,6 +59,7 @@ function dataObjForCharacter(char: ICachedCharacter): Data {
       burst: constant(char.talent.burst),
     },
     enemy: {
+      eleAffliction: constant(undefined), // TODO
       ...objectKeyMap(allElementsWithPhy.map(ele => `${ele}_res_`), ele =>
         percent((char.enemyOverride[`${ele.slice(0, -5)}_enemyRes_`] ?? 10) / 100)),
       level: constant(char.enemyOverride.enemyLevel ?? char.level),

--- a/src/Formula/api.tsx
+++ b/src/Formula/api.tsx
@@ -59,14 +59,13 @@ function dataObjForCharacter(char: ICachedCharacter): Data {
       burst: constant(char.talent.burst),
     },
     enemy: {
-      eleAffliction: constant(undefined), // TODO
       ...objectKeyMap(allElementsWithPhy.map(ele => `${ele}_res_`), ele =>
         percent((char.enemyOverride[`${ele.slice(0, -5)}_enemyRes_`] ?? 10) / 100)),
       level: constant(char.enemyOverride.enemyLevel ?? char.level),
     },
     hit: {
       hitMode: constant(char.hitMode),
-      reaction: constant(char.reactionMode),
+      reaction: constant(undefined), // TODO: Convert to "vape", "melt", or undefined
     },
     customBonus: {},
   }

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -218,14 +218,12 @@ const common: Data = {
     ),
     ampMulti: lookup(enemy.eleAffliction, {
       pyro: lookup(hit.ele, {
-        hydro: infoMut(prod(2, sum(baseAmpBonus, total.vaporize_dmg_)), { key: "vaporize_dmg_" }),
-        cryo: infoMut(prod(1.5, sum(baseAmpBonus, total.melt_dmg_)), { key: "melt_dmg_" }),
-      }, 1),
-      cryo: compareEq(hit.ele, "pyro",
-        infoMut(prod(2, sum(baseAmpBonus, total.melt_dmg_)), { key: "melt_dmg_" }), 1),
-      hydro: compareEq(hit.ele, "pyro",
-        infoMut(prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)), { key: "vaporize_dmg_" }), 1),
-    }, 1),
+        hydro: prod(2, sum(baseAmpBonus, total.vaporize_dmg_)),
+        cryo: prod(1.5, sum(baseAmpBonus, total.melt_dmg_)),
+      }, one),
+      cryo: compareEq(hit.ele, "pyro", prod(2, sum(baseAmpBonus, total.melt_dmg_)), one),
+      hydro: compareEq(hit.ele, "pyro", prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)), one),
+    }, one),
   },
 
   enemy: {

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -117,7 +117,7 @@ const input = setReadNodeKeys(deepClone({
 
   hit: {
     ele: stringRead(), reaction: stringRead(), move: stringRead(), hitMode: stringRead(),
-    base: read("add", { key: "base" }),
+    base: read("add", { key: "base" }), ampMulti: read(),
 
     dmgBonus: read("add", { key: "dmg_", pivot }),
     dmgInc: read("add", { key: "dmgInc", pivot }),
@@ -217,17 +217,18 @@ const common: Data = {
       enemy.def,
       lookup(hit.ele,
         objectKeyMap(allElements, ele => enemy[`${ele}_resMulti` as const]), NaN),
-      lookup(effectiveReaction, {
-        melt: lookup(hit.ele, {
-          pyro: prod(2, sum(baseAmpBonus, total.melt_dmg_)),
-          cryo: prod(1.5, sum(baseAmpBonus, total.melt_dmg_)),
-        }, 1, { key: "melt_dmg_" }),
-        vaporize: lookup(hit.ele, {
-          hydro: prod(2, sum(baseAmpBonus, total.vaporize_dmg_)),
-          pyro: prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)),
-        }, 1, { key: "vaporize_dmg_" }),
-      }, 1),
+      hit.ampMulti,
     ),
+    ampMulti: lookup(effectiveReaction, {
+      melt: lookup(hit.ele, {
+        pyro: prod(2, sum(baseAmpBonus, total.melt_dmg_)),
+        cryo: prod(1.5, sum(baseAmpBonus, total.melt_dmg_)),
+      }, 1, { key: "melt_dmg_" }),
+      vaporize: lookup(hit.ele, {
+        hydro: prod(2, sum(baseAmpBonus, total.vaporize_dmg_)),
+        pyro: prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)),
+      }, 1, { key: "vaporize_dmg_" }),
+    }, 1),
   },
 
   enemy: {

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -215,7 +215,7 @@ const common: Data = {
       hit.ampMulti,
     ),
     ampMulti: lookup(hit.reaction, {
-      vape: lookup(hit.ele, {
+      vaporize: lookup(hit.ele, {
         hydro: prod(2, sum(baseAmpBonus, total.vaporize_dmg_)),
         pyro: prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)),
 

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -2,7 +2,7 @@ import { allEleEnemyResKeys } from "../KeyMap"
 import { allArtifactSets, allElementsWithPhy, allRegions, allSlotKeys } from "../Types/consts"
 import { crawlObject, deepClone, objectKeyMap, objectKeyValueMap } from "../Util/Util"
 import { Data, Info, NumNode, ReadNode, StrNode } from "./type"
-import { compareEq, constant, frac, infoMut, lookup, max, min, naught, one, percent, prod, read, res, setReadNodeKeys, stringRead, sum, todo } from "./utils"
+import { constant, frac, lookup, max, min, naught, one, percent, prod, read, res, setReadNodeKeys, stringRead, sum, todo } from "./utils"
 
 const asConst = true as const, pivot = true as const
 
@@ -106,7 +106,6 @@ const input = setReadNodeKeys(deepClone({
   }),
 
   enemy: {
-    eleAffliction: stringRead(),
     def: read("add", { key: "enemyDef_multi", pivot }),
     ...objectKeyMap(allElements.map(ele => `${ele}_resMulti` as const), _ => read()),
 
@@ -117,7 +116,6 @@ const input = setReadNodeKeys(deepClone({
   },
 
   hit: {
-    /** @deprecated Use `enemy.eleAfflication` instead */
     reaction: stringRead(),
     ele: stringRead(), move: stringRead(), hitMode: stringRead(),
     base: read("add", { key: "base" }), ampMulti: read(),
@@ -216,13 +214,16 @@ const common: Data = {
         objectKeyMap(allElements, ele => enemy[`${ele}_resMulti` as const]), NaN),
       hit.ampMulti,
     ),
-    ampMulti: lookup(enemy.eleAffliction, {
-      pyro: lookup(hit.ele, {
+    ampMulti: lookup(hit.reaction, {
+      vape: lookup(hit.ele, {
         hydro: prod(2, sum(baseAmpBonus, total.vaporize_dmg_)),
+        pyro: prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)),
+
+      }, one),
+      melt: lookup(hit.ele, {
+        pyro: prod(2, sum(baseAmpBonus, total.melt_dmg_)),
         cryo: prod(1.5, sum(baseAmpBonus, total.melt_dmg_)),
       }, one),
-      cryo: compareEq(hit.ele, "pyro", prod(2, sum(baseAmpBonus, total.melt_dmg_)), one),
-      hydro: compareEq(hit.ele, "pyro", prod(1.5, sum(baseAmpBonus, total.vaporize_dmg_)), one),
     }, one),
   },
 

--- a/src/Formula/index.ts
+++ b/src/Formula/index.ts
@@ -106,6 +106,7 @@ const input = setReadNodeKeys(deepClone({
   }),
 
   enemy: {
+    eleAffliction: stringRead(),
     def: read("add", { key: "enemyDef_multi", pivot }),
     ...objectKeyMap(allElements.map(ele => `${ele}_resMulti` as const), _ => read()),
 
@@ -116,7 +117,9 @@ const input = setReadNodeKeys(deepClone({
   },
 
   hit: {
-    ele: stringRead(), reaction: stringRead(), move: stringRead(), hitMode: stringRead(),
+    /** @deprecated Use `enemy.eleAfflication` instead */
+    reaction: stringRead(),
+    ele: stringRead(), move: stringRead(), hitMode: stringRead(),
     base: read("add", { key: "base" }), ampMulti: read(),
 
     dmgBonus: read("add", { key: "dmg_", pivot }),
@@ -145,9 +148,9 @@ total.critRate_.info!.prefix = "uncapped"
 const baseAmpBonus = sum(one, prod(25 / 9, frac(total.eleMas, 1400)))
 /** Effective reaction, taking into account the hit's element */
 export const effectiveReaction = lookup(hit.ele, {
-  pyro: lookup(hit.reaction, { pyro_vaporize: constant("vaporize"), pyro_melt: constant("melt") }, undefined),
-  hydro: equalStr(hit.reaction, "hydro_vaporize", "vaporize"),
-  cryo: equalStr(hit.reaction, "cryo_melt", "melt"),
+  pyro: lookup(enemy.eleAffliction, { hydro: constant("vaporize"), cryo: constant("melt") }, undefined),
+  hydro: equalStr(enemy.eleAffliction, "pyro", "vaporize"),
+  cryo: equalStr(enemy.eleAffliction, "pyro", "melt"),
 }, undefined)
 
 const common: Data = {

--- a/src/Formula/reaction.ts
+++ b/src/Formula/reaction.ts
@@ -31,7 +31,7 @@ const trans = {
       infoMut(prod(multi, transMulti1), { asConst }),
       sum(one, transMulti2, input.total[`${reaction}_dmg_`]),
       input.enemy[`${ele}_resMulti`]),
-      { key: `${reaction}_hit`, variant: reaction })
+      { key: `${reaction}_hit` })
   }),
   swirl: objectKeyMap(transformativeReactions.swirl.variants, ele => {
     const base = [
@@ -42,7 +42,7 @@ const trans = {
     return infoMut(["pyro", "hydro", "cryo"].includes(ele)
       ? data(prod(...base, input.hit.ampMulti), { hit: { ele: constant(ele) } })
       : prod(...base),
-      { key: `${ele}_swirl_hit`, variant: ele })
+      { key: `${ele}_swirl_hit` })
   })
 }
 export const reactions = {

--- a/src/Formula/reaction.ts
+++ b/src/Formula/reaction.ts
@@ -39,9 +39,15 @@ const trans = {
       sum(one, transMulti2, input.total.swirl_dmg_),
       input.enemy[`${ele}_resMulti`]
     ]
-    return infoMut(["pyro", "hydro", "cryo"].includes(ele)
-      ? data(prod(...base, input.hit.ampMulti), { hit: { ele: constant(ele) } })
-      : prod(...base),
+    return infoMut(
+      // CAUTION:
+      // Add amp multiplier only to swirls that have amp reactions.
+      // It is wasteful to add them indiscriminately, but this means
+      // that we need to audit and add appropriate elements here
+      // should amp reactions be added to more swirls.
+      ["pyro", "hydro", "cryo"].includes(ele)
+        ? data(prod(...base, input.hit.ampMulti), { hit: { ele: constant(ele) } })
+        : prod(...base),
       { key: `${ele}_swirl_hit` })
   })
 }

--- a/src/Formula/reaction.ts
+++ b/src/Formula/reaction.ts
@@ -2,7 +2,7 @@ import { transformativeReactions } from "../KeyMap/StatConstants";
 import { absorbableEle } from "../Types/consts";
 import { objectKeyMap } from "../Util/Util";
 import { input } from "./index";
-import { frac, infoMut, percent, prod, subscript, sum, one } from "./utils";
+import { frac, infoMut, percent, prod, subscript, sum, one, data, constant } from "./utils";
 
 // https://github.com/Dimbreath/GenshinData/blob/72c9112a7c5e8e5014f61009a1a2764e266aeab7/ExcelBinOutput/ElementCoeffExcelConfigData.json
 //   or if the permalink is dead,
@@ -33,12 +33,17 @@ const trans = {
       input.enemy[`${ele}_resMulti`]),
       { key: `${reaction}_hit`, variant: reaction })
   }),
-  swirl: objectKeyMap(transformativeReactions.swirl.variants, ele => infoMut(
-    prod(
+  swirl: objectKeyMap(transformativeReactions.swirl.variants, ele => {
+    const base = [
       infoMut(prod(transformativeReactions.swirl.multi, transMulti1), { asConst }),
       sum(one, transMulti2, input.total.swirl_dmg_),
-      input.enemy[`${ele}_resMulti`]),
-    { key: `${ele}_swirl_hit`, variant: ele }))
+      input.enemy[`${ele}_resMulti`]
+    ]
+    return infoMut(["pyro", "hydro", "cryo"].includes(ele)
+      ? data(prod(...base, input.hit.ampMulti), { hit: { ele: constant(ele) } })
+      : prod(...base),
+      { key: `${ele}_swirl_hit`, variant: ele })
+  })
 }
 export const reactions = {
   anemo: {

--- a/src/Formula/uiData.tsx
+++ b/src/Formula/uiData.tsx
@@ -307,8 +307,9 @@ function accumulateInfo<V>(operands: ContextNodeDisplay<V>[]): Info {
   function score(variant: Required<Info>["variant"]) {
     switch (variant) {
       case "overloaded": case "shattered": case "electrocharged": case "superconduct":
-      case "vaporize": case "swirl": case "melt": case "success": return 2
+      case "vaporize": case "melt": case "success": return 2
       case "anemo": case "cryo": case "hydro": case "pyro": case "electro": case "geo": return 1
+      case "swirl": return 0.5
       case "physical": return 0
       default: assertUnreachable(variant)
     }

--- a/src/Formula/utils.ts
+++ b/src/Formula/utils.ts
@@ -61,6 +61,14 @@ export function res(base: Num): NumNode {
   return { operation: "res", operands: intoOps([base]) }
 }
 
+/** v1 == v2 ? eq : neq */
+export function compareEq(v1: Num, v2: Num, eq: Num, neq: Num, info?: Info): MatchNode<NumNode, NumNode>
+export function compareEq(v1: Num, v2: Num, eq: Str, neq: Str, info?: Info): MatchNode<NumNode, StrNode>
+export function compareEq(v1: Str, v2: Str, eq: Num, neq: Num, info?: Info): MatchNode<StrNode, NumNode>
+export function compareEq(v1: Str, v2: Str, eq: Str, neq: Str, info?: Info): MatchNode<StrNode, StrNode>
+export function compareEq(v1: Num | Str, v2: Num | Str, eq: Num | Str, neq: Num | Str, info?: Info): MatchNode<NumNode | StrNode, NumNode | StrNode> {
+  return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(eq), intoV(neq)], info }
+}
 /** v1 == v2 ? pass : 0 */
 export function equal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode, NumNode>
 export function equal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<StrNode, NumNode>
@@ -173,7 +181,7 @@ type NodeList = _NodeList | ReadNode<number> | ReadNode<string>
 
 /**
  * `v1` === `v2` ? `match` : `unmatch`
- * @deprecated Use `equal`, `unequal`, or `equalStr` instead
+ * @deprecated Use `equal`, `unequal`, `equalStr`, or `compareEq` instead
  */
 export function matchFull(v1: Num, v2: Num, match: Num, unmatch: Num, info?: Info): MatchNode<NumNode, NumNode>
 export function matchFull(v1: Num, v2: Num, match: Str, unmatch: Str, info?: Info): MatchNode<NumNode, StrNode>

--- a/src/PageCharacter/CharacterDisplay/FormulaModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/FormulaModal.tsx
@@ -1,6 +1,7 @@
 import { ExpandMore } from '@mui/icons-material';
 import { Accordion, AccordionDetails, AccordionSummary, Box, CardContent, CardHeader, Divider, Skeleton, Typography } from '@mui/material';
 import { MutableRefObject, Suspense, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import AmpReactionModeText from '../../Components/AmpReactionModeText';
 import CardDark from '../../Components/Card/CardDark';
 import CardHeaderCustom from '../../Components/Card/CardHeaderCustom';
 import CardLight from '../../Components/Card/CardLight';
@@ -12,10 +13,11 @@ import SqBadge from '../../Components/SqBadge';
 import { DataContext } from '../../Context/DataContext';
 import { FormulaDataContext } from '../../Context/FormulaDataContext';
 import { getDisplayHeader, getDisplaySections } from '../../Formula/DisplayUtil';
-import { DisplaySub } from '../../Formula/type';
+import { DisplaySub, Variant } from '../../Formula/type';
 import { NodeDisplay } from '../../Formula/uiData';
 import KeyMap, { valueString } from '../../KeyMap';
 import usePromise from '../../ReactHooks/usePromise';
+import { allAmpReactions, AmpReactionKey } from '../../Types/consts';
 
 export default function FormulaModal() {
   const { modalOpen } = useContext(FormulaDataContext)
@@ -70,6 +72,9 @@ function FormulaAccordian({ node }: { node: NodeDisplay }) {
   return <Accordion sx={{ bgcolor: "contentDark.main" }} expanded={node === contextNode || expanded} onChange={handleChange} ref={scrollRef} >
     <AccordionSummary expandIcon={<ExpandMore />} >
       <Typography><ColorText color={node.info.variant}>{KeyMap.get(node.info.key ?? "")}</ColorText> <strong>{valueString(node.value, node.unit)}</strong></Typography>
+      {allAmpReactions.includes(node.info.variant as any) && <SqBadge sx={{ display: "inline-block", ml: "auto", mr: 2, my: "-0.25em" }}>
+        <AmpReactionModeText reaction={node.info.variant as AmpReactionKey} subvariant={node.info.subVariant as Variant} />
+      </SqBadge>}
     </AccordionSummary>
     <AccordionDetails >
       {node.formulas.map((subform, i) => <Typography key={i}>{subform}</Typography>)}

--- a/src/PageCharacter/CharacterDisplay/FormulaModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/FormulaModal.tsx
@@ -72,9 +72,9 @@ function FormulaAccordian({ node }: { node: NodeDisplay }) {
   return <Accordion sx={{ bgcolor: "contentDark.main" }} expanded={node === contextNode || expanded} onChange={handleChange} ref={scrollRef} >
     <AccordionSummary expandIcon={<ExpandMore />} >
       <Typography><ColorText color={node.info.variant}>{KeyMap.get(node.info.key ?? "")}</ColorText> <strong>{valueString(node.value, node.unit)}</strong></Typography>
-      {allAmpReactions.includes(node.info.variant as any) && <SqBadge sx={{ display: "inline-block", ml: "auto", mr: 2, my: "-0.25em" }}>
+      {allAmpReactions.includes(node.info.variant as any) && <Box sx={{ display: "inline-block", ml: "auto", mr: 2 }}>
         <AmpReactionModeText reaction={node.info.variant as AmpReactionKey} subvariant={node.info.subVariant as Variant} />
-      </SqBadge>}
+      </Box>}
     </AccordionSummary>
     <AccordionDetails >
       {node.formulas.map((subform, i) => <Typography key={i}>{subform}</Typography>)}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
@@ -43,7 +43,7 @@ export function TeamBuffDisplay() {
   Object.entries(teamBuffs.premod ?? {}).forEach(([key, node]) =>
     !node.isEmpty && node.value !== 0 && nodes.push([["premod", key], node]))
   Object.entries(teamBuffs.enemy ?? {}).forEach(([key, node]) =>
-    !node.isEmpty && node.value !== 0 && nodes.push([["enemy", key], node]))
+    !node.isEmpty && typeof node.value === "number" && node.value !== 0 && nodes.push([["enemy", key], node as NodeDisplay<number>]))
   if (!nodes.length) return null
   return <CardLight>
     <CardContent>

--- a/src/ReactHooks/useCharSelectionCallback.tsx
+++ b/src/ReactHooks/useCharSelectionCallback.tsx
@@ -47,7 +47,6 @@ export function initialCharacter(key: CharacterKey): ICachedCharacter {
     level: 1,
     ascension: 0,
     hitMode: "avgHit",
-    reactionMode: "",
     equippedArtifacts: objectKeyMap(allSlotKeys, () => ""),
     equippedWeapon: "",
     conditional: {},

--- a/src/Types/character.d.ts
+++ b/src/Types/character.d.ts
@@ -1,5 +1,5 @@
 import { EleEnemyResKey, StatKey } from "../KeyMap";
-import { CharacterKey, ElementKey, HitModeKey, InfusionAuraElements, ReactionModeKey, SlotKey } from "./consts";
+import { CharacterKey, ElementKey, HitModeKey, InfusionAuraElements, AmpReactionKey, SlotKey } from "./consts";
 import { IConditionalValues } from "./IConditional";
 import { DocumentSection } from "./sheet";
 export interface ICharacter {
@@ -17,7 +17,7 @@ export interface ICharacter {
   // GO-specific
   hitMode: HitModeKey
   elementKey?: ElementKey
-  reactionMode: ReactionModeKey | ""
+  reaction?: AmpReactionKey
   conditional: IConditionalValues
   bonusStats: Partial<Record<StatKey, number>>
   enemyOverride: Partial<Record<EleEnemyResKey | "enemyLevel" | "enemyDefRed_" | "enemyDefIgn_", number>>

--- a/src/Types/consts.ts
+++ b/src/Types/consts.ts
@@ -1,6 +1,6 @@
 export const allHitModes = ["hit", "avgHit", "critHit"] as const
 export const allRegions = ["mondstadt", "liyue", "inazuma", "sumeru", "fontaine", "natlan", "snezhnaya", "khaenriah"] as const
-export const allReactionModes = ["hydro_vaporize", "pyro_vaporize", "pyro_melt", "cryo_melt",] as const
+export const allAmpReactions = ["vaporize", "melt",] as const
 export const allArtifactSetCount = [1, 2, 3, 4, 5] as const
 export const allRarities = [5, 4, 3, 2, 1] as const
 export const allArtifactRarities = [5, 4, 3] as const
@@ -272,7 +272,7 @@ export const characterSpecializedStatKeys = ["hp_", "atk_", "def_", "eleMas", "e
 
 export type HitModeKey = typeof allHitModes[number]
 export type Region = typeof allRegions[number]
-export type ReactionModeKey = typeof allReactionModes[number]
+export type AmpReactionKey = typeof allAmpReactions[number]
 export type SetNum = typeof allArtifactSetCount[number]
 export type Rarity = typeof allRarities[number]
 export type ArtifactRarity = typeof allArtifactRarities[number]


### PR DESCRIPTION
- Add `input.hit.ampMulti`
- Add swirl amp multiplier
- Add ReactionToggle to anemo characters
- Update Reaction toggle.
- Update formula tooltip to show reaction direction.

![image](https://user-images.githubusercontent.com/1754901/182497178-bceb2657-d1a5-4cde-9470-bc45faf1464a.png)
