### PR TITLE
improve type inference for `mapFormulas()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genshin-optimizer",
-  "version": "8.20.3",
+  "version": "8.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "genshin-optimizer",
-      "version": "8.20.3",
+      "version": "8.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.9.0",

--- a/src/Formula/optimization.ts
+++ b/src/Formula/optimization.ts
@@ -67,7 +67,6 @@ const x0=0`; // making sure `const` has at least one entry
       case "sum_frac": body += `,${name}=${operandNames[0]}/(${operandNames[0]}+${operandNames[1]})`; break
 
       case "match": case "lookup": case "subscript":
-      case "prio": case "small":
       case "data": throw new Error(`Unsupported ${operation} node in precompute`)
       default: assertUnreachable(operation)
     }

--- a/src/Formula/type.d.ts
+++ b/src/Formula/type.d.ts
@@ -31,8 +31,10 @@ interface Info {
 }
 export type Variant = ElementKeyWithPhy | TransformativeReactionsKey | AmplifyingReactionsKey | AdditiveReactionsKey | "heal" | "invalid"
 
-interface Base {
+export interface Base {
   info?: Info
+  operation: string
+  operands: readonly Base[]
 }
 export interface StrPrioNode extends Base {
   operation: "prio"


### PR DESCRIPTION
I got annoyed by VsCode constantly complaining that `n` could be a `StrNode` in the following example.

```ts
// nodes is NumNode[]
mapFormulas(nodes, n => n, n => {
  // stuff with n
})
```
