### PR TITLE
Update database handling when switching between different databases

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,8 +58,21 @@ function ScrollTop({ children }: { children: React.ReactElement }) {
 }
 
 function App() {
-  const [database, setDatabase] = useState(() => new ArtCharDatabase(new DBLocalStorage(localStorage)))
-  const dbContextObj = useMemo(() => ({ database, setDatabase }), [database, setDatabase])
+  const [databases, setDatabases] = useState(() => [1, 2, 3, 4].map(index => {
+    const curDBIndex = parseInt(localStorage.getItem("dbIndex") || "1")
+    if (index === curDBIndex) {
+      return new ArtCharDatabase(new DBLocalStorage(localStorage))
+    } else {
+      const dbName = `extraDatabase_${index}`
+      const eDB = localStorage.getItem(dbName)
+      const dbObj = eDB ? JSON.parse(eDB) : { dbIndex: `${index}` }
+      const db = new ArtCharDatabase(new SandboxStorage(dbObj))
+      db.toExtraLocalDB()
+      return db
+    }
+  }))
+  const [database, setDatabase] = useState(() => databases[parseInt(localStorage.getItem("dbIndex") || "1") - 1])
+  const dbContextObj = useMemo(() => ({ databases, setDatabases, database, setDatabase }), [databases, setDatabases, database, setDatabase])
   return <StyledEngineProvider injectFirst>{/* https://mui.com/guides/interoperability/#css-injection-order-2 */}
     <ThemeProvider theme={theme}>
       <CssBaseline />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { KeyboardArrowUp } from '@mui/icons-material';
 import { Box, Container, CssBaseline, Fab, Grid, Skeleton, StyledEngineProvider, ThemeProvider, useScrollTrigger, Zoom } from '@mui/material';
-import React, { lazy, Suspense, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HashRouter, Route, Routes, useMatch } from "react-router-dom";
 import './App.scss';
@@ -58,9 +58,9 @@ function ScrollTop({ children }: { children: React.ReactElement }) {
 }
 
 function App() {
+  const dbIndex = parseInt(localStorage.getItem("dbIndex") || "1")
   const [databases, setDatabases] = useState(() => [1, 2, 3, 4].map(index => {
-    const curDBIndex = parseInt(localStorage.getItem("dbIndex") || "1")
-    if (index === curDBIndex) {
+    if (index === dbIndex) {
       return new ArtCharDatabase(new DBLocalStorage(localStorage))
     } else {
       const dbName = `extraDatabase_${index}`
@@ -71,7 +71,13 @@ function App() {
       return db
     }
   }))
-  const [database, setDatabase] = useState(() => databases[parseInt(localStorage.getItem("dbIndex") || "1") - 1])
+  const setDatabase = useCallback((index: number, db: ArtCharDatabase) => {
+    const dbs = [...databases]
+    dbs[index] = db
+    setDatabases(dbs)
+  }, [databases, setDatabases],)
+
+  const database = databases[dbIndex - 1]
   const dbContextObj = useMemo(() => ({ databases, setDatabases, database, setDatabase }), [databases, setDatabases, database, setDatabase])
   return <StyledEngineProvider injectFirst>{/* https://mui.com/guides/interoperability/#css-injection-order-2 */}
     <ThemeProvider theme={theme}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { HashRouter, Route, Routes, useMatch } from "react-router-dom";
 import './App.scss';
 import './Database/Database';
 import { ArtCharDatabase, DatabaseContext } from './Database/Database';
-import { DBLocalStorage } from './Database/DBStorage';
+import { DBLocalStorage, SandboxStorage } from './Database/DBStorage';
 import Footer from './Footer';
 import Header from './Header';
 import './i18n';

--- a/src/Database/DBStorage.ts
+++ b/src/Database/DBStorage.ts
@@ -87,8 +87,8 @@ export class DBLocalStorage implements DBStorage {
 export class SandboxStorage implements DBStorage {
   protected storage: Dict<string, string> = {}
 
-  constructor(other: DBStorage | undefined = undefined) {
-    other && this.copyFrom(other)
+  constructor(obj?: Dict<string, string>) {
+    if (obj) this.storage = obj
   }
 
   get keys(): string[] {
@@ -145,19 +145,4 @@ export class SandboxStorage implements DBStorage {
   setDBIndex(ind: 1 | 2 | 3 | 4) {
     this.setString('dbIndex', ind.toString())
   }
-}
-
-export class ExtraStorage extends SandboxStorage {
-  databaseName: string
-  constructor(databaseName: string, other: DBStorage | undefined = undefined) {
-    super(other)
-    this.databaseName = databaseName
-  }
-  setStorage(obj: Dict<string, string>): void {
-    this.storage = obj
-  }
-  saveStorage() {
-    localStorage.setItem(this.databaseName, JSON.stringify(this.storage))
-  }
-
 }

--- a/src/Database/DataEntries/DBMetaEntry.ts
+++ b/src/Database/DataEntries/DBMetaEntry.ts
@@ -9,9 +9,9 @@ interface IDBMeta {
   gender: Gender
 }
 
-function dbMetaInit(): IDBMeta {
+function dbMetaInit(database: ArtCharDatabase): IDBMeta {
   return {
-    name: `Database`,
+    name: `Database ${database.storage.getDBIndex()}`,
     lastEdit: 0,
     gender: "F"
   }

--- a/src/Database/DataEntry.ts
+++ b/src/Database/DataEntry.ts
@@ -5,20 +5,20 @@ import { IGO, IGOOD, ImportResult } from "./exim"
 
 export class DataEntry<Key extends string, GOkey extends string, CacheValue, StorageValue>{
   database: ArtCharDatabase
-  init: () => StorageValue
+  init: (database: ArtCharDatabase) => StorageValue
   data: CacheValue
   key: Key
   goKey: GOkey
-  constructor(database: ArtCharDatabase, key: Key, init: () => StorageValue, goKey: GOkey) {
+  constructor(database: ArtCharDatabase, key: Key, init: (database: ArtCharDatabase) => StorageValue, goKey: GOkey) {
     this.database = database
     this.key = key
     this.init = init
     this.goKey = goKey
     if (this.database.storage.keys.includes(key)) {
-      this.data = this.toCache(init())!
+      this.data = this.toCache(init(this.database))!
       this.set(this.database.storage.get(key))
     } else {
-      this.data = this.toCache(init())!
+      this.data = this.toCache(init(this.database))!
       this.setCached(this.data)
     }
   }
@@ -57,10 +57,16 @@ export class DataEntry<Key extends string, GOkey extends string, CacheValue, Sto
     this.database.storage.set(this.key, this.deCache(cached))
     this.trigger("update", cached)
   }
-  reset() {
-    this.data = this.toCache(this.init())!
+  clear() {
+    this.data = this.toCache(this.init(this.database))!
     this.setCached(this.data)
     this.listeners = []
+  }
+  clearStorage() {
+    this.database.storage.remove(this.key)
+  }
+  saveStorage() {
+    this.database.storage.set(this.key, this.deCache(this.data))
   }
 
   trigger(reason: TriggerString, object?: any) {

--- a/src/Database/DataManager.ts
+++ b/src/Database/DataManager.ts
@@ -65,7 +65,7 @@ export class DataManager<CacheKey extends string | number, StorageKey extends st
   setCached(key: CacheKey, cached: CacheValue) {
     deepFreeze(cached)
     this.data[key] = cached
-    this.database.storage.set(this.toStorageKey(key) as string, this.deCache(cached))
+    this.saveStorageEntry(key, cached)
     this.trigger(key, "update", cached)
   }
   /** Trigger update event */
@@ -76,7 +76,7 @@ export class DataManager<CacheKey extends string | number, StorageKey extends st
   remove(key: CacheKey) {
     const rem = this.data[key]
     delete this.data[key]
-    this.database.storage.remove(this.toStorageKey(key) as string)
+    this.removeStorageEntry(key)
 
     this.trigger(key, "remove", rem)
     delete this.listeners[key]
@@ -85,6 +85,19 @@ export class DataManager<CacheKey extends string | number, StorageKey extends st
     for (const key in this.data) {
       this.remove(key)
     }
+  }
+  removeStorageEntry(key: CacheKey) {
+    this.database.storage.remove(this.toStorageKey(key) as string)
+  }
+  saveStorageEntry(key: CacheKey, cached: CacheValue) {
+    this.database.storage.set(this.toStorageKey(key) as string, this.deCache(cached))
+  }
+  clearStorage() {
+    for (const key in this.data)
+      this.removeStorageEntry(key)
+  }
+  saveStorage() {
+    Object.entries(this.data).forEach(([k, v]) => this.saveStorageEntry(k as CacheKey, v))
   }
   exportGOOD(go: Partial<IGOOD & IGO>) {
     go[this.goKey as any] = Object.entries(this.data).map(([id, value]) => ({ ...value, id }))

--- a/src/Database/Database.ts
+++ b/src/Database/Database.ts
@@ -180,6 +180,8 @@ export class ArtCharDatabase {
   }
 }
 export type DatabaseContextObj = {
+  databases: ArtCharDatabase[],
+  setDatabases: (dbs: ArtCharDatabase[]) => void,
   database: ArtCharDatabase,
   setDatabase: (db: ArtCharDatabase) => void
 }

--- a/src/Database/Database.ts
+++ b/src/Database/Database.ts
@@ -13,7 +13,7 @@ import { CharacterDataManager } from "./DataManagers/CharacterData";
 import { CharacterTCDataManager } from "./DataManagers/CharacterTCData";
 import { CharMetaDataManager } from "./DataManagers/CharMetaData";
 import { WeaponDataManager } from "./DataManagers/WeaponData";
-import { DBStorage } from "./DBStorage";
+import { DBStorage, SandboxStorage } from "./DBStorage";
 import { GOSource, IGO, IGOOD, ImportResult, newImportResult } from "./exim";
 import { currentDBVersion, migrate, migrateGOOD } from "./migrate";
 
@@ -33,11 +33,20 @@ export class ArtCharDatabase {
   displayOptimize: DisplayOptimizeEntry
   displayCharacter: DisplayCharacterEntry
   displayTool: DisplayToolEntry
+  dbIndex: number
+  dbVer: number
 
   constructor(storage: DBStorage) {
     this.storage = storage
 
     migrate(storage)
+    // Transfer non DataManager/DataEntry data from storage
+    this.dbIndex = storage.getDBIndex()
+    this.dbVer = storage.getDBVersion()
+    this.storage.setDBVersion(this.dbVer)
+    this.storage.setDBIndex(this.dbIndex as 1 | 2 | 3 | 4)
+
+    // Handle Datamanagers
     this.chars = new CharacterDataManager(this)
 
     // Weapons needs to be instantiated after character to check for relations
@@ -54,6 +63,7 @@ export class ArtCharDatabase {
     this.charTCs = new CharacterTCDataManager(this)
     this.charMeta = new CharMetaDataManager(this)
 
+    // Handle DataEntries
     this.dbMeta = new DBMetaEntry(this)
     this.displayWeapon = new DisplayWeaponEntry(this)
     this.displayArtifact = new DisplayArtifactEntry(this)
@@ -94,7 +104,7 @@ export class ArtCharDatabase {
   clear() {
     this.dataManagers.map(dm => dm.clear())
     this.teamData = {};
-    this.dataEntries.map(de => de.reset())
+    this.dataEntries.map(de => de.clear())
   }
   get gender() {
     const gender: Gender = this.dbMeta.get().gender ?? "F"
@@ -133,6 +143,40 @@ export class ArtCharDatabase {
     unfollows.map(f => f())
 
     return result
+  }
+  clearStorage() {
+    this.dataManagers.map(dm => dm.clearStorage());
+    this.dataEntries.map(de => de.clearStorage());
+  }
+  saveStorage() {
+    this.dataManagers.map(dm => dm.saveStorage());
+    this.dataEntries.map(de => de.saveStorage());
+    this.storage.setDBVersion(this.dbVer)
+    this.storage.setDBIndex(this.dbIndex as 1 | 2 | 3 | 4)
+  }
+  swapStorage(other: ArtCharDatabase) {
+    this.clearStorage()
+    other.clearStorage()
+
+    const thisStorage = this.storage
+    this.storage = other.storage
+    other.storage = thisStorage
+
+    this.saveStorage()
+    other.saveStorage()
+  }
+  toExtraLocalDB() {
+    const key = `extraDatabase_${this.storage.getDBIndex()}`
+    const other = new SandboxStorage()
+    const oldstorage = this.storage
+    this.storage = other
+    this.saveStorage()
+    this.storage = oldstorage
+    localStorage.setItem(key, JSON.stringify(Object.fromEntries(other.entries)))
+  }
+  rmExtraLocalDB() {
+    const key = `extraDatabase_${this.storage.getDBIndex()}`
+    localStorage.removeItem(key)
   }
 }
 export type DatabaseContextObj = {

--- a/src/Database/Database.ts
+++ b/src/Database/Database.ts
@@ -174,15 +174,11 @@ export class ArtCharDatabase {
     this.storage = oldstorage
     localStorage.setItem(key, JSON.stringify(Object.fromEntries(other.entries)))
   }
-  rmExtraLocalDB() {
-    const key = `extraDatabase_${this.storage.getDBIndex()}`
-    localStorage.removeItem(key)
-  }
+
 }
 export type DatabaseContextObj = {
   databases: ArtCharDatabase[],
-  setDatabases: (dbs: ArtCharDatabase[]) => void,
-  database: ArtCharDatabase,
-  setDatabase: (db: ArtCharDatabase) => void
+  setDatabase: (index: number, db: ArtCharDatabase) => void,
+  database: ArtCharDatabase
 }
 export const DatabaseContext = createContext({} as DatabaseContextObj)

--- a/src/Database/migrate.ts
+++ b/src/Database/migrate.ts
@@ -94,17 +94,16 @@ export function migrate(storage: DBStorage) {
     }
   }
 
-  migrateVersion(8, () => {
-    storage.clear()
-    storage.setDBVersion(currentDBVersion)
-  })
+  migrateVersion(8, () => { })
 
   // 6.1.9 - 6.2.3
   migrateVersion(11, () => {
     for (const key of storage.keys) {
       if (key.startsWith("char_")) {
         const character = storage.get(key)
-        const { baseStatOverrides = {} } = character
+        if (!character) continue
+        const baseStatOverrides = character?.baseStatOverrides ?? {}
+        if (!baseStatOverrides) continue
         if (baseStatOverrides.critRate_) baseStatOverrides.critRate_ -= 5
         if (baseStatOverrides.critDMG_) baseStatOverrides.critDMG_ -= 50
         if (baseStatOverrides.enerRech_) baseStatOverrides.enerRech_ -= 100

--- a/src/PageSettings/DatabaseCard.tsx
+++ b/src/PageSettings/DatabaseCard.tsx
@@ -57,8 +57,8 @@ function DataCard({ index }: { index: number }) {
 
   const onDelete = useCallback(() => {
     if (!window.confirm(`Are you sure you want to delete "${name}"?`)) return
-    database.rmExtraLocalDB()
     database.clear()
+    database.toExtraLocalDB()
   }, [database, name])
 
   const download = useCallback(() => {
@@ -80,8 +80,8 @@ function DataCard({ index }: { index: number }) {
     if (current) return
     mainDB.toExtraLocalDB()
     database.swapStorage(mainDB)
-    setDatabase(database)
-  }, [setDatabase, mainDB, current, database])
+    setDatabase(index, database)
+  }, [index, setDatabase, mainDB, current, database])
 
   const [tempName, setTempName] = useState(name)
   useEffect(() => setTempName(name), [name])

--- a/src/PageSettings/DatabaseCard.tsx
+++ b/src/PageSettings/DatabaseCard.tsx
@@ -81,7 +81,7 @@ function DataCard({ index }: { index: number }) {
     mainDB.toExtraLocalDB()
     database.swapStorage(mainDB)
     setDatabase(database)
-  }, [setDatabase, mainDB, database])
+  }, [setDatabase, mainDB, current, database])
 
   const [tempName, setTempName] = useState(name)
   useEffect(() => setTempName(name), [name])

--- a/src/PageSettings/DatabaseCard.tsx
+++ b/src/PageSettings/DatabaseCard.tsx
@@ -96,7 +96,7 @@ function DataCard({ index }: { index: number }) {
     <CardContent sx={{ display: "flex", gap: 1, justifyContent: "space-between" }}>
       < StyledInputBase value={tempName} sx={{ borderRadius: 1, px: 1, flexGrow: 1 }} onChange={(e) => setTempName(e.target.value)} onBlur={onBlur} onKeyDown={onKeyDOwn} />
       {!current && <Button startIcon={<ImportExport />} onClick={onSwap} color="warning">{t`DatabaseCard.button.swap`}</Button>}
-      <Chip color={current ? "success" : "secondary"} label={current ? t`DatabaseCard.currentDB` : `${t`DatabaseCard.title`} ${index}`} />
+      <Chip color={current ? "success" : "secondary"} label={current ? t`DatabaseCard.currentDB` : `${t`DatabaseCard.title`} ${database.dbIndex}`} />
     </CardContent>
     <Divider />
     <CardContent>

--- a/src/PageSettings/UploadCard.tsx
+++ b/src/PageSettings/UploadCard.tsx
@@ -168,7 +168,7 @@ function GOUploadAction({ index, importedDatabase, reset }: { index: number, imp
     setDatabases(dbs)
     importedDatabase.toExtraLocalDB()
     reset()
-  }, [database, importedDatabase, reset, setDatabases])
+  }, [databases, database, index, importedDatabase, reset, setDatabases])
 
 
   return <><Divider /><CardContent sx={{ py: 1 }}>

--- a/src/PageSettings/UploadCard.tsx
+++ b/src/PageSettings/UploadCard.tsx
@@ -14,8 +14,9 @@ const InvisInput = styled('input')({
   display: 'none',
 });
 
-export default function UploadCard({ onReplace }: { onReplace: () => void }) {
-  const { database } = useContext(DatabaseContext)
+export default function UploadCard({ index, onReplace }: { index: number, onReplace: () => void }) {
+  const { databases } = useContext(DatabaseContext)
+  const database = databases[index]
   const { t } = useTranslation("settings");
   const [data, setdata] = useState("")
   const [filename, setfilename] = useState("")
@@ -101,7 +102,7 @@ export default function UploadCard({ onReplace }: { onReplace: () => void }) {
       <Box component="textarea" sx={{ width: "100%", fontFamily: "monospace", minHeight: "10em", mb: 2, resize: "vertical" }} value={data} onChange={e => setdata(e.target.value)} />
       {(importResult && importedDatabase) ? <GOODUploadInfo importResult={importResult} importedDatabase={importedDatabase} /> : t(errorMsg)}
     </CardContent>
-    <GOUploadAction importedDatabase={importedDatabase} reset={reset} />
+    <GOUploadAction index={index} importedDatabase={importedDatabase} reset={reset} />
   </CardLight>
 }
 
@@ -155,16 +156,19 @@ function MergeResult({ result, dbTotal, type }: { result: ImportResultCounter<an
   </CardLight>
 }
 
-function GOUploadAction({ importedDatabase, reset }: { importedDatabase?: ArtCharDatabase, reset: () => void }) {
-  const { database, setDatabase } = useContext(DatabaseContext)
+function GOUploadAction({ index, importedDatabase, reset }: { index: number, importedDatabase?: ArtCharDatabase, reset: () => void }) {
+  const { databases, setDatabases } = useContext(DatabaseContext)
+  const database = databases[index]
   const { t } = useTranslation("settings")
   const replaceDB = useCallback(() => {
     if (!importedDatabase) return
-    database.swapStorage(importedDatabase)
-    setDatabase(importedDatabase)
+    importedDatabase.swapStorage(database)
+    const dbs = [...databases]
+    dbs[index] = importedDatabase
+    setDatabases(dbs)
     importedDatabase.toExtraLocalDB()
     reset()
-  }, [database, importedDatabase, reset, setDatabase])
+  }, [database, importedDatabase, reset, setDatabases])
 
 
   return <><Divider /><CardContent sx={{ py: 1 }}>

--- a/src/PageSettings/UploadCard.tsx
+++ b/src/PageSettings/UploadCard.tsx
@@ -157,18 +157,16 @@ function MergeResult({ result, dbTotal, type }: { result: ImportResultCounter<an
 }
 
 function GOUploadAction({ index, importedDatabase, reset }: { index: number, importedDatabase?: ArtCharDatabase, reset: () => void }) {
-  const { databases, setDatabases } = useContext(DatabaseContext)
+  const { databases, setDatabase } = useContext(DatabaseContext)
   const database = databases[index]
   const { t } = useTranslation("settings")
   const replaceDB = useCallback(() => {
     if (!importedDatabase) return
     importedDatabase.swapStorage(database)
-    const dbs = [...databases]
-    dbs[index] = importedDatabase
-    setDatabases(dbs)
+    setDatabase(index, importedDatabase)
     importedDatabase.toExtraLocalDB()
     reset()
-  }, [databases, database, index, importedDatabase, reset, setDatabases])
+  }, [database, index, importedDatabase, reset, setDatabase])
 
 
   return <><Divider /><CardContent sx={{ py: 1 }}>

--- a/src/PageSettings/UploadCard.tsx
+++ b/src/PageSettings/UploadCard.tsx
@@ -160,9 +160,9 @@ function GOUploadAction({ importedDatabase, reset }: { importedDatabase?: ArtCha
   const { t } = useTranslation("settings")
   const replaceDB = useCallback(() => {
     if (!importedDatabase) return
-    database.clear()
-    database.storage.copyFrom(importedDatabase.storage)
-    setDatabase(new ArtCharDatabase(database.storage))
+    database.swapStorage(importedDatabase)
+    setDatabase(importedDatabase)
+    importedDatabase.toExtraLocalDB()
     reset()
   }, [database, importedDatabase, reset, setDatabase])
 


### PR DESCRIPTION
- Allow databases to switch their storage, while maintaining their cached data.
- Database swapping no long have expensive new database initialization steps, since they are swapped "hot".
- Use the data entry classes in database to set/unset data in storage, thus extra data in the localstorage are no longer being bundled in the data of other databases.