### PR TITLE
Optimize the flow of the Optimize tab

### DIFF
--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -89,5 +89,6 @@
   "targetSelector": {
     "selectOptTarget": "Select an Optimization Target",
     "selectGraphTarget": "Select a Graph Target"
-  }
+  },
+  "selectTargetFirst": "Select an Optimization Target first"
 }

--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -17,7 +17,7 @@
     "downloadData": "Download Data",
     "optTarget": "Optimization Target",
     "minStatReqThr": "Minimum Stat Requirement Threshold",
-    "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. another selected target. The graph will show the maximum Optimization Target value per 0.01 of the selected target. Enabling this is optional, and doing so will slow down build times"
+    "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. the selected Graph Target. The graph will show the maximum Optimization Target value per 0.01 of the selected Graph Target. Enabling this is optional, and doing so will slow down build times"
   },
   "levelFilter": "Artifact Level Filter",
   "useExcluded": {
@@ -85,5 +85,9 @@
   "build_one": "<0>{{count}}</0> Build",
   "build_other": "<0>{{count}}</0> Builds",
   "thread_one": "<0>{{count}}</0> Thread",
-  "thread_other": "<0>{{count}}</0> Threads"
+  "thread_other": "<0>{{count}}</0> Threads",
+  "targetSelector": {
+    "selectOptTarget": "Select an Optimization Target",
+    "selectGraphTarget": "Select a Graph Target"
+  }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -65,7 +65,11 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
           <Typography >{t`tcGraph.vs`}</Typography>
         </Grid>
         <Grid item>
-          <OptimizationTargetSelector optimizationTarget={plotBase} setTarget={target => setPlotBase(target)} />
+          <OptimizationTargetSelector
+            optimizationTarget={plotBase}
+            setTarget={target => setPlotBase(target)}
+            defaultText={t("page_character_optimize:targetSelector.selectGraphTarget")}
+          />
         </Grid>
         <Grid item>
           <BootstrapTooltip title={t("ui:reset")} placement="top">

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -21,9 +21,10 @@ type ChartCardProps = {
   plotBase?: string[],
   setPlotBase: (path: string[] | undefined) => void
   disabled?: boolean
+  showTooltip?: boolean
 }
 type Point = { x: number, y: number, min?: number }
-export default function ChartCard({ chartData, plotBase, setPlotBase, disabled = false }: ChartCardProps) {
+export default function ChartCard({ chartData, plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
   const [showDownload, setshowDownload] = useState(false)
   const [showMin, setshowMin] = useState(true)
@@ -65,14 +66,19 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
           <Typography >{t`tcGraph.vs`}</Typography>
         </Grid>
         <Grid item>
-          <OptimizationTargetSelector
-            optimizationTarget={plotBase}
-            setTarget={target => setPlotBase(target)}
-            defaultText={t("page_character_optimize:targetSelector.selectGraphTarget")}
-          />
+          <BootstrapTooltip placement="top" title={showTooltip ? t("page_character_optimize:selectTargetFirst") : ""}>
+            <span>
+              <OptimizationTargetSelector
+                optimizationTarget={plotBase}
+                setTarget={target => setPlotBase(target)}
+                defaultText={t("page_character_optimize:targetSelector.selectGraphTarget")}
+                disabled={disabled}
+              />
+            </span>
+          </BootstrapTooltip>
         </Grid>
         <Grid item>
-          <BootstrapTooltip title={t("ui:reset")} placement="top">
+          <BootstrapTooltip title={!plotBase ? "" : t("ui:reset")} placement="top">
             <span><Button color="error" onClick={() => setPlotBase(undefined)} disabled={!plotBase}>
               <Replay />
             </Button></span>
@@ -150,6 +156,6 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
 function getLabelFromNode(node: NumNode, t: any) {
   console.log(node)
   return typeof node.info?.name === "string"
-      ? node.info.name
-      : `${t(`${node.info?.name?.props.ns}:${node.info?.name?.props.key18}`)}${node.info?.textSuffix ? ` ${node.info?.textSuffix}` : ""}`
+    ? node.info.name
+    : `${t(`${node.info?.name?.props.ns}:${node.info?.name?.props.key18}`)}${node.info?.textSuffix ? ` ${node.info?.textSuffix}` : ""}`
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
@@ -44,7 +44,7 @@ export default function OptimizationTargetSelector({ optimizationTarget, setTarg
   const suffixDisplay = textSuffix && <span> {textSuffix}</span>
   const iconDisplay = icon ? <ImgIcon src={icon} size={2} sx={{ my: -1 }} /> : node?.info.icon
   return <>
-    <Button color="info" onClick={onShow} disabled={disabled} >
+    <Button color="info" onClick={onShow} disabled={disabled} sx={{ flexGrow: 1 }} >
       {invalidTarget ? <strong>{defaultText}</strong> : <Stack direction="row" divider={<Divider orientation='vertical' flexItem />} spacing={1}>
         <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
           {iconDisplay}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
@@ -1,6 +1,7 @@
 import { Button, Divider, Stack } from '@mui/material';
 import { Box } from '@mui/system';
 import { useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import ImgIcon from '../../../../../Components/Image/ImgIcon';
 import SqBadge from '../../../../../Components/SqBadge';
 import { DataContext } from '../../../../../Context/DataContext';
@@ -12,9 +13,10 @@ import usePromise from '../../../../../ReactHooks/usePromise';
 import { objPathValue } from '../../../../../Util/Util';
 import { TargetSelectorModal, TargetSelectorModalProps } from './TargetSelectorModal';
 
-export default function OptimizationTargetSelector({ optimizationTarget, setTarget, disabled = false, ignoreGlobal = false, targetSelectorModalProps = {} }: {
-  optimizationTarget?: string[], setTarget: (target: string[]) => void, disabled?: boolean, ignoreGlobal?: boolean, targetSelectorModalProps?: Partial<TargetSelectorModalProps>
+export default function OptimizationTargetSelector({ optimizationTarget, setTarget, disabled = false, ignoreGlobal = false, defaultText, targetSelectorModalProps = {} }: {
+  optimizationTarget?: string[], setTarget: (target: string[]) => void, disabled?: boolean, ignoreGlobal?: boolean, defaultText?: string, targetSelectorModalProps?: Partial<TargetSelectorModalProps>
 }) {
+  const { t } = useTranslation("page_character_optimize")
   const [show, onShow, onClose] = useBoolState(false)
 
   const setTargetHandler = useCallback(
@@ -27,6 +29,8 @@ export default function OptimizationTargetSelector({ optimizationTarget, setTarg
   const { data } = useContext(DataContext)
   const { database } = useContext(DatabaseContext)
   const displayHeader = usePromise(() => optimizationTarget && getDisplayHeader(data, optimizationTarget[0], database), [data, optimizationTarget, database])
+
+  if (!defaultText) defaultText = t("targetSelector.selectOptTarget")
 
   const { title, icon, action } = displayHeader ?? {}
   const node: NodeDisplay | undefined = optimizationTarget && objPathValue(data.getDisplay(), optimizationTarget) as any
@@ -41,7 +45,7 @@ export default function OptimizationTargetSelector({ optimizationTarget, setTarg
   const iconDisplay = icon ? <ImgIcon src={icon} size={2} sx={{ my: -1 }} /> : node?.info.icon
   return <>
     <Button color="info" onClick={onShow} disabled={disabled} >
-      {invalidTarget ? <strong>Select an Optimization Target</strong> : <Stack direction="row" divider={<Divider orientation='vertical' flexItem />} spacing={1}>
+      {invalidTarget ? <strong>{defaultText}</strong> : <Stack direction="row" divider={<Divider orientation='vertical' flexItem />} spacing={1}>
         <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
           {iconDisplay}
           <span>{title}</span>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -360,18 +360,20 @@ export default function TabBuild() {
       </Grid>
       {/* Footer */}
       <Grid container spacing={1}>
-        <Grid item flexGrow={1} >
+        <Grid item flexGrow={1}>
+          <span>Optimization Target: </span>
+          {<OptimizationTargetSelector
+            optimizationTarget={optimizationTarget}
+            setTarget={target => buildSettingDispatch({ optimizationTarget: target })}
+            disabled={!!generatingBuilds}
+          />}
+        </Grid>
+        <Grid item>
           <ButtonGroup>
-            <Button
-              disabled={!characterKey || generatingBuilds || !optimizationTarget || !objPathValue(data?.getDisplay(), optimizationTarget)}
-              color={characterKey ? "success" : "warning"}
-              onClick={generateBuilds}
-              startIcon={<TrendingUp />}
-            >Generate Builds</Button>
             <DropdownButton disabled={generatingBuilds || !characterKey}
               title={<Trans t={t} i18nKey="build" count={maxBuildsToShow}>
                 {{ count: maxBuildsToShow }} Builds
-                </Trans>}>
+              </Trans>}>
               <MenuItem>
                 <Typography variant="caption" color="info.main">
                   {t("buildDropdownDesc")}
@@ -380,15 +382,16 @@ export default function TabBuild() {
               <Divider />
               {maxBuildsToShowList.map(v => <MenuItem key={v}
                 onClick={() => buildSettingDispatch({ maxBuildsToShow: v })}>
-                  <Trans t={t} i18nKey="build" count={v}>
-                    {{ count: v }} Builds
-                  </Trans>
-                </MenuItem>)}
+                <Trans t={t} i18nKey="build" count={v}>
+                  {{ count: v }} Builds
+                </Trans>
+              </MenuItem>)}
             </DropdownButton>
             <DropdownButton disabled={generatingBuilds || !characterKey}
+              sx={{ borderRadius: "4px 0px 0px 4px"}}
               title={<Trans t={t} i18nKey="thread" count={maxWorkers}>
                 {{ count: maxWorkers }} Threads
-                </Trans>}>
+              </Trans>}>
               <MenuItem>
                 <Typography variant="caption" color="info.main">
                   {t("threadDropdownDesc")}
@@ -397,32 +400,29 @@ export default function TabBuild() {
               <Divider />
               {range(1, defThreads).reverse().map(v => <MenuItem key={v}
                 onClick={() => setMaxWorkers(v)}>
-                  <Trans t={t} i18nKey="thread" count={v}>
-                    {{ count: v }} Threads
-                  </Trans>
+                <Trans t={t} i18nKey="thread" count={v}>
+                  {{ count: v }} Threads
+                </Trans>
               </MenuItem>)}
             </DropdownButton>
-            <Button
-              disabled={!generatingBuilds}
-              color="error"
-              onClick={() => cancelToken.current()}
-              startIcon={<Close />}
-            >Cancel</Button>
+            <BootstrapTooltip placement="top" title={!optimizationTarget ? t("selectTargetFirst") : ""}>
+              <span>
+                <Button
+                  disabled={!characterKey || !optimizationTarget || !objPathValue(data?.getDisplay(), optimizationTarget)}
+                  color={generatingBuilds ? "error" : "success"}
+                  onClick={generatingBuilds ? () => cancelToken.current() : generateBuilds}
+                  startIcon={generatingBuilds ? <Close /> : <TrendingUp />}
+                  sx={{ borderRadius: "0px 4px 4px 0px"}}
+                >{generatingBuilds ? "Cancel" : "Generate Builds"}</Button>
+              </span>
+            </BootstrapTooltip>
           </ButtonGroup>
-        </Grid>
-        <Grid item>
-          <span>Optimization Target: </span>
-          {<OptimizationTargetSelector
-            optimizationTarget={optimizationTarget}
-            setTarget={target => buildSettingDispatch({ optimizationTarget: target })}
-            disabled={!!generatingBuilds}
-          />}
         </Grid>
       </Grid>
 
       {!!characterKey && <BuildAlert {...{ status: buildStatus, characterName, maxBuildsToShow }} />}
       <Box >
-        <ChartCard disabled={generatingBuilds} chartData={chartData} plotBase={plotBase} setPlotBase={setPlotBase} />
+        <ChartCard disabled={generatingBuilds || !optimizationTarget} chartData={chartData} plotBase={plotBase} setPlotBase={setPlotBase} showTooltip={!optimizationTarget} />
       </Box>
       <CardLight>
         <CardContent>


### PR DESCRIPTION
## Fixes
* Resolve #733 
* Update wording for Graph Target selector
* Move generate button to the right side, move opt target selector to the left side
* Make the generate button turn into a cancel button; removed the dedicated cancel button
* Disabled Graph Target selector when no opt target has been selected
* Add tooltips for Generate button and Graph Target selector when no opt target has been selected