### PR TITLE
Retype

### DIFF
--- a/src/Formula/internal.ts
+++ b/src/Formula/internal.ts
@@ -1,10 +1,12 @@
-import { AnyNode, NumNode, StrNode } from "./type"
+import { NumNode, StrNode } from "./type"
 import { constant } from "./utils"
 
-export function forEachNodes(formulas: (NumNode | StrNode)[], topDown: (formula: (NumNode | StrNode)) => void, bottomUp: (formula: (NumNode | StrNode)) => void): void {
-  const visiting = new Set<(NumNode | StrNode)>(), visited = new Set<(NumNode | StrNode)>()
+type Node = NumNode | StrNode
 
-  function traverse(formula: (NumNode | StrNode)) {
+export function forEachNodes(formulas: Node[], topDown: (formula: Node) => void, bottomUp: (formula: Node) => void): void {
+  const visiting = new Set<Node>(), visited = new Set<Node>()
+
+  function traverse(formula: Node) {
     if (visited.has(formula)) return
 
     if (visiting.has(formula)) {
@@ -26,13 +28,13 @@ export function forEachNodes(formulas: (NumNode | StrNode)[], topDown: (formula:
   formulas.forEach(traverse)
 }
 
-export function mapFormulas(formulas: NumNode[], topDownMap: (formula: (NumNode | StrNode)) => (NumNode | StrNode), bottomUpMap: (current: (NumNode | StrNode), orig: (NumNode | StrNode)) => (NumNode | StrNode)): NumNode[]
-export function mapFormulas(formulas: (NumNode | StrNode)[], topDownMap: (formula: (NumNode | StrNode)) => (NumNode | StrNode), bottomUpMap: (current: (NumNode | StrNode), orig: (NumNode | StrNode)) => (NumNode | StrNode)): (NumNode | StrNode)[] {
-  const visiting = new Set<(NumNode | StrNode)>()
-  const topDownMapped = new Map<(NumNode | StrNode), (NumNode | StrNode)>()
-  const bottomUpMapped = new Map<(NumNode | StrNode), (NumNode | StrNode)>()
+export function mapFormulas(formulas: NumNode[], topDownMap: (formula: Node) => Node, bottomUpMap: (current: Node, orig: Node) => Node): NumNode[]
+export function mapFormulas(formulas: Node[], topDownMap: (formula: Node) => Node, bottomUpMap: (current: Node, orig: Node) => Node): Node[] {
+  const visiting = new Set<Node>()
+  const topDownMapped = new Map<Node, Node>()
+  const bottomUpMapped = new Map<Node, Node>()
 
-  function check(formula: (NumNode | StrNode)): (NumNode | StrNode) {
+  function check(formula: Node): Node {
     let topDown = topDownMapped.get(formula)
     if (topDown) return topDown
     topDown = topDownMap(formula)
@@ -55,7 +57,7 @@ export function mapFormulas(formulas: (NumNode | StrNode)[], topDownMap: (formul
     return bottomUp
   }
 
-  function traverse(formula: (NumNode | StrNode)): (NumNode | StrNode) {
+  function traverse(formula: Node): Node {
     const operands = formula.operands.map(check)
     return arrayEqual(operands, formula.operands) ? formula : { ...formula, operands } as any
   }
@@ -64,13 +66,13 @@ export function mapFormulas(formulas: (NumNode | StrNode)[], topDownMap: (formul
   return arrayEqual(result, formulas) ? formulas : result
 }
 
-export function mapContextualFormulas(formulas: NumNode[], baseContextId: number, topDownMap: (formula: AnyNode, contextId: ContextID) => [AnyNode, ContextID], bottomUpMap: (formula: AnyNode, orig: AnyNode, contextId: ContextID, origContextId: ContextID) => AnyNode): NumNode[]
-export function mapContextualFormulas(formulas: AnyNode[], baseContextId: number, topDownMap: (formula: AnyNode, contextId: ContextID) => [AnyNode, ContextID], bottomUpMap: (formula: AnyNode, orig: AnyNode, contextId: ContextID, origContextId: ContextID) => AnyNode): AnyNode[] {
-  const visiting = new Set<AnyNode>()
-  const topDownByContext = new Map<ContextID, Map<AnyNode, AnyNode>>()
-  const bottomUpByContext = new Map<ContextID, Map<AnyNode, AnyNode>>()
+export function mapContextualFormulas(formulas: NumNode[], baseContextId: number, topDownMap: (formula: Node, contextId: ContextID) => [Node, ContextID], bottomUpMap: (formula: Node, orig: Node, contextId: ContextID, origContextId: ContextID) => Node): NumNode[]
+export function mapContextualFormulas(formulas: Node[], baseContextId: number, topDownMap: (formula: Node, contextId: ContextID) => [Node, ContextID], bottomUpMap: (formula: Node, orig: Node, contextId: ContextID, origContextId: ContextID) => Node): Node[] {
+  const visiting = new Set<Node>()
+  const topDownByContext = new Map<ContextID, Map<Node, Node>>()
+  const bottomUpByContext = new Map<ContextID, Map<Node, Node>>()
 
-  function check(formula: AnyNode, parentContextId: ContextID): AnyNode {
+  function check(formula: Node, parentContextId: ContextID): Node {
     let topDownMapping = topDownByContext.get(parentContextId)
     if (!topDownMapping) {
       topDownMapping = new Map()
@@ -105,9 +107,9 @@ export function mapContextualFormulas(formulas: AnyNode[], baseContextId: number
     return bottomUp
   }
 
-  function traverse(formula: AnyNode, contextId: ContextID): AnyNode {
+  function traverse(formula: Node, contextId: ContextID): Node {
     const operands = formula.operands.map(f => check(f, contextId))
-    return arrayEqual(operands, formula.operands) ? formula : { ...formula, operands }
+    return arrayEqual(operands, formula.operands) ? formula : { ...formula, operands } as any
   }
 
   const result = formulas.map(f => check(f, baseContextId))

--- a/src/Formula/optimization.ts
+++ b/src/Formula/optimization.ts
@@ -307,14 +307,13 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
         break
       }
       case "threshold": {
-        const [v, t, p, f] = formula.operands
-        const [value, threshold, pass, fail] = [fold(v, context), fold(t, context), fold(p, context), fold(f, context)]
+        const [value, threshold, pass, fail] = formula.operands.map(x => fold(x, context) as NumNode)
         if (pass.operation === "const" && fail.operation === "const" && pass.value === fail.value)
           result = pass
         else if (value.operation === "const" && threshold.operation === "const")
           result = value.value >= threshold.value ? pass : fail
         else
-          result = { ...formula, operands: [value, threshold, pass, fail] as any }
+          result = { ...formula, operands: [value, threshold, pass, fail] }
         break
       }
       case "subscript": {

--- a/src/Formula/optimization.ts
+++ b/src/Formula/optimization.ts
@@ -307,13 +307,14 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
         break
       }
       case "threshold": {
-        const [value, threshold, pass, fail] = formula.operands.map(x => fold(x, context))
+        const [v, t, p, f] = formula.operands
+        const [value, threshold, pass, fail] = [fold(v, context), fold(t, context), fold(p, context), fold(f, context)]
         if (pass.operation === "const" && fail.operation === "const" && pass.value === fail.value)
           result = pass
         else if (value.operation === "const" && threshold.operation === "const")
           result = value.value >= threshold.value ? pass : fail
         else
-          result = { ...formula, operands: [value, threshold, pass, fail] }
+          result = { ...formula, operands: [value, threshold, pass, fail] as any }
         break
       }
       case "subscript": {

--- a/src/Formula/type.d.ts
+++ b/src/Formula/type.d.ts
@@ -8,16 +8,11 @@ export type NumNode = ComputeNode | ThresholdNode<NumNode> |
   LookupNode<NumNode> | MatchNode<StrNode, NumNode> | MatchNode<NumNode, NumNode> |
   SubscriptNode<number> |
   ReadNode<number> | ConstantNode<number>
-export type StrNode = StrPrioNode | SmallestNode |
+export type StrNode = StrPrioNode | SmallestNode | ThresholdNode<StrNode> |
   DataNode<StrNode> |
   LookupNode<StrNode> |
   MatchNode<StrNode, StrNode> | MatchNode<NumNode, StrNode> |
   ReadNode<string | undefined> | ConstantNode<string | undefined>
-export type AnyNode = NumNode | StrNode | {
-  operation: string
-  operands: readonly AnyNode[]
-  info?: Info
-}
 
 interface Info {
   key?: string
@@ -33,7 +28,6 @@ interface Info {
 export type Variant = ElementKeyWithPhy | TransformativeReactionsKey | AmplifyingReactionsKey | AdditiveReactionsKey | "heal" | "invalid"
 
 interface Base {
-  operands: readonly AnyNode[]
   info?: Info
 }
 export interface StrPrioNode extends Base {

--- a/src/Formula/utils.ts
+++ b/src/Formula/utils.ts
@@ -4,7 +4,7 @@ import type { ComputeNode, ConstantNode, Data, DataNode, Info, LookupNode, Match
 
 type Num = number | NumNode
 type Str = string | undefined | StrNode
-type Any = Num | Str
+type N_S = Num | Str
 type AnyNode = NumNode | StrNode
 
 export const todo: NumNode = constant(NaN, { key: "TODO" })
@@ -36,7 +36,7 @@ export function infoMut(node: AnyNode, info: Info): AnyNode {
 /** `table[string] ?? defaultNode` */
 export function lookup(index: StrNode, table: Dict<string, NumNode>, defaultV: Num | "none", info?: Info): LookupNode<NumNode>
 export function lookup(index: StrNode, table: Dict<string, StrNode>, defaultV: Str | "none", info?: Info): LookupNode<StrNode>
-export function lookup(index: StrNode, table: Dict<string, AnyNode>, defaultV: Any | "none", info?: Info): LookupNode<AnyNode> {
+export function lookup(index: StrNode, table: Dict<string, AnyNode>, defaultV: N_S | "none", info?: Info): LookupNode<AnyNode> {
   const operands = defaultV !== "none" ? [intoV(index), intoV(defaultV)] as const : [intoV(index)] as const
   return { operation: "lookup", operands, table, info }
 }
@@ -70,31 +70,31 @@ export function compareEq(v1: Num, v2: Num, eq: Num, neq: Num, info?: Info): Mat
 export function compareEq(v1: Num, v2: Num, eq: Str, neq: Str, info?: Info): MatchNode<NumNode, StrNode>
 export function compareEq(v1: Str, v2: Str, eq: Num, neq: Num, info?: Info): MatchNode<StrNode, NumNode>
 export function compareEq(v1: Str, v2: Str, eq: Str, neq: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function compareEq(v1: Any, v2: Any, eq: Any, neq: Any, info?: Info): MatchNode<AnyNode, AnyNode> {
+export function compareEq(v1: N_S, v2: N_S, eq: N_S, neq: N_S, info?: Info): MatchNode<AnyNode, AnyNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(eq), intoV(neq)], info }
 }
 /** v1 == v2 ? pass : 0 */
 export function equal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode, NumNode>
 export function equal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function equal(v1: Any, v2: Any, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
+export function equal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(pass), intoV(0)], info, emptyOn: "unmatch" }
 }
 /** v1 == v2 ? pass : `undefined` */
 export function equalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<NumNode, StrNode>
 export function equalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function equalStr(v1: Any, v2: Any, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
+export function equalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(pass), intoV(undefined)], info, emptyOn: "unmatch" }
 }
 /** v1 != v2 ? pass : 0 */
 export function unequal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode, NumNode>
 export function unequal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function unequal(v1: Any, v2: Any, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
+export function unequal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(0), intoV(pass)], info, emptyOn: "match" }
 }
 /** v1 != v2 ? pass : `undefined` */
 export function unequalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<NumNode, StrNode>
 export function unequalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function unequalStr(v1: Any, v2: Any, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
+export function unequalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(undefined), intoV(pass)], info, emptyOn: "match" }
 }
 /** v1 >= v2 ? pass : 0 */
@@ -162,13 +162,13 @@ export function subscript<V>(index: NumNode, list: V[], info?: Info): SubscriptN
 
 function intoOps(values: Num[]): NumNode[]
 function intoOps(values: Str[]): StrNode[]
-function intoOps(values: Any[]): AnyNode[] {
+function intoOps(values: N_S[]): AnyNode[] {
   return values.map(value => typeof value === "object" ? value : constant(value))
 }
 function intoV(value: Num): NumNode
 function intoV(value: Str): StrNode
-function intoV(value: Any): AnyNode
-function intoV(value: Any): AnyNode {
+function intoV(value: N_S): AnyNode
+function intoV(value: N_S): AnyNode {
   return (typeof value !== "object") ? constant(value) : value
 }
 
@@ -183,6 +183,6 @@ export function matchFull(v1: Num, v2: Num, match: Num, unmatch: Num, info?: Inf
 export function matchFull(v1: Num, v2: Num, match: Str, unmatch: Str, info?: Info): MatchNode<NumNode, StrNode>
 export function matchFull(v1: Str, v2: Str, match: Num, unmatch: Num, info?: Info): MatchNode<StrNode, NumNode>
 export function matchFull(v1: Str, v2: Str, match: Str, unmatch: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function matchFull(v1: Any, v2: Any, match: Any, unmatch: Any, info?: Info): MatchNode<AnyNode, AnyNode> {
+export function matchFull(v1: N_S, v2: N_S, match: N_S, unmatch: N_S, info?: Info): MatchNode<AnyNode, AnyNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(match), intoV(unmatch)], info }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/common.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/common.ts
@@ -71,8 +71,8 @@ function reaffine(nodes: NumNode[], arts: ArtifactsBySlot, forceRename: boolean 
 
   const dynKeys = new Set<string>()
 
-  forEachNodes(nodes, _ => { }, f => {
-    const operation = f.operation
+  forEachNodes(nodes, _ => { }, _f => {
+    const f = _f as NumNode, { operation } = f
     switch (operation) {
       case "read":
         if (f.type !== "number" || f.path[0] !== "dyn" || f.accu !== "add")
@@ -92,7 +92,7 @@ function reaffine(nodes: NumNode[], arts: ArtifactsBySlot, forceRename: boolean 
         visit(f as NumNode, true); break
       case "res": case "threshold": case "sum_frac":
       case "max": case "min": visit(f, false); break
-      case "data": case "subscript": case "lookup": case "match": case "prio": case "small":
+      case "data": case "subscript": case "lookup": case "match":
         throw new Error(`Found unsupported ${operation} node when computing affine nodes`)
       default: assertUnreachable(operation)
     }

--- a/src/Types/global.d.ts
+++ b/src/Types/global.d.ts
@@ -1,26 +1,17 @@
-
 declare global {
-    type Displayable = string | JSX.Element
-    type Dict<K extends string | number, V> = {
-        [key in K]?: V
-    }
-    type StrictDict<K extends string | number, V> = {
-        [key in K]: V
-    }
+  type Displayable = string | JSX.Element
+  type Dict<K extends string | number, V> = Partial<Record<K, V>>
+  type StrictDict<K extends string | number, V> = Record<K, V>
 
-    interface ObjectConstructor {
-        export keys<K, V>(o: Dict<K, V> | {}): `${K}`[]
-        export values<K, V>(o: Dict<K, V> | {}): V[]
-        export entries<K, V>(o: Dict<K, V> | {}): [`${K}`, V][]
+  interface ObjectConstructor {
+    export keys<K, V>(o: StrictDict<K, V>): `${K}`[]
+    export values<K, V>(o: StrictDict<K, Exclude<V, undefined>>): Exclude<V, undefined>[]
+    export entries<K, V>(o: StrictDict<K, Exclude<V, undefined>>): [`${K}`, Exclude<V, undefined>][]
 
-        export keys<K, V>(o: StrictDict<K, V> | {}): `${K}`[]
-        export values<K, V>(o: StrictDict<K, V> | {}): V[]
-        export entries<K, V>(o: StrictDict<K, V> | {}): [`${K}`, V][]
-    }
+    export keys<K, V>(o: Dict<K, V> | {}): `${K}`[]
+    export values<K, V>(o: Dict<K, V> | {}): V[]
+    export entries<K, V>(o: Dict<K, V> | {}): [`${K}`, V][]
+  }
 }
 
-export {
-    Dict,
-    Displayable,
-    ObjectConstructor,
-}
+export { }

--- a/src/Util/Util.ts
+++ b/src/Util/Util.ts
@@ -122,8 +122,8 @@ export function objectKeyValueMap<T, K extends string | number, V>(items: readon
   return Object.fromEntries(items.map(t => map(t))) as any
 }
 
+export function objectMap<K extends string, V, T>(obj: Record<K, Exclude<V, undefined>>, fn: (value: V, key: `${K}`, index: number) => T): Record<K, T>
 export function objectMap<K extends string, V, T>(obj: Partial<Record<K, V>>, fn: (value: V, key: `${K}`, index: number) => T): Partial<Record<K, T>>
-export function objectMap<K extends string, V, T>(obj: Record<K, V>, fn: (value: V, key: `${K}`, index: number) => T): Record<K, T>
 export function objectMap<K extends string, V, T>(obj: Partial<Record<K, V>>, fn: (value: V, key: `${K}`, index: number) => T): Partial<Record<K, T>> {
   return Object.fromEntries(Object.entries(obj).map(
     ([k, v], i) => [k, fn(v, k, i)]


### PR DESCRIPTION
Some house cleaning regarding the types of functions in `Formula`, fixing some typing bugs along the way.

- Fix a bug that causes `objectMap` to use an incorrect variation
- Update types of util functions
- Remove `AnyNode` and `Base.operands` from type decl