### PR TITLE
Fix mistake in skill name of C2 Hu Tao

### DIFF
--- a/src/Data/Characters/HuTao/index.tsx
+++ b/src/Data/Characters/HuTao/index.tsx
@@ -185,7 +185,7 @@ const sheet: ICharacterSheet = {
       fields: [{
         node: infoMut(dmgFormulas.skill.dmg, { name: ct.chg(`skill.skillParams.2`) })
       }, {
-        node: infoMut(dmgFormulas.skill.dmgC2, { name: ct.chg("constellation2.skillParams.2") }),
+        node: infoMut(dmgFormulas.skill.dmgC2, { name: ct.chg(`constellation2.skillParams.2`) }),
       }, {
         text: ct.chg("skill.skillParams.3"),
         value: datamine.skill.bloodBlossomDuration,


### PR DESCRIPTION
C1 Hu Tao:
![图片](https://user-images.githubusercontent.com/32670075/196000195-e88db970-3070-45c1-8a5c-b38d36e6fa6a.png)


C2 Hu Tao:
![图片](https://user-images.githubusercontent.com/32670075/196000176-3a0f37cf-f0d7-44cb-8785-ad1540e01316.png)

> char_HuTao_gen:constellation2.skillParams.2

I'm not familiar with TypeScript. So please check whether this is the correct way to fix it. Thanks.