### PR TITLE
Fix sorting inconsistencies

### DIFF
--- a/src/Components/Character/CharacterAutocomplete.tsx
+++ b/src/Components/Character/CharacterAutocomplete.tsx
@@ -43,7 +43,7 @@ export default function CharacterAutocomplete({ value, onChange, defaultText = "
   const sortConfigs = useMemo(() => characterSheets && characterSortConfigs(database, characterSheets), [database, characterSheets])
   const characterKeys = useMemo(() => sortConfigs
     && database.chars.keys.filter(ck => characterSheets?.[ck] && filter(characterSheets[ck], ck))
-      .sort(sortFunction(["favorite", "name"], false, sortConfigs)),
+      .sort(sortFunction([...sortConfigs.favorite.sortByKeys, ...sortConfigs.name.sortByKeys], false, sortConfigs)),
     [characterSheets, sortConfigs, filter, database.chars.keys])
 
   const textForValue = useCallback((value: CharacterAutocompleteValue): string => {

--- a/src/PageArtifact/ArtifactSort.ts
+++ b/src/PageArtifact/ArtifactSort.ts
@@ -49,22 +49,23 @@ export function artifactSortConfigs(effFilterSet: Set<SubstatKey>, probabilityFi
   return {
     rarity: {
       getValue: art => art.rarity ?? 0,
-      tieBreakers: ["level", "artsetkey"]
+      sortByKeys: ["rarity", "level", "artsetkey"]
     },
     level: {
       getValue: art => art.level ?? 0,
-      tieBreakers: ["artsetkey", "rarity"]
+      sortByKeys: ["level", "artsetkey", "rarity"]
     },
     artsetkey: {
       getValue: art => art.setKey ?? "",
-      tieBreakers: ["level", "rarity"]
+      sortByKeys: ["artsetkey", "level", "rarity"]
     },
     efficiency: {
       getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).currentEfficiency,
-      tieBreakers: ["artsetkey", "rarity", "level", "mefficiency"]
+      sortByKeys: ["efficiency", "artsetkey", "rarity", "level", "mefficiency"]
     },
     mefficiency: {
-      getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).maxEfficiency
+      getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).maxEfficiency,
+      sortByKeys: ["mefficiency", "artsetkey", "rarity", "level", "efficiency"]
     },
     probability: {
       getValue: art => {
@@ -72,7 +73,8 @@ export function artifactSortConfigs(effFilterSet: Set<SubstatKey>, probabilityFi
         const prob = (art as any).probability
         if (prob === undefined) return probability(art, probabilityFilter);
         return prob
-      }
+      },
+      sortByKeys: ["probability", "artsetkey", "rarity", "level"]
     }
   }
 }

--- a/src/PageArtifact/ArtifactSort.ts
+++ b/src/PageArtifact/ArtifactSort.ts
@@ -49,18 +49,19 @@ export function artifactSortConfigs(effFilterSet: Set<SubstatKey>, probabilityFi
   return {
     rarity: {
       getValue: art => art.rarity ?? 0,
-      tieBreaker: "level"
+      tieBreakers: ["level", "artsetkey"]
     },
     level: {
       getValue: art => art.level ?? 0,
-      tieBreaker: "artsetkey"
+      tieBreakers: ["artsetkey", "rarity"]
     },
     artsetkey: {
       getValue: art => art.setKey ?? "",
-      tieBreaker: "level"
+      tieBreakers: ["level", "rarity"]
     },
     efficiency: {
-      getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).currentEfficiency
+      getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).currentEfficiency,
+      tieBreakers: ["artsetkey", "rarity", "level", "mefficiency"]
     },
     mefficiency: {
       getValue: art => Artifact.getArtifactEfficiency(art, effFilterSet).maxEfficiency

--- a/src/PageArtifact/index.tsx
+++ b/src/PageArtifact/index.tsx
@@ -98,7 +98,7 @@ export default function PageArtifact() {
     const { sortType = artifactSortKeys[0], ascending = false, filterOption } = deferredArtifactDisplayState
     let allArtifacts = database.arts.values
     const filterFunc = filterFunction(filterOption, filterConfigs)
-    const sortFunc = sortFunction([sortType], ascending, sortConfigs)
+    const sortFunc = sortFunction(sortConfigs[sortType].sortByKeys, ascending, sortConfigs)
     //in probability mode, filter out the artifacts that already reach criteria
     if (showProbability) {
       allArtifacts = allArtifacts.filter(art => art.probability && art.probability !== 1)

--- a/src/PageArtifact/index.tsx
+++ b/src/PageArtifact/index.tsx
@@ -98,7 +98,7 @@ export default function PageArtifact() {
     const { sortType = artifactSortKeys[0], ascending = false, filterOption } = deferredArtifactDisplayState
     let allArtifacts = database.arts.values
     const filterFunc = filterFunction(filterOption, filterConfigs)
-    const sortFunc = sortFunction(sortType, ascending, sortConfigs)
+    const sortFunc = sortFunction([sortType], ascending, sortConfigs)
     //in probability mode, filter out the artifacts that already reach criteria
     if (showProbability) {
       allArtifacts = allArtifacts.filter(art => art.probability && art.probability !== 1)

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOverview/WeaponSwapModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOverview/WeaponSwapModal.tsx
@@ -44,7 +44,7 @@ export default function WeaponSwapModal({ onChangeId, weaponTypeKey, show, onClo
 
   const weaponIdList = useMemo(() => (filterConfigs && sortConfigs && dbDirty && database.weapons.values
     .filter(filterFunction({ weaponType: weaponTypeKey, rarity, name: deferredSearchTerm }, filterConfigs))
-    .sort(sortFunction(["level"], false, sortConfigs))
+    .sort(sortFunction(sortConfigs.level.sortByKeys, false, sortConfigs))
     .map(weapon => weapon.id)) ?? []
     , [dbDirty, database, filterConfigs, sortConfigs, rarity, weaponTypeKey, deferredSearchTerm])
 

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOverview/WeaponSwapModal.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOverview/WeaponSwapModal.tsx
@@ -44,7 +44,7 @@ export default function WeaponSwapModal({ onChangeId, weaponTypeKey, show, onClo
 
   const weaponIdList = useMemo(() => (filterConfigs && sortConfigs && dbDirty && database.weapons.values
     .filter(filterFunction({ weaponType: weaponTypeKey, rarity, name: deferredSearchTerm }, filterConfigs))
-    .sort(sortFunction("level", false, sortConfigs))
+    .sort(sortFunction(["level"], false, sortConfigs))
     .map(weapon => weapon.id)) ?? []
     , [dbDirty, database, filterConfigs, sortConfigs, rarity, weaponTypeKey, deferredSearchTerm])
 

--- a/src/PageCharacter/CharacterSelectionModal.tsx
+++ b/src/PageCharacter/CharacterSelectionModal.tsx
@@ -57,7 +57,10 @@ export function CharacterSelectionModal({ show, onHide, onSelect, filter = () =>
   const characterKeyList = useMemo(() => (characterSheets && sortConfigs && filterConfigs) ?
     ownedCharacterKeyList
       .filter(filterFunction({ element, weaponType, name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction(sortBy === "new" ? [sortBy] : ["favorite", sortBy], ascending, sortConfigs) as (a: CharacterKey, b: CharacterKey) => number)
+      .sort(sortFunction(sortBy === "new"
+        ? sortConfigs[sortBy].sortByKeys
+        : [...sortConfigs.favorite.sortByKeys, ...sortConfigs[sortBy].sortByKeys],
+      ascending, sortConfigs) as (a: CharacterKey, b: CharacterKey) => number)
     : [],
     [characterSheets, element, weaponType, sortBy, ascending, sortConfigs, filterConfigs, ownedCharacterKeyList, deferredSearchTerm])
 

--- a/src/PageCharacter/CharacterSelectionModal.tsx
+++ b/src/PageCharacter/CharacterSelectionModal.tsx
@@ -31,7 +31,7 @@ type CharacterSelectionModalProps = {
 }
 
 export function CharacterSelectionModal({ show, onHide, onSelect, filter = () => true, newFirst = false }: CharacterSelectionModalProps) {
-  const sortKeys = useMemo(() => newFirst ? [...characterSortKeys] : characterSortKeys.slice(1), [newFirst])
+  const sortKeys = useMemo(() => newFirst ? characterSortKeys.slice(0, 4) : characterSortKeys.slice(1, 4), [newFirst])
   const { database } = useContext(DatabaseContext)
   const [state, stateDispatch] = useDBState("CharacterDisplay", initialCharacterDisplayState)
   const { weaponType, element } = state
@@ -56,13 +56,8 @@ export function CharacterSelectionModal({ show, onHide, onSelect, filter = () =>
   const ownedCharacterKeyList = useMemo(() => characterSheets ? allCharacterKeys.filter(cKey => filter(database.chars.get(cKey), characterSheets[cKey])) : [], [database, characterSheets, filter])
   const characterKeyList = useMemo(() => (characterSheets && sortConfigs && filterConfigs) ?
     ownedCharacterKeyList
-      .filter(filterFunction({ element, weaponType, favorite: "yes", name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction(sortBy, ascending, sortConfigs) as (a: CharacterKey, b: CharacterKey) => number)
-      .concat(
-        ownedCharacterKeyList
-          .filter(filterFunction({ element, weaponType, favorite: "no", name: deferredSearchTerm }, filterConfigs))
-          .sort(sortFunction(sortBy, ascending, sortConfigs) as (a: CharacterKey, b: CharacterKey) => number)
-      )
+      .filter(filterFunction({ element, weaponType, name: deferredSearchTerm }, filterConfigs))
+      .sort(sortFunction(sortBy === "new" ? [sortBy] : ["favorite", sortBy], ascending, sortConfigs) as (a: CharacterKey, b: CharacterKey) => number)
     : [],
     [characterSheets, element, weaponType, sortBy, ascending, sortConfigs, filterConfigs, ownedCharacterKeyList, deferredSearchTerm])
 

--- a/src/PageCharacter/index.tsx
+++ b/src/PageCharacter/index.tsx
@@ -20,7 +20,7 @@ import useForceUpdate from '../ReactHooks/useForceUpdate';
 import useMediaQueryUp from '../ReactHooks/useMediaQueryUp';
 import usePromise from '../ReactHooks/usePromise';
 import { CharacterKey } from '../Types/consts';
-import { characterFilterConfigs, characterSortConfigs, characterSortKeys } from '../Util/CharacterSort';
+import { characterFilterConfigs, characterSortConfigs } from '../Util/CharacterSort';
 import { filterFunction, sortFunction } from '../Util/SortByFilters';
 import { clamp } from '../Util/Util';
 import { initialCharacterDisplayState } from './CharacterDisplayState';
@@ -127,7 +127,7 @@ export default function PageCharacter() {
         </Grid>
         <Grid item >
           <SortByButton sx={{ height: "100%" }}
-            sortKeys={characterSortKeys.slice(1, 4)} value={sortType} onChange={sortType => stateDispatch({ sortType })}
+            sortKeys={["level", "rarity", "name"]} value={sortType} onChange={sortType => stateDispatch({ sortType })}
             ascending={ascending} onChangeAsc={ascending => stateDispatch({ ascending })} />
         </Grid>
       </Grid>

--- a/src/PageCharacter/index.tsx
+++ b/src/PageCharacter/index.tsx
@@ -87,12 +87,8 @@ export default function PageCharacter() {
     if (!sortConfigs || !filterConfigs) return { charKeyList: [], totalCharNum }
     const { element, weaponType, sortType, ascending } = deferredState
     const charKeyList = database.chars.keys
-      .filter(filterFunction({ element, weaponType, favorite: "yes", name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction(sortType, ascending, sortConfigs))
-      .concat(
-        database.chars.keys
-          .filter(filterFunction({ element, weaponType, favorite: "no", name: deferredSearchTerm }, filterConfigs))
-          .sort(sortFunction(sortType, ascending, sortConfigs)))
+      .filter(filterFunction({ element, weaponType, name: deferredSearchTerm }, filterConfigs))
+      .sort(sortFunction(["favorite", sortType], ascending, sortConfigs))
     return deferredDbDirty && { charKeyList, totalCharNum }
   },
     [deferredDbDirty, database, sortConfigs, filterConfigs, deferredState, deferredSearchTerm])
@@ -131,7 +127,7 @@ export default function PageCharacter() {
         </Grid>
         <Grid item >
           <SortByButton sx={{ height: "100%" }}
-            sortKeys={characterSortKeys.slice(1)} value={sortType} onChange={sortType => stateDispatch({ sortType })}
+            sortKeys={characterSortKeys.slice(1, 4)} value={sortType} onChange={sortType => stateDispatch({ sortType })}
             ascending={ascending} onChangeAsc={ascending => stateDispatch({ ascending })} />
         </Grid>
       </Grid>

--- a/src/PageCharacter/index.tsx
+++ b/src/PageCharacter/index.tsx
@@ -88,7 +88,7 @@ export default function PageCharacter() {
     const { element, weaponType, sortType, ascending } = deferredState
     const charKeyList = database.chars.keys
       .filter(filterFunction({ element, weaponType, name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction(["favorite", sortType], ascending, sortConfigs))
+      .sort(sortFunction([...sortConfigs.favorite.sortByKeys, ...sortConfigs[sortType].sortByKeys], ascending, sortConfigs))
     return deferredDbDirty && { charKeyList, totalCharNum }
   },
     [deferredDbDirty, database, sortConfigs, filterConfigs, deferredState, deferredSearchTerm])

--- a/src/PageWeapon/index.tsx
+++ b/src/PageWeapon/index.tsx
@@ -88,7 +88,7 @@ export default function PageWeapon() {
     const totalWeaponNum = weapons.length
     if (!sortConfigs || !filterConfigs) return { weaponIdList: [], totalWeaponNum }
     const weaponIdList = weapons.filter(filterFunction({ weaponType, rarity, name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction(sortType, ascending, sortConfigs))
+      .sort(sortFunction([sortType], ascending, sortConfigs))
       .map(weapon => weapon.id)
     return dbDirty && { weaponIdList, totalWeaponNum }
   }, [dbDirty, database, sortConfigs, filterConfigs, sortType, ascending, rarity, weaponType, deferredSearchTerm])

--- a/src/PageWeapon/index.tsx
+++ b/src/PageWeapon/index.tsx
@@ -88,7 +88,7 @@ export default function PageWeapon() {
     const totalWeaponNum = weapons.length
     if (!sortConfigs || !filterConfigs) return { weaponIdList: [], totalWeaponNum }
     const weaponIdList = weapons.filter(filterFunction({ weaponType, rarity, name: deferredSearchTerm }, filterConfigs))
-      .sort(sortFunction([sortType], ascending, sortConfigs))
+      .sort(sortFunction(sortConfigs[sortType].sortByKeys, ascending, sortConfigs))
       .map(weapon => weapon.id)
     return dbDirty && { weaponIdList, totalWeaponNum }
   }, [dbDirty, database, sortConfigs, filterConfigs, sortType, ascending, rarity, weaponType, deferredSearchTerm])

--- a/src/Util/CharacterSort.ts
+++ b/src/Util/CharacterSort.ts
@@ -4,14 +4,14 @@ import i18n from "../i18n";
 import { initCharMeta } from "../stateInit";
 import { CharacterKey } from "../Types/consts";
 import { FilterConfigs, SortConfigs } from "./SortByFilters";
-export const characterSortKeys = ["new", "level", "rarity", "name",] as const
+export const characterSortKeys = ["new", "level", "rarity", "name", "favorite"] as const
 export type CharacterSortKey = typeof characterSortKeys[number]
 
 export function characterSortConfigs(database: ArtCharDatabase, characterSheets: Record<CharacterKey, CharacterSheet>): SortConfigs<CharacterSortKey, CharacterKey> {
   return {
     new: {
       getValue: (ck) => database.chars.get(ck as CharacterKey) ? 0 : 1,
-      tieBreaker: "name"
+      tieBreakers: ["favorite", "name"]
     },
     name: {
       getValue: (ck) => i18n.t(`charNames_gen"${ck}`).toString(),
@@ -22,24 +22,25 @@ export function characterSortConfigs(database: ArtCharDatabase, characterSheets:
         if (!char) return 0
         return char.level * char.ascension
       },
-      tieBreaker: "rarity"
+      tieBreakers: ["rarity", "name"]
     },
     rarity: {
       getValue: (ck) => characterSheets?.[ck]?.rarity,
-      tieBreaker: "level"
+      tieBreakers: ["level", "name"]
+    },
+    favorite: {
+      getValue: (ck) => database.states.getWithInit(`charMeta_${ck}`, initCharMeta).favorite ? 1 : 0
     }
   }
 }
 
-export type CharacterFilterConfigs = FilterConfigs<"element" | "weaponType" | "favorite" | "name", CharacterKey>
+export type CharacterFilterConfigs = FilterConfigs<"element" | "weaponType" | "name", CharacterKey>
 export function characterFilterConfigs(database: ArtCharDatabase, characterSheets: Record<CharacterKey, CharacterSheet>): CharacterFilterConfigs {
   return {
     element: (ck, filter) => filter.includes(characterSheets?.[ck]?.elementKey) ||
       (ck === "Traveler" && !database.chars.get(ck as CharacterKey) && filter.some(fe => characterSheets.Traveler.elementKeys.includes(fe))) ||
       (ck === "Traveler" && filter.includes(database.chars.get(ck as CharacterKey)?.elementKey)),
     weaponType: (ck, filter) => filter.includes(characterSheets?.[ck]?.weaponTypeKey),
-    favorite: (ck, filter) =>
-      !filter || (filter === (database.states.getWithInit(`charMeta_${ck}`, initCharMeta).favorite ? "yes" : "no")),
     name: (ck, filter) => !filter || (i18n.t(`charNames_gen:${ck}`).toLowerCase().includes(filter.toLowerCase()))
   }
 }

--- a/src/Util/CharacterSort.ts
+++ b/src/Util/CharacterSort.ts
@@ -11,10 +11,11 @@ export function characterSortConfigs(database: ArtCharDatabase, characterSheets:
   return {
     new: {
       getValue: (ck) => database.chars.get(ck as CharacterKey) ? 0 : 1,
-      tieBreakers: ["favorite", "name"]
+      sortByKeys: ["new", "favorite", "name"]
     },
     name: {
       getValue: (ck) => i18n.t(`charNames_gen"${ck}`).toString(),
+      sortByKeys: ["name"]
     },
     level: {
       getValue: (ck) => {
@@ -22,14 +23,15 @@ export function characterSortConfigs(database: ArtCharDatabase, characterSheets:
         if (!char) return 0
         return char.level * char.ascension
       },
-      tieBreakers: ["rarity", "name"]
+      sortByKeys: ["level", "rarity", "name"]
     },
     rarity: {
       getValue: (ck) => characterSheets?.[ck]?.rarity,
-      tieBreakers: ["level", "name"]
+      sortByKeys: ["rarity", "level", "name"]
     },
     favorite: {
-      getValue: (ck) => database.states.getWithInit(`charMeta_${ck}`, initCharMeta).favorite ? 1 : 0
+      getValue: (ck) => database.states.getWithInit(`charMeta_${ck}`, initCharMeta).favorite ? 1 : 0,
+      sortByKeys: ["favorite"]
     }
   }
 }

--- a/src/Util/SortByFilters.ts
+++ b/src/Util/SortByFilters.ts
@@ -1,10 +1,10 @@
 type SortConfig<T> = {
   getValue: (id: T) => number | string
-  tieBreaker?: string
+  tieBreakers?: string[]
 }
 export type SortConfigs<Keys extends string, T> = Record<Keys, SortConfig<T>>
 
-export function sortFunction<Keys extends string, T>(sortby: string, ascending: boolean, configs: SortConfigs<Keys, T>) {
+export function sortFunction<Keys extends string, T>(sortbyKeys: string[], ascending: boolean, configs: SortConfigs<Keys, T>): (a: T, b: T) => number {
   function Sort(a: T, b: T, ascending: boolean, config: SortConfig<T>) {
     const aV = config.getValue(a)
     const bV = config.getValue(b)
@@ -15,12 +15,21 @@ export function sortFunction<Keys extends string, T>(sortby: string, ascending: 
       diff = ((bV as number) - (aV as number))
     return (ascending ? -1 : 1) * diff
   }
+
   return (a: T, b: T) => {
-    if (!configs[sortby]) return 0
-    const filterOption = configs[sortby]
-    let diff = Sort(a, b, ascending, filterOption)
-    if (!diff && filterOption.tieBreaker && configs[filterOption.tieBreaker])
-      diff = Sort(a, b, ascending, configs[filterOption.tieBreaker])
+    let diff: number = 0;
+    for (const sortby of sortbyKeys) {
+      const sortConfig: SortConfig<T> = configs[sortby]
+      if (!sortConfig) return 0
+      diff = Sort(a, b, ascending, sortConfig)
+      if (diff) return diff
+
+      if (sortConfig.tieBreakers) for (const tieBreaker of sortConfig.tieBreakers) {
+        diff = Sort(a, b, ascending, configs[tieBreaker])
+        if (diff) return diff
+      }
+    }
+
     return diff
   }
 }

--- a/src/Util/SortByFilters.ts
+++ b/src/Util/SortByFilters.ts
@@ -17,15 +17,14 @@ export function sortFunction<Keys extends string, T>(sortbyKeys: string[], ascen
   }
 
   return (a: T, b: T) => {
-    let diff: number = 0;
     for (const sortby of sortbyKeys) {
       const sortConfig: SortConfig<T> = configs[sortby]
       if (!sortConfig) return 0
-      diff = Sort(a, b, ascending, sortConfig)
+      const diff = Sort(a, b, ascending, sortConfig)
       if (diff) return diff
     }
 
-    return diff
+    return 0 // Tied on all passed in keys
   }
 }
 

--- a/src/Util/SortByFilters.ts
+++ b/src/Util/SortByFilters.ts
@@ -1,6 +1,6 @@
 type SortConfig<T> = {
   getValue: (id: T) => number | string
-  tieBreakers?: string[]
+  sortByKeys: string[]
 }
 export type SortConfigs<Keys extends string, T> = Record<Keys, SortConfig<T>>
 
@@ -23,11 +23,6 @@ export function sortFunction<Keys extends string, T>(sortbyKeys: string[], ascen
       if (!sortConfig) return 0
       diff = Sort(a, b, ascending, sortConfig)
       if (diff) return diff
-
-      if (sortConfig.tieBreakers) for (const tieBreaker of sortConfig.tieBreakers) {
-        diff = Sort(a, b, ascending, configs[tieBreaker])
-        if (diff) return diff
-      }
     }
 
     return diff

--- a/src/Util/WeaponSort.ts
+++ b/src/Util/WeaponSort.ts
@@ -10,11 +10,11 @@ export function weaponSortConfigs(weaponSheets: Record<WeaponKey, WeaponSheet>):
   return {
     level: {
       getValue: wp => wp.level * wp.ascension ?? 0,
-      tieBreaker: "rarity"
+      tieBreakers: ["rarity"]
     },
     rarity: {
       getValue: wp => weaponSheets?.[wp.key]?.rarity,
-      tieBreaker: "level"
+      tieBreakers: ["level"]
     }
   }
 }

--- a/src/Util/WeaponSort.ts
+++ b/src/Util/WeaponSort.ts
@@ -10,11 +10,11 @@ export function weaponSortConfigs(weaponSheets: Record<WeaponKey, WeaponSheet>):
   return {
     level: {
       getValue: wp => wp.level * wp.ascension ?? 0,
-      tieBreakers: ["rarity"]
+      sortByKeys: ["level", "rarity"]
     },
     rarity: {
       getValue: wp => weaponSheets?.[wp.key]?.rarity,
-      tieBreakers: ["level"]
+      sortByKeys: ["rarity", "level"]
     }
   }
 }


### PR DESCRIPTION
## Fixes
* Fix #463 - Fix favorite characters sorting above new characters
* Fix browsers treating sorting tie breakers differently

## Technical
* Change the sorting of favorite characters to the top to rely on sorting one array, rather than splitting the array into favorites/non-favorites, then sorting those individually
* Refactor sorting code to remove tiebreaker keys to simplify sorting logic