### PR TITLE
Update `Node` types

### DIFF
--- a/src/Data/Characters/dataUtil.tsx
+++ b/src/Data/Characters/dataUtil.tsx
@@ -100,7 +100,7 @@ export function dataObjForCharacterSheet(
   additional: Data = {},
 ): Data {
   function curve(base: number, lvlCurve: string): NumNode {
-    return prod(base, subscript(input.lvl, charCurves[lvlCurve]))
+    return prod(base, subscript<number>(input.lvl, charCurves[lvlCurve]))
   }
   display.basic = { ...commonBasic }
   const data: Data = {

--- a/src/Formula/internal.ts
+++ b/src/Formula/internal.ts
@@ -72,7 +72,7 @@ export function mapFormulas<Input extends Base<Input> = AnyNode, Interim extends
   return arrayEqual<Input | Output>(result, formulas) ? formulas as any : result
 }
 
-export function customMapFormula<Context, Output, Input extends Base<Input> = AnyNode>(formulas: Input[], context: Context, map: (formula: Input, context: Context, map: (node: Input, context: Context) => Output) => Output): Output[] {
+export function customMapFormula<Context, Output, Input extends Base<Input>>(formulas: Input[], context: Context, map: (formula: Input, context: Context, map: (node: Input, context: Context) => Output) => Output): Output[] {
   const contextMapping = new Map<Context, [Set<Input>, Map<Input, Output>]>()
   function internalMap(formula: Input, context: Context): Output {
     let current = contextMapping.get(context)

--- a/src/Formula/internal.ts
+++ b/src/Formula/internal.ts
@@ -1,8 +1,6 @@
 import { crawlObject, deepClone, objPathValue } from "../Util/Util"
-import { NodeData, NumNode, StrNode } from "./type"
+import { AnyNode, Base, NodeData, NumNode, StrNode } from "./type"
 import { constant } from "./utils"
-
-type Node = NumNode | StrNode
 
 export function deepNodeClone<T extends NodeData<NumNode | StrNode | undefined>>(data: T): T {
   const result = deepClone(data)
@@ -12,10 +10,10 @@ export function deepNodeClone<T extends NodeData<NumNode | StrNode | undefined>>
   return result
 }
 
-export function forEachNodes(formulas: Node[], topDown: (formula: Node) => void, bottomUp: (formula: Node) => void): void {
-  const visiting = new Set<Node>(), visited = new Set<Node>()
+export function forEachNodes<T extends Base<T> = AnyNode>(formulas: T[], topDown: (formula: T) => void, bottomUp: (formula: T) => void): void {
+  const visiting = new Set<T>(), visited = new Set<T>()
 
-  function traverse(formula: Node) {
+  function traverse(formula: T) {
     if (visited.has(formula)) return
 
     if (visiting.has(formula)) {
@@ -37,14 +35,13 @@ export function forEachNodes(formulas: Node[], topDown: (formula: Node) => void,
   formulas.forEach(traverse)
 }
 
-export function mapFormulas(formulas: NumNode[], topDownMap: (formula: Node) => Node, bottomUpMap: (current: Node, orig: Node) => Node): NumNode[]
-export function mapFormulas(formulas: Node[], topDownMap: (formula: Node) => Node, bottomUpMap: (current: Node, orig: Node) => Node): Node[] {
-  const visiting = new Set<Node>()
-  const topDownMapped = new Map<Node, Node>()
-  const bottomUpMapped = new Map<Node, Node>()
+export function mapFormulas<Input extends Base<Input> = AnyNode, Interim extends Base<Interim> = Input, Output extends Base<Output> = Interim>(formulas: Input[], topDownMap: (formula: Input | Interim) => Interim, bottomUpMap: (current: Interim | Output, orig: Input | Interim) => Output): Output[] {
+  const visiting = new Set<Input | Interim>()
+  const topDownMapped = new Map<Input | Interim, Output>()
+  const bottomUpMapped = new Map<Interim, Output>()
 
-  function check(formula: Node): Node {
-    let topDown = topDownMapped.get(formula)
+  function check(formula: Input | Interim): Output {
+    let topDown: Interim | Output | undefined = topDownMapped.get(formula)
     if (topDown) return topDown
     topDown = topDownMap(formula)
 
@@ -53,7 +50,7 @@ export function mapFormulas(formulas: Node[], topDownMap: (formula: Node) => Nod
 
     if (visiting.has(topDown)) {
       console.error("Found cyclical dependency during formula mapping")
-      return constant(NaN)
+      return constant(NaN) as any
     }
     visiting.add(topDown)
 
@@ -66,18 +63,18 @@ export function mapFormulas(formulas: Node[], topDownMap: (formula: Node) => Nod
     return bottomUp
   }
 
-  function traverse(formula: Node): Node {
+  function traverse(formula: Interim): Interim | Output {
     const operands = formula.operands.map(check)
-    return arrayEqual(operands, formula.operands) ? formula : { ...formula, operands } as any
+    return arrayEqual<Interim | Output>(operands, formula.operands) ? formula : { ...formula, operands }
   }
 
   const result = formulas.map(check)
-  return arrayEqual(result, formulas) ? formulas : result
+  return arrayEqual<Input | Output>(result, formulas) ? formulas as any : result
 }
 
-export function customMapFormula<Context, Output>(formulas: NumNode[], context: Context, map: (formula: Node, context: Context, map: (node: NumNode, context: Context) => Output) => Output): Output[] {
-  const contextMapping = new Map<Context, [Set<NumNode>, Map<NumNode, Output>]>()
-  function internalMap(formula: NumNode, context: Context): Output {
+export function customMapFormula<Context, Output, Input extends Base<Input> = AnyNode>(formulas: Input[], context: Context, map: (formula: Input, context: Context, map: (node: Input, context: Context) => Output) => Output): Output[] {
+  const contextMapping = new Map<Context, [Set<Input>, Map<Input, Output>]>()
+  function internalMap(formula: Input, context: Context): Output {
     let current = contextMapping.get(context)
     if (!current) contextMapping.set(context, current = [new Set(), new Map()])
     const [visiting, mapping] = current

--- a/src/Formula/optimization.ts
+++ b/src/Formula/optimization.ts
@@ -1,8 +1,11 @@
 import type { ArtifactBuildData } from "../PageCharacter/CharacterDisplay/Tabs/TabOptimize/common"
 import { assertUnreachable, objPathValue } from "../Util/Util"
-import { forEachNodes, mapFormulas } from "./internal"
-import { CommutativeMonoidOperation, ComputeNode, ConstantNode, Data, NumNode, Operation, ReadNode, StrNode, StrPrioNode } from "./type"
+import { customMapFormula, forEachNodes, mapFormulas } from "./internal"
+import { AnyNode, CommutativeMonoidOperation, ComputeNode, ConstantNode, Data, NumNode, Operation, ReadNode, StrNode, StrPrioNode, ThresholdNode } from "./type"
 import { constant } from "./utils"
+
+export type OptNode = ComputeNode<OptNode, OptNode> | ThresholdNode<OptNode, OptNode, OptNode> |
+  ReadNode<number> | ConstantNode<number>
 
 const allCommutativeMonoidOperations: StrictDict<CommutativeMonoidOperation, (_: number[]) => number> = {
   min: (x: number[]): number => Math.min(...x),
@@ -23,13 +26,12 @@ export const allOperations: StrictDict<Operation | "threshold", (_: number[]) =>
 
 const commutativeMonoidOperationSet = new Set(Object.keys(allCommutativeMonoidOperations) as (NumNode["operation"])[])
 
-export function optimize(formulas: NumNode[], topLevelData: Data, shouldFold = (_formula: ReadNode<number | string | undefined>) => false): NumNode[] {
-  formulas = constantFold(formulas, topLevelData, shouldFold)
-  formulas = flatten(formulas)
-  formulas = deduplicate(formulas)
-  return formulas
+export function optimize(formulas: NumNode[], topLevelData: Data, shouldFold = (_formula: ReadNode<number | string | undefined>) => false): OptNode[] {
+  let opts = constantFold(formulas, topLevelData, shouldFold)
+  opts = flatten(opts)
+  return deduplicate(opts)
 }
-export function precompute(formulas: NumNode[], initial: ArtifactBuildData["values"], binding: (readNode: ReadNode<number> | ReadNode<string | undefined>) => string, slotCount: number): (_: ArtifactBuildData[]) => number[] {
+export function precompute(formulas: OptNode[], initial: ArtifactBuildData["values"], binding: (readNode: ReadNode<number> | ReadNode<string | undefined>) => string, slotCount: number): (_: ArtifactBuildData[]) => number[] {
   let body = `
 "use strict";
 // copied from the code above
@@ -43,7 +45,7 @@ const x0=0`; // making sure `const` has at least one entry
   let i = 1;
   const names = new Map<NumNode | StrNode, string>()
   forEachNodes(formulas, _ => { }, f => {
-    const { operation, operands } = f, name = `x${i++}`, operandNames = operands.map(x => names.get(x)!)
+    const { operation, operands } = f, name = `x${i++}`, operandNames = operands.map((x: OptNode) => names.get(x)!)
     names.set(f, name)
     switch (operation) {
       case "read": {
@@ -66,9 +68,6 @@ const x0=0`; // making sure `const` has at least one entry
       case "res": body += `,${name}=res(${operandNames[0]})`; break
       case "sum_frac": body += `,${name}=${operandNames[0]}/(${operandNames[0]}+${operandNames[1]})`; break
 
-      case "match": case "lookup": case "subscript":
-      case "prio": case "small":
-      case "data": throw new Error(`Unsupported ${operation} node in precompute`)
       default: assertUnreachable(operation)
     }
   })
@@ -76,11 +75,11 @@ const x0=0`; // making sure `const` has at least one entry
   return new (Function as any)(`b`, body)
 }
 
-function flatten(formulas: NumNode[]): NumNode[] {
+function flatten(formulas: OptNode[]): OptNode[] {
   return mapFormulas(formulas, f => f, _formula => {
     let result = _formula
-    if (commutativeMonoidOperationSet.has(_formula.operation as any)) {
-      const formula = _formula as ComputeNode
+    if (commutativeMonoidOperationSet.has(_formula.operation as Operation)) {
+      const formula = _formula as ComputeNode<OptNode>
       const { operation } = formula
 
       let flattened = false
@@ -92,7 +91,7 @@ function flatten(formulas: NumNode[]): NumNode[] {
     return result
   })
 }
-function deduplicate(formulas: NumNode[]): NumNode[] {
+function deduplicate(formulas: OptNode[]): OptNode[] {
   function elementCounts<T>(array: readonly T[]): Map<T, number> {
     const result = new Map<T, number>()
     for (const value of array) result.set(value, (result.get(value) ?? 0) + 1)
@@ -104,8 +103,8 @@ function deduplicate(formulas: NumNode[]): NumNode[] {
 
   const wrap = {
     common: {
-      counts: new Map<NumNode, number>(),
-      formulas: new Set<NumNode>(),
+      counts: new Map<OptNode, number>(),
+      formulas: new Set<OptNode>(),
       operation: "add" as Operation
     }
   }
@@ -113,15 +112,15 @@ function deduplicate(formulas: NumNode[]): NumNode[] {
   while (true) {
     let next: typeof wrap.common | undefined
 
-    const factored: ComputeNode = { operation: wrap.common.operation, operands: arrayFromCounts(wrap.common.counts) }
+    const factored: ComputeNode<OptNode> = { operation: wrap.common.operation, operands: arrayFromCounts(wrap.common.counts) }
 
-    let candidatesByOperation = new Map<Operation, [ComputeNode, Map<NumNode, number>][]>()
+    let candidatesByOperation = new Map<Operation, [ComputeNode<OptNode>, Map<OptNode, number>][]>()
     for (const operation of Object.keys(allCommutativeMonoidOperations))
       candidatesByOperation.set(operation, [])
 
     formulas = mapFormulas(formulas, _formula => {
-      if (wrap.common.formulas.has(_formula as NumNode)) {
-        const formula = _formula as ComputeNode
+      if (wrap.common.formulas.has(_formula)) {
+        const formula = _formula as ComputeNode<OptNode>
         const remainingCounts = new Map(wrap.common.counts)
         const operands = formula.operands.filter(dep => {
           const count = remainingCounts.get(dep)
@@ -140,11 +139,11 @@ function deduplicate(formulas: NumNode[]): NumNode[] {
       return _formula
     }, _formula => {
       if (!commutativeMonoidOperationSet.has(_formula.operation as any)) return _formula
-      const formula = _formula as ComputeNode
+      const formula = _formula as ComputeNode<OptNode>
 
       if (next) {
         if (next.operation === formula.operation) {
-          const currentCounts = elementCounts(formula.operands), commonCounts = new Map<NumNode, number>()
+          const currentCounts = elementCounts(formula.operands), commonCounts = new Map<OptNode, number>()
           const nextCounts = next.counts
           let total = 0
 
@@ -167,7 +166,7 @@ function deduplicate(formulas: NumNode[]): NumNode[] {
         for (const [candidate, candidateCounts] of candidates) {
           let total = 0
 
-          const commonCounts = new Map<NumNode, number>()
+          const commonCounts = new Map<OptNode, number>()
           for (const [dependency, candidateCount] of candidateCounts.entries()) {
             const count = Math.min(candidateCount, counts.get(dependency) ?? 0)
             if (count) {
@@ -202,26 +201,24 @@ function deduplicate(formulas: NumNode[]): NumNode[] {
  * Replace nodes with known values with appropriate constants,
  * avoiding removal of any nodes that pass `isFixed` predicate
  */
-export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold = (_formula: ReadNode<number | string | undefined>) => false): NumNode[] {
-  type Context = { data: Data[], processed: Map<NumNode | StrNode, NumNode | StrNode> }
+export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold = (_formula: ReadNode<number | string | undefined>) => false): OptNode[] {
+  type Context = { data: Data[], processed: Map<NumNode | StrNode, OptNode | StrNode> }
   const origin: Context = { data: [], processed: new Map() }
   const nextContextMap = new Map([[origin, new Map<Data, Context>()]])
 
-  function fold(formula: StrNode, context: Context): StrNode
-  function fold(formula: NumNode, context: Context): NumNode
-  function fold(formula: NumNode | StrNode, context: Context): NumNode | StrNode
-  function fold(formula: NumNode | StrNode, context: Context): NumNode | StrNode {
-    const old = context.processed.get(formula)
-    if (old) return old
-
-    const { operation } = formula
-    let result: NumNode | StrNode
+  const context = { data: [topLevelData], processed: new Map() }
+  nextContextMap.set(context, new Map())
+  nextContextMap.get(origin)!.set(topLevelData, context)
+  return customMapFormula<typeof context, OptNode | StrNode, AnyNode>(formulas, context, (formula, context, map) => {
+    const { operation } = formula, fold = (x: NumNode, c: typeof context) => map(x, c) as OptNode
+    const foldStr = (x: StrNode, c: typeof context) => map(x, c) as StrNode
+    let result: OptNode | StrNode
     switch (operation) {
       case "const": return formula
       case "add": case "mul": case "max": case "min":
         const f = allOperations[operation]
         const numericOperands: number[] = []
-        const formulaOperands: NumNode[] = formula.operands.filter(formula => {
+        const formulaOperands: OptNode[] = formula.operands.filter(formula => {
           const folded = fold(formula, context)
           return (folded.operation === "const")
             ? (numericOperands.push(folded.value), false)
@@ -267,11 +264,11 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
         break
       }
       case "lookup": {
-        const index = fold(formula.operands[0], context)
+        const index = foldStr(formula.operands[0], context)
         if (index.operation === "const") {
           const selected = formula.table[index.value!] ?? formula.operands[1]
           if (selected) {
-            result = fold(selected, context)
+            result = map(selected, context)
             break
           }
         }
@@ -279,18 +276,18 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
       }
       case "prio": {
         const first = formula.operands.find(op => {
-          const folded = fold(op, context)
+          const folded = foldStr(op, context)
           if (folded.operation !== "const")
             throw new Error(`Unsupported ${operation} node while folding`)
           return folded.value !== undefined
         })
-        result = first ? fold(first, context) : constant(undefined)
+        result = first ? foldStr(first, context) : constant(undefined)
         break
       }
       case "small": {
         let smallest = undefined as ConstantNode<string | undefined> | undefined
         for (const operand of formula.operands) {
-          const folded = fold(operand, context)
+          const folded = foldStr(operand, context)
           if (folded.operation !== "const")
             throw new Error(`Unsupported ${operation} node while folding`)
           if (smallest?.value === undefined || (folded.value !== undefined && folded.value < smallest.value))
@@ -300,14 +297,14 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
         break
       }
       case "match": {
-        const [v1, v2, match, unmatch] = formula.operands.map((x: NumNode | StrNode) => fold(x, context))
+        const [v1, v2, match, unmatch] = formula.operands.map((x: NumNode | StrNode) => map(x, context))
         if (v1.operation !== "const" || v2.operation !== "const")
           throw new Error(`Unsupported ${operation} node while folding`)
         result = (v1.value === v2.value) ? match : unmatch
         break
       }
       case "threshold": {
-        const [value, threshold, pass, fail] = formula.operands.map(x => fold(x, context) as NumNode)
+        const [value, threshold, pass, fail] = formula.operands.map(x => map(x, context) as OptNode)
         if (pass.operation === "const" && fail.operation === "const" && pass.value === fail.value)
           result = pass
         else if (value.operation === "const" && threshold.operation === "const")
@@ -317,10 +314,10 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
         break
       }
       case "subscript": {
-        const [index] = formula.operands.map(x => fold(x, context))
-        result = (index.operation === "const")
-          ? constant(formula.list[index.value])
-          : { ...formula, operands: [index] }
+        const index = fold(formula.operands[0], context)
+        if (index.operation !== "const")
+          throw new Error("Found non-constant subscript node while folding")
+        result = constant(formula.list[index.value])
         break
       }
       case "read": {
@@ -336,22 +333,23 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
             else result = constant(allOperations[accu]([]))
           } else result = formula
         } else if (formula.accu === undefined || operands.length === 1)
-          result = fold(operands[operands.length - 1], context)
+          result = map(operands[operands.length - 1], context)
         else
-          result = fold({ operation: formula.accu, operands } as ComputeNode | StrPrioNode, context)
+          result = map({ operation: formula.accu, operands } as ComputeNode | StrPrioNode, context)
         break
       }
-      case "data":
+      case "data": {
         if (formula.reset) context = origin
-        const map = nextContextMap.get(context)!
-        let nextContext = map.get(formula.data)
+        const nextMap = nextContextMap.get(context)!
+        let nextContext = nextMap.get(formula.data)
         if (!nextContext) {
           nextContext = { data: [...context.data, formula.data], processed: new Map() }
           nextContextMap.set(nextContext, new Map())
-          map.set(formula.data, nextContext)
+          nextMap.set(formula.data, nextContext)
         }
-        result = fold(formula.operands[0], nextContext)
+        result = map(formula.operands[0], nextContext)
         break
+      }
       default: assertUnreachable(operation)
     }
 
@@ -359,14 +357,8 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
       result = { ...result }
       delete result.info
     }
-    context.processed.set(formula, result)
     return result
-  }
-
-  const context = { data: [topLevelData], processed: new Map() }
-  nextContextMap.set(context, new Map())
-  nextContextMap.get(origin)!.set(topLevelData, context)
-  return formulas.map(x => fold(x, context))
+  }) as OptNode[]
 }
 
 export const testing = {

--- a/src/Formula/optimization.ts
+++ b/src/Formula/optimization.ts
@@ -214,7 +214,7 @@ export function constantFold(formulas: NumNode[], topLevelData: Data, shouldFold
     const foldStr = (x: StrNode, c: typeof context) => map(x, c) as StrNode
     let result: OptNode | StrNode
     switch (operation) {
-      case "const": return formula
+      case "const": result = formula; break
       case "add": case "mul": case "max": case "min":
         const f = allOperations[operation]
         const numericOperands: number[] = []

--- a/src/Formula/type.d.ts
+++ b/src/Formula/type.d.ts
@@ -5,13 +5,13 @@ import type { input, uiInput } from "./index"
 
 export type NumNode = ComputeNode | ThresholdNode<NumNode> |
   DataNode<NumNode> |
-  LookupNode<NumNode> | MatchNode<StrNode, NumNode> | MatchNode<NumNode, NumNode> |
+  LookupNode<NumNode> | MatchNode<NumNode> |
   SubscriptNode<number> |
   ReadNode<number> | ConstantNode<number>
 export type StrNode = StrPrioNode | SmallestNode | ThresholdNode<StrNode> |
   DataNode<StrNode> |
   LookupNode<StrNode> |
-  MatchNode<StrNode, StrNode> | MatchNode<NumNode, StrNode> |
+  MatchNode<StrNode> |
   ReadNode<string | undefined> | ConstantNode<string | undefined>
 type AnyNode = NumNode | StrNode
 
@@ -65,7 +65,7 @@ export interface ThresholdNode<Output, Input extends NumNode = NumNode, Leaf ext
   operands: readonly [Input, Input, Output, Output]
   emptyOn?: "ge" | "l"
 }
-export interface MatchNode<Input, Output, Leaf extends Input | Output = AnyNode> extends Base<Leaf> {
+export interface MatchNode<Output, Input = AnyNode, Leaf extends Input | Output = AnyNode> extends Base<Leaf> {
   operation: "match"
   operands: readonly [v1: Input, v2: Input, match: Output, unmatch: Output]
   emptyOn?: "match" | "unmatch"

--- a/src/Formula/type.d.ts
+++ b/src/Formula/type.d.ts
@@ -13,6 +13,7 @@ export type StrNode = StrPrioNode | SmallestNode | ThresholdNode<StrNode> |
   LookupNode<StrNode> |
   MatchNode<StrNode, StrNode> | MatchNode<NumNode, StrNode> |
   ReadNode<string | undefined> | ConstantNode<string | undefined>
+type AnyNode = NumNode | StrNode
 
 interface Info {
   name?: Displayable
@@ -31,56 +32,57 @@ interface Info {
 }
 export type Variant = ElementKeyWithPhy | TransformativeReactionsKey | AmplifyingReactionsKey | AdditiveReactionsKey | "heal" | "invalid"
 
-interface Base {
+interface Base<Leaf extends Base<Leaf>> {
   info?: Info
+  operands: readonly Leaf[]
 }
-export interface StrPrioNode extends Base {
+export interface StrPrioNode<Leaf = AnyNode> extends Base<Leaf> {
   operation: "prio"
   operands: readonly StrNode[]
 }
 /** Pick the lexcicographically smallest non-`undefined` value. If all values are `undefined` or there is no value, use `undefined`. */
-export interface SmallestNode extends Base {
+export interface SmallestNode<Leaf = AnyNode> extends Base<Leaf> {
   operation: "small"
   operands: readonly StrNode[]
 }
-export interface LookupNode<Output> extends Base {
+export interface LookupNode<Output, Input extends StrNode = StrNode, Leaf extends Input | Output = AnyNode> extends Base<Leaf> {
   operation: "lookup"
-  operands: readonly [index: StrNode] | readonly [index: StrNode, defaultNode: Output]
+  operands: readonly [index: Input] | readonly [index: Input, defaultNode: Output]
   table: Dict<string, Output>
 }
-export interface DataNode<Output> extends Base {
+export interface DataNode<Output, Leaf extends Output = AnyNode> extends Base<Leaf> {
   operation: "data"
   operands: readonly [Output]
   data: Data
   reset?: true
 }
-export interface ComputeNode extends Base {
+export interface ComputeNode<Input extends NumNode = NumNode, Leaf extends Input = AnyNode> extends Base<Leaf> {
   operation: Operation
-  operands: readonly NumNode[]
+  operands: readonly Input[]
 }
-export interface ThresholdNode<Output> extends Base {
+export interface ThresholdNode<Output, Input extends NumNode = NumNode, Leaf extends Input | Output = AnyNode> extends Base<Leaf> {
   operation: "threshold"
-  operands: readonly [NumNode, NumNode, Output, Output]
+  operands: readonly [Input, Input, Output, Output]
   emptyOn?: "ge" | "l"
 }
-export interface MatchNode<Input, Output> extends Base {
+export interface MatchNode<Input, Output, Leaf extends Input | Output = AnyNode> extends Base<Leaf> {
   operation: "match"
   operands: readonly [v1: Input, v2: Input, match: Output, unmatch: Output]
   emptyOn?: "match" | "unmatch"
 }
-export interface SubscriptNode<Value> extends Base {
+export interface SubscriptNode<Value, Input extends NumNode = NumNode, Leaf extends Input = AnyNode> extends Base<Leaf> {
   operation: "subscript"
-  operands: readonly [index: NumNode]
+  operands: readonly [index: Input]
   list: readonly Value[]
 }
-export interface ReadNode<Value> extends Base {
+export interface ReadNode<Value> extends Base<any> {
   operation: "read"
   operands: readonly []
   accu?: Value extends number ? CommutativeMonoidOperation : "small"
   path: readonly string[]
   type: Value extends number ? "number" : Value extends string ? "string" : undefined
 }
-export interface ConstantNode<Value> extends Base {
+export interface ConstantNode<Value> extends Base<any> {
   operation: "const"
   operands: readonly []
   value: Value

--- a/src/Formula/utils.ts
+++ b/src/Formula/utils.ts
@@ -1,13 +1,15 @@
 
 import { objectKeyMap } from "../Util/Util"
+import type { OptNode } from "./optimization"
 import type { ComputeNode, ConstantNode, Data, DataNode, Info, LookupNode, MatchNode, NumNode, ReadNode, StrNode, StrPrioNode, SubscriptNode, ThresholdNode } from "./type"
 
+type Opt = number | OptNode
 type Num = number | NumNode
 type Str = string | undefined | StrNode
 type N_S = Num | Str
 type AnyNode = NumNode | StrNode
 
-export const todo: NumNode = constant(NaN, { name: "TODO" })
+export const todo: OptNode = constant(NaN, { name: "TODO" })
 export const one = percent(1), naught = percent(0)
 export const none = constant("none")
 
@@ -26,6 +28,7 @@ export function percent(value: number, info?: Info): ConstantNode<number> {
   return constant(value, { unit: "%", ...info })
 }
 /** Inject `info` to the node in-place */
+export function infoMut(node: OptNode, info: Info): OptNode
 export function infoMut(node: NumNode, info: Info): NumNode
 export function infoMut(node: StrNode, info: Info): StrNode
 export function infoMut(node: AnyNode, info: Info): AnyNode {
@@ -42,25 +45,37 @@ export function lookup(index: StrNode, table: Dict<string, AnyNode>, defaultV: N
 }
 
 /** min( x1, x2, ... ) */
+export function min(...values: Opt[]): ComputeNode<OptNode, OptNode>
+export function min(...values: Num[]): ComputeNode
 export function min(...values: Num[]): ComputeNode {
   return { operation: "min", operands: intoOps(values) }
 }
 /** max( x1, x2, ... ) */
+export function max(...values: Opt[]): ComputeNode<OptNode, OptNode>
+export function max(...values: Num[]): ComputeNode
 export function max(...values: Num[]): ComputeNode {
   return { operation: "max", operands: intoOps(values) }
 }
 /** x1 + x2 + ... */
+export function sum(...values: Opt[]): ComputeNode<OptNode, OptNode>
+export function sum(...values: Num[]): ComputeNode
 export function sum(...values: Num[]): ComputeNode {
   return { operation: "add", operands: intoOps(values) }
 }
 /** x1 * x2 * ... */
+export function prod(...values: Opt[]): ComputeNode<OptNode, OptNode>
+export function prod(...values: Num[]): ComputeNode
 export function prod(...values: Num[]): ComputeNode {
   return { operation: "mul", operands: intoOps(values) }
 }
 /** x / (x + c) */
+export function frac(x: Opt, c: Opt): ComputeNode<OptNode, OptNode>
+export function frac(x: Num, c: Num): ComputeNode
 export function frac(x: Num, c: Num): ComputeNode {
   return { operation: "sum_frac", operands: intoOps([x, c]) }
 }
+export function res(base: Opt): ComputeNode<OptNode, OptNode>
+export function res(base: Num): ComputeNode
 export function res(base: Num): ComputeNode {
   return { operation: "res", operands: intoOps([base]) }
 }
@@ -98,6 +113,8 @@ export function unequalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(undefined), intoV(pass)], info, emptyOn: "match" }
 }
 /** v1 >= v2 ? pass : 0 */
+export function greaterEq(v1: Opt, v2: Opt, pass: Opt, info?: Info): ThresholdNode<OptNode, OptNode, OptNode>
+export function greaterEq(v1: Num, v2: Num, pass: Num, info?: Info): ThresholdNode<NumNode>
 export function greaterEq(v1: Num, v2: Num, pass: Num, info?: Info): ThresholdNode<NumNode> {
   const operands = [intoV(v1), intoV(v2), intoV(pass), intoV(0)] as any
   return { operation: "threshold", operands, info, emptyOn: "l" }
@@ -108,11 +125,15 @@ export function greaterEqStr(v1: Num, v2: Num, pass: Str, info?: Info): Threshol
   return { operation: "threshold", operands, info, emptyOn: "l" }
 }
 /** v1 < v2 ? pass : 0 */
+export function lessThan(v1: Opt, v2: Opt, pass: Opt, info?: Info): ThresholdNode<OptNode, OptNode, OptNode>
+export function lessThan(v1: Num, v2: Num, pass: Num, info?: Info): ThresholdNode<NumNode>
 export function lessThan(v1: Num, v2: Num, pass: Num, info?: Info): ThresholdNode<NumNode> {
   const operands = [intoV(v1), intoV(v2), intoV(0), intoV(pass)] as any
   return { operation: "threshold", operands, info, emptyOn: "ge" }
 }
 /** v1 >= v2 ? ge : le */
+export function threshold(v1: Opt, v2: Opt, ge: Opt, le: Opt, info?: Info): OptNode
+export function threshold(v1: Num, v2: Num, ge: Num, le: Num, info?: Info): NumNode
 export function threshold(v1: Num, v2: Num, ge: Num, le: Num, info?: Info): NumNode {
   return { operation: "threshold", operands: intoOps([v1, v2, ge, le]) as any, info }
 }

--- a/src/Formula/utils.ts
+++ b/src/Formula/utils.ts
@@ -81,35 +81,35 @@ export function res(base: Num): ComputeNode {
 }
 
 /** v1 == v2 ? eq : neq */
-export function compareEq(v1: Num, v2: Num, eq: Num, neq: Num, info?: Info): MatchNode<NumNode, NumNode>
-export function compareEq(v1: Num, v2: Num, eq: Str, neq: Str, info?: Info): MatchNode<NumNode, StrNode>
-export function compareEq(v1: Str, v2: Str, eq: Num, neq: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function compareEq(v1: Str, v2: Str, eq: Str, neq: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function compareEq(v1: N_S, v2: N_S, eq: N_S, neq: N_S, info?: Info): MatchNode<AnyNode, AnyNode> {
+export function compareEq(v1: Num, v2: Num, eq: Num, neq: Num, info?: Info): MatchNode<NumNode>
+export function compareEq(v1: Num, v2: Num, eq: Str, neq: Str, info?: Info): MatchNode<StrNode>
+export function compareEq(v1: Str, v2: Str, eq: Num, neq: Num, info?: Info): MatchNode<NumNode>
+export function compareEq(v1: Str, v2: Str, eq: Str, neq: Str, info?: Info): MatchNode<StrNode>
+export function compareEq(v1: N_S, v2: N_S, eq: N_S, neq: N_S, info?: Info): MatchNode<AnyNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(eq), intoV(neq)], info }
 }
 /** v1 == v2 ? pass : 0 */
-export function equal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode, NumNode>
-export function equal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function equal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
+export function equal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode>
+export function equal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<NumNode>
+export function equal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<NumNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(pass), intoV(0)], info, emptyOn: "unmatch" }
 }
 /** v1 == v2 ? pass : `undefined` */
-export function equalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<NumNode, StrNode>
-export function equalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function equalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
+export function equalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<StrNode>
+export function equalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode>
+export function equalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<StrNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(pass), intoV(undefined)], info, emptyOn: "unmatch" }
 }
 /** v1 != v2 ? pass : 0 */
-export function unequal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode, NumNode>
-export function unequal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function unequal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<AnyNode, NumNode> {
+export function unequal(v1: Num, v2: Num, pass: Num, info?: Info): MatchNode<NumNode>
+export function unequal(v1: Str, v2: Str, pass: Num, info?: Info): MatchNode<NumNode>
+export function unequal(v1: N_S, v2: N_S, pass: Num, info?: Info): MatchNode<NumNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(0), intoV(pass)], info, emptyOn: "match" }
 }
 /** v1 != v2 ? pass : `undefined` */
-export function unequalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<NumNode, StrNode>
-export function unequalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function unequalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<AnyNode, StrNode> {
+export function unequalStr(v1: Num, v2: Num, pass: Str, info?: Info): MatchNode<StrNode>
+export function unequalStr(v1: Str, v2: Str, pass: Str, info?: Info): MatchNode<StrNode>
+export function unequalStr(v1: N_S, v2: N_S, pass: Str, info?: Info): MatchNode<StrNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(undefined), intoV(pass)], info, emptyOn: "match" }
 }
 /** v1 >= v2 ? pass : 0 */
@@ -204,10 +204,10 @@ type NodeList = _NodeList | ReadNode<number> | ReadNode<string>
  * `v1` === `v2` ? `match` : `unmatch`
  * @deprecated Use `equal`, `unequal`, `equalStr`, or `compareEq` instead
  */
-export function matchFull(v1: Num, v2: Num, match: Num, unmatch: Num, info?: Info): MatchNode<NumNode, NumNode>
-export function matchFull(v1: Num, v2: Num, match: Str, unmatch: Str, info?: Info): MatchNode<NumNode, StrNode>
-export function matchFull(v1: Str, v2: Str, match: Num, unmatch: Num, info?: Info): MatchNode<StrNode, NumNode>
-export function matchFull(v1: Str, v2: Str, match: Str, unmatch: Str, info?: Info): MatchNode<StrNode, StrNode>
-export function matchFull(v1: N_S, v2: N_S, match: N_S, unmatch: N_S, info?: Info): MatchNode<AnyNode, AnyNode> {
+export function matchFull(v1: Num, v2: Num, match: Num, unmatch: Num, info?: Info): MatchNode<NumNode>
+export function matchFull(v1: Num, v2: Num, match: Str, unmatch: Str, info?: Info): MatchNode<StrNode>
+export function matchFull(v1: Str, v2: Str, match: Num, unmatch: Num, info?: Info): MatchNode<NumNode>
+export function matchFull(v1: Str, v2: Str, match: Str, unmatch: Str, info?: Info): MatchNode<StrNode>
+export function matchFull(v1: N_S, v2: N_S, match: N_S, unmatch: N_S, info?: Info): MatchNode<AnyNode> {
   return { operation: "match", operands: [intoV(v1), intoV(v2), intoV(match), intoV(unmatch)], info }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/BackgroundWorker.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/BackgroundWorker.ts
@@ -1,9 +1,9 @@
 import { ArtSetExclusion } from '../../../../Database/DataManagers/BuildsettingData'
-import { NumNode } from '../../../../Formula/type'
+import { OptNode } from '../../../../Formula/optimization'
 import { assertUnreachable } from '../../../../Util/Util'
+import { BNBSplitWorker } from "./BNBSplitWorker"
 import { ArtifactsBySlot, artSetPerm, Build, countBuilds, filterArts, filterFeasiblePerm, PlotData, RequestFilter } from "./common"
 import { ComputeWorker } from "./ComputeWorker"
-import { BNBSplitWorker } from "./BNBSplitWorker"
 import { DefaultSplitWorker } from './DefaultSplitWorker'
 
 let id: number, splitWorker: SplitWorker, computeWorker: ComputeWorker
@@ -69,9 +69,9 @@ export interface Setup {
   id: number
   arts: ArtifactsBySlot
 
-  optimizationTarget: NumNode
-  filters: { value: NumNode, min: number }[]
-  plotBase: NumNode | undefined,
+  optimizationTarget: OptNode
+  filters: { value: OptNode, min: number }[]
+  plotBase: OptNode | undefined,
   maxBuilds: number
 }
 export interface Split {

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/ComputeWorker.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/ComputeWorker.ts
@@ -1,5 +1,4 @@
-import { optimize, precompute } from '../../../../Formula/optimization';
-import type { NumNode } from '../../../../Formula/type';
+import { optimize, OptNode, precompute } from '../../../../Formula/optimization';
 import type { InterimResult, Setup } from './BackgroundWorker';
 import { ArtifactBuildData, ArtifactsBySlot, Build, countBuilds, filterArts, mergePlot, PlotData, pruneAll, RequestFilter } from './common';
 
@@ -12,7 +11,7 @@ export class ComputeWorker {
   min: number[]
 
   arts: ArtifactsBySlot
-  nodes: NumNode[]
+  nodes: OptNode[]
 
   callback: (interim: InterimResult) => void
 

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/common.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/common.ts
@@ -1,13 +1,13 @@
 import { ArtSetExclusion } from "../../../../Database/DataManagers/BuildsettingData";
 import { forEachNodes, mapFormulas } from "../../../../Formula/internal";
-import { allOperations, constantFold } from "../../../../Formula/optimization";
+import { allOperations, constantFold, OptNode } from "../../../../Formula/optimization";
 import { ConstantNode, NumNode } from "../../../../Formula/type";
 import { constant, customRead, max, min, threshold } from "../../../../Formula/utils";
 import { allSlotKeys, ArtifactSetKey, SlotKey } from "../../../../Types/consts";
 import { assertUnreachable, objectKeyMap, objectMap, range } from "../../../../Util/Util";
 
 type MicropassOperation = "reaffine" | "pruneArtRange" | "pruneNodeRange" | "pruneOrder"
-export function pruneAll(nodes: NumNode[], minimum: number[], arts: ArtifactsBySlot, numTop: number, exclusion: ArtSetExclusion, forced: Dict<MicropassOperation, boolean>): { nodes: NumNode[], arts: ArtifactsBySlot } {
+export function pruneAll(nodes: OptNode[], minimum: number[], arts: ArtifactsBySlot, numTop: number, exclusion: ArtSetExclusion, forced: Dict<MicropassOperation, boolean>): { nodes: OptNode[], arts: ArtifactsBySlot } {
   let should = forced
   /** If `key` makes progress, all operations in `value` should be performed */
   const deps: StrictDict<MicropassOperation, Dict<MicropassOperation, true>> = {
@@ -55,7 +55,7 @@ export function pruneAll(nodes: NumNode[], minimum: number[], arts: ArtifactsByS
   return { nodes, arts }
 }
 
-export function pruneExclusion(nodes: NumNode[], exclusion: ArtSetExclusion): NumNode[] {
+export function pruneExclusion(nodes: OptNode[], exclusion: ArtSetExclusion): OptNode[] {
   const maxValues: Dict<keyof typeof exclusion, number> = {}
   for (const [key, e] of Object.entries(exclusion)) {
     if (!e.includes(4)) continue
@@ -64,7 +64,7 @@ export function pruneExclusion(nodes: NumNode[], exclusion: ArtSetExclusion): Nu
   return mapFormulas(nodes, f => f, f => {
     if (f.operation !== "threshold") return f
 
-    const [v, t, pass, fail] = f.operands as readonly NumNode[]
+    const [v, t, pass, fail] = f.operands
     if (v.operation === "read" && t.operation === "const") {
       const key = v.path[v.path.length - 1], thres = t.value
       if (key in maxValues) {
@@ -78,7 +78,7 @@ export function pruneExclusion(nodes: NumNode[], exclusion: ArtSetExclusion): Nu
   })
 }
 
-function reaffine(nodes: NumNode[], arts: ArtifactsBySlot, forceRename: boolean = false): { nodes: NumNode[], arts: ArtifactsBySlot } {
+function reaffine(nodes: OptNode[], arts: ArtifactsBySlot, forceRename: boolean = false): { nodes: OptNode[], arts: ArtifactsBySlot } {
   const affineNodes = new Set<NumNode>(), topLevelAffine = new Set<NumNode>()
 
   function visit(node: NumNode, isAffine: boolean) {
@@ -181,7 +181,7 @@ function pruneOrder(arts: ArtifactsBySlot, numTop: number, exclusion: ArtSetExcl
   return progress ? { base: arts.base, values } : arts
 }
 /** Remove artifacts that cannot reach `minimum` in any build */
-function pruneArtRange(nodes: NumNode[], arts: ArtifactsBySlot, minimum: number[]): ArtifactsBySlot {
+function pruneArtRange(nodes: OptNode[], arts: ArtifactsBySlot, minimum: number[]): ArtifactsBySlot {
   const baseRange = Object.fromEntries(Object.entries(arts.base).map(([key, x]) => [key, { min: x, max: x }]))
   const wrap = { arts }
   while (true) {
@@ -205,14 +205,14 @@ function pruneArtRange(nodes: NumNode[], arts: ArtifactsBySlot, minimum: number[
   }
   return wrap.arts
 }
-function pruneNodeRange(nodes: NumNode[], arts: ArtifactsBySlot): NumNode[] {
+function pruneNodeRange(nodes: OptNode[], arts: ArtifactsBySlot): OptNode[] {
   const baseRange = Object.fromEntries(Object.entries(arts.base).map(([key, x]) => [key, { min: x, max: x }]))
   const reads = addArtRange([baseRange, ...Object.values(arts.values).map(values => computeArtRange(values))])
   const nodeRange = computeNodeRange(nodes, reads)
 
   return mapFormulas(nodes, f => {
     {
-      const { min, max } = nodeRange.get(f as NumNode)!
+      const { min, max } = nodeRange.get(f)!
       if (min === max) return constant(min)
     }
     const { operation } = f
@@ -282,11 +282,10 @@ export function computeFullArtRange(arts: ArtifactsBySlot): DynMinMax {
   const baseRange = Object.fromEntries(Object.entries(arts.base).map(([key, x]) => [key, { min: x, max: x }]))
   return addArtRange([baseRange, ...Object.values(arts.values).map(values => computeArtRange(values))])
 }
-export function computeNodeRange(nodes: NumNode[], reads: DynMinMax): Map<NumNode, MinMax> {
-  const range = new Map<NumNode, MinMax>()
+export function computeNodeRange(nodes: OptNode[], reads: DynMinMax): Map<OptNode, MinMax> {
+  const range = new Map<OptNode, MinMax>()
 
-  forEachNodes(nodes, _ => { }, _f => {
-    const f = _f as NumNode
+  forEachNodes(nodes, _ => { }, f => {
     const { operation } = f
     const operands = f.operands.map(op => range.get(op)!)
     let current: MinMax
@@ -297,7 +296,6 @@ export function computeNodeRange(nodes: NumNode[], reads: DynMinMax): Map<NumNod
         current = reads[f.path[1]] ?? { min: 0, max: 0 }
         break
       case "const": current = computeMinMax([f.value]); break
-      case "subscript": current = computeMinMax(f.list); break
       case "add": case "min": case "max":
         current = {
           min: allOperations[operation](operands.map(x => x.min)),
@@ -328,8 +326,6 @@ export function computeNodeRange(nodes: NumNode[], reads: DynMinMax): Map<NumNod
           ])
         break
       }
-      case "data": case "lookup": case "match":
-        throw new Error(`Unsupported ${operation} node`)
       default: assertUnreachable(operation)
     }
     range.set(f, current)


### PR DESCRIPTION
This is an exploration of an alternative to #692. In this approach, we attach the information about permissible nodes in the tree (`Leaf`) to each `Node` type directly.

The `Node` now have three types, unoptimized `NumNode` and `StrNode`, and optimized `OptNode`. Nodes going through `optimize` now becomes `OptNode`, a much smaller subset of `NumNode`.