### PR TITLE
Fix a typo in Anemo Traveler's Constellation

### DIFF
--- a/public/locales/en/char_TravelerAnemo.json
+++ b/public/locales/en/char_TravelerAnemo.json
@@ -1,5 +1,5 @@
 {
   "p1": "Wind Blade DMG",
-  "c1": "Reduce DMG taken while casting",
+  "c4": "Reduce DMG taken while casting",
   "c6": "Targets who take DMG from <strong>Gust Surge</strong>"
 }

--- a/src/Data/Characters/TravelerAnemoF/anemo.tsx
+++ b/src/Data/Characters/TravelerAnemoF/anemo.tsx
@@ -114,7 +114,7 @@ export default function anemo(key: CharacterSheetKey, charKey: CharacterKey, dmg
         unit: "s"
       }, {
         canShow: data => data.get(input.constellation).value >= 4,
-        text: trm("c1"),
+        text: trm("c4"),
         value: 10,
         unit: "%"
       }]


### PR DESCRIPTION
I found it weird while translating the text. The reduce DMG effect should be in C4 of Anemo Traveler but not C1. But after some tests I think it's just a typo rather than a bug. I'm making this PR mainly as a reminder since I'm not sure whether it affects other functions or contents. So it's not necessary to merge if it doesn't affect anything.