### PR TITLE
Fix a glitch in language name

### DIFF
--- a/src/PageSettings/LanguageCard.tsx
+++ b/src/PageSettings/LanguageCard.tsx
@@ -18,8 +18,8 @@ export default function LanguageCard() {
 }
 
 const nativeLanguages = {
-  "chs": "中文 正体字",
-  "cht": "中文 繁體字",
+  "chs": "简体中文",
+  "cht": "繁體中文",
   "de": "Deutsch",
   "en": "English",
   "es": "español",


### PR DESCRIPTION
The translation of language name 'Chinese (Simplified)' is incorrect. '正体字' has more than one meanings. It refers to Traditional Chinese sometimes, but cannot mean Simplified Chinese.

The native word corresponding to 'Chinese (Simplified)' is '简体中文' or '中文（简体）'. And for better format, the translation of cht was also adjusted.