### PR TITLE
Fixes

### DIFF
--- a/src/Components/Character/CharacterSelectionModal.tsx
+++ b/src/Components/Character/CharacterSelectionModal.tsx
@@ -126,6 +126,7 @@ function CharacterBtn({ onClick, characterKey, characterSheet }: { onClick: () =
   const teamData = useTeamData(characterKey)
   const { target: data } = teamData?.[characterKey] ?? {}
   const rarity = characterSheet.rarity
+  const element = data ? data.get(input.charEle).value : undefined
   const [{ favorite }, setCharMeta] = useDBState(`charMeta_${characterKey}`, initCharMeta)
   return <Suspense fallback={<Skeleton variant="rectangular" height={130} />}><Box>
     {favorite !== undefined && <Box display="flex" position="absolute" alignSelf="start" zIndex={1}>
@@ -139,7 +140,7 @@ function CharacterBtn({ onClick, characterKey, characterSheet }: { onClick: () =
         <Box sx={{ pl: 1 }}>
           <Typography><strong>{characterSheet.name}</strong></Typography>
           {data ? <>
-            <Typography variant="h6" sx={{ display: "flex", gap: 0.5, alignItems: "center" }}> {characterSheet.elementKey && StatIcon[characterSheet.elementKey]} <ImgIcon src={Assets.weaponTypes?.[characterSheet.weaponTypeKey]} />{` `}{getLevelString(data.get(input.lvl).value, data.get(input.asc).value as Ascension)}</Typography>
+            <Typography variant="h6" sx={{ display: "flex", gap: 0.5, alignItems: "center" }}> {element && StatIcon[element]} <ImgIcon src={Assets.weaponTypes?.[characterSheet.weaponTypeKey]} />{` `}{getLevelString(data.get(input.lvl).value, data.get(input.asc).value as Ascension)}</Typography>
             <Typography variant="subtitle2" >
               <SqBadge color="success">{`C${data.get(input.constellation).value}`}</SqBadge>{` `}
               <SqBadge color={data.get(input.bonus.auto).value ? "info" : "secondary"}><strong >{data.get(input.total.auto).value}</strong></SqBadge>{` `}

--- a/src/Components/StatIcon.tsx
+++ b/src/Components/StatIcon.tsx
@@ -13,14 +13,14 @@ export const elementSvg = {
   physical: faPhysicalDmgBonus,
 }
 export const uncoloredEleIcons = {
-  anemo: <FontAwesomeIcon icon={faAnemo as any} fixedWidth />,
-  geo: <FontAwesomeIcon icon={faGeo as any} fixedWidth />,
-  electro: <FontAwesomeIcon icon={faElectro as any} fixedWidth />,
-  hydro: <FontAwesomeIcon icon={faHydro as any} fixedWidth />,
-  pyro: <FontAwesomeIcon icon={faPyro as any} fixedWidth />,
-  cryo: <FontAwesomeIcon icon={faCryo as any} fixedWidth />,
-  dendro: <FontAwesomeIcon icon={faDendro as any} fixedWidth />,
-  physical: <FontAwesomeIcon icon={faPhysicalDmgBonus as any} fixedWidth />,
+  anemo: <FontAwesomeIcon icon={faAnemo as any} />,
+  geo: <FontAwesomeIcon icon={faGeo as any} />,
+  electro: <FontAwesomeIcon icon={faElectro as any} />,
+  hydro: <FontAwesomeIcon icon={faHydro as any} />,
+  pyro: <FontAwesomeIcon icon={faPyro as any} />,
+  cryo: <FontAwesomeIcon icon={faCryo as any} />,
+  dendro: <FontAwesomeIcon icon={faDendro as any} />,
+  physical: <FontAwesomeIcon icon={faPhysicalDmgBonus as any} />,
 } as const
 const coloredEleIcon = objectKeyMap(Object.keys(uncoloredEleIcons), key => <ColorText color={key} sx={{ lineHeight: 1 }} >{uncoloredEleIcons[key]}</ColorText>)
 

--- a/src/Data/Characters/SangonomiyaKokomi/index.tsx
+++ b/src/Data/Characters/SangonomiyaKokomi/index.tsx
@@ -85,13 +85,13 @@ const burstNormalDmgInc = equal(condBurst, "on", prod(
     subscript(input.total.burstIndex, datamine.burst.nBonus_, { key: '_' }),
     greaterEq(input.asc, 4, prod(percent(datamine.p2.heal_ratio_), input.premod.heal_)),
   ),
-  input.premod.hp))
+  input.premod.hp), { variant: "invalid" })
 const burstChargedDmgInc = equal(condBurst, "on", prod(
   sum(
     subscript(input.total.burstIndex, datamine.burst.cBonus_, { key: '_' }),
     greaterEq(input.asc, 4, prod(percent(datamine.p2.heal_ratio_), input.premod.heal_)),
   ),
-  input.premod.hp))
+  input.premod.hp), { variant: "invalid" })
 const burstSkillDmgInc = equal(condBurst, "on", prod(
   subscript(input.total.burstIndex, datamine.burst.sBonus_, { key: '_' }),
   input.premod.hp))

--- a/src/Data/Characters/YunJin/index.tsx
+++ b/src/Data/Characters/YunJin/index.tsx
@@ -1,6 +1,6 @@
 import { CharacterData } from 'pipeline'
 import { input, tally } from '../../../Formula'
-import { equal, greaterEq, infoMut, prod, subscript, sum } from '../../../Formula/utils'
+import { equal, greaterEq, infoMut, prod, subscript, sum, unequal } from '../../../Formula/utils'
 import { allElements, CharacterKey, ElementKey } from '../../../Types/consts'
 import { cond, sgt, trans } from '../../SheetUtil'
 import CharacterSheet, { charTemplates, ICharacterSheet } from '../CharacterSheet'
@@ -216,7 +216,26 @@ const sheet: ICharacterSheet = {
             }]
           }
         }
-      })]),
+      }), ct.conditionalTemplate("constellation4", {
+        // C4 conditional in teambuff panel if burst is enabled
+        teamBuff: true,
+        canShow: unequal(input.activeCharKey, key, equal(condBurst, "on", 1)),
+        value: condC4,
+        path: condC4Path,
+        name: trm("c4"),
+        states: {
+          on: {
+            fields: [{
+              node: nodeC4
+            }, {
+              text: sgt("duration"),
+              value: datamine.constellation4.duration,
+              unit: "s"
+            },]
+          }
+        }
+      })
+    ]),
 
       passive1: ct.talentTemplate("passive1"),
       passive2: ct.talentTemplate("passive2", [ct.fieldsTemplate("passive2", {

--- a/src/Formula/uiData.tsx
+++ b/src/Formula/uiData.tsx
@@ -307,9 +307,9 @@ function accumulateInfo<V>(operands: ContextNodeDisplay<V>[]): Info {
   function score(variant: Required<Info>["variant"]) {
     switch (variant) {
       case "overloaded": case "shattered": case "electrocharged": case "superconduct":
-      case "vaporize": case "melt": case "heal": return 2
+      case "vaporize": case "melt": return 2
       case "anemo": case "cryo": case "hydro": case "pyro": case "electro": case "geo": return 1
-      case "swirl": return 0.5
+      case "swirl": case "heal": return 0.5
       case "physical": return 0
       case "invalid": return -1
       default: assertUnreachable(variant)

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabTeambuffs.tsx
@@ -51,7 +51,7 @@ export function TeamBuffDisplay() {
     <Divider />
     <CardContent>
       <Grid container>
-        {nodes.map(([path, n], i) => n && <Grid item xs={12} key={n.info.key ?? "" + i} >
+        {nodes.map(([path, n], i) => n && <Grid item xs={12} key={(n.info.key ?? "") + i} >
           <NodeFieldDisplay node={n} oldValue={objPathValue(oldData?.getTeamBuff(), path)?.value} />
         </Grid>)}
       </Grid>


### PR DESCRIPTION
## Fixes
* Fix #547 - Add element icon to Traveler button in selection modal
* Fix #550 - Fix DMG bonus on CharacterCard not lining up
* Fix #551 - Fix Kokomi attacks being converted to "heal" variant, reduced "heal" variant priority
* Fix #553 - Fix Yunjin C4 not showing in teambuff panel when needed
* Fix #530 - Fix pyro dmg visual bug with Bennett/Kazuha