### PR TITLE
Move mount path and print server url

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prebuild": "npm run gen-files",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "testserver": "set PUBLIC_URL= && npm run build && node ./test-server.js",
+    "testserver": "npm run build && node ./test-server.js",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "postinstall": "node ./clone_genshindata.js",
     "pipeline-datamined": "cd ./pipeline && npx ts-node ./main.ts",

--- a/test-server.js
+++ b/test-server.js
@@ -2,12 +2,14 @@ const express = require('express');
 const path = require('path');
 const app = express();
 
-app.use(express.static(path.join(__dirname, 'build')));
+const mount_path = '/genshin-optimizer'
+app.use(mount_path, express.static(path.join(__dirname, 'build')));
 
-app.get('/', function (req, res) {
+app.get(mount_path, function (req, res) {
   res.sendFile(path.join(__dirname, 'build', 'index.html'));
 });
 
-app.listen(9000, () => {
-  console.log("Test Server Listening on port 9000");
+const port = 9000
+app.listen(port, () => {
+  console.log(`Test Server Listening at http://localhost:${port}${mount_path}`);
 });


### PR DESCRIPTION
Plain `npm build` doesn't work with the testserver, so this addresses that