### PR TITLE
Fix more sheet issues

### DIFF
--- a/public/locales/en/weapon_Moonpiercer.json
+++ b/public/locales/en/weapon_Moonpiercer.json
@@ -1,3 +1,3 @@
 {
-  "condName": "After picking up a Leaf of Consciousness"
+  "condName": "After picking up a Leaf of Revival"
 }

--- a/src/Components/Artifact/ArtifactAutocomplete.tsx
+++ b/src/Components/Artifact/ArtifactAutocomplete.tsx
@@ -91,7 +91,7 @@ export function ArtifactSetMultiAutocomplete({ artSetKeys, setArtSetKeys, ...pro
     allArtifactKeysWithGrouper={allArtifactSetsAndRarities}
     selectedArtifactKeys={artSetKeys}
     setArtifactKeys={setArtSetKeys}
-    getName={(key: ArtifactSetKey) => artifactSheets(key).nameRaw}
+    getName={(key: ArtifactSetKey) => t(`artifactNames_gen:${key}`)}
     getImage={(key: ArtifactSetKey) => artifactSheets(key).defIcon}
     label={t("artifact:autocompleteLabels.sets")}
     groupBy={(option) => option.grouper?.toString() ?? ""}
@@ -222,7 +222,7 @@ export function ArtifactSetSingleAutocomplete({ artSetKey, setArtSetKey, label =
     allArtifactKeysWithGrouper={allArtifactSetsAndRarities}
     selectedArtifactKey={artSetKey}
     setArtifactKey={setArtSetKey}
-    getName={(key: ArtifactSetKey | "") => key && artifactSheets(key).nameRaw}
+    getName={(key: ArtifactSetKey | "") => key && t(`artifactNames_gen:${key}`)}
     getImage={(key: ArtifactSetKey | "") => key ? artifactSheets(key).defIcon : <></>}
     label={label}
     groupBy={(option) => option.grouper?.toString() ?? ""}

--- a/src/Data/Characters/Aloy/index.tsx
+++ b/src/Data/Characters/Aloy/index.tsx
@@ -97,7 +97,6 @@ const dmgFormulas = {
   skill: {
     freezeBombDmg: dmgNode("atk", datamine.skill.freezeBombDmg, "skill"),
     chillWaterBomblets: dmgNode("atk", datamine.skill.chillWaterBomblets, "skill"),
-    atkDecrease: subscript(input.total.skillIndex, datamine.skill.atkDecrease)
   },
   burst: {
     dmg: dmgNode("atk", datamine.burst.dmg, "burst"),
@@ -159,7 +158,7 @@ const sheet: ICharacterSheet = {
       }, {
         node: infoMut(dmgFormulas.skill.chillWaterBomblets, { name: ct.chg(`skill.skillParams.1`) }),
       }, {
-        node: infoMut(dmgFormulas.skill.atkDecrease, { name: ct.chg(`skill.skillParams.2_`) }),
+        node: subscript(input.total.skillIndex, datamine.skill.atkDecrease, { name: ct.chg(`skill.skillParams.2`), unit: "%" }),
       }, {
         text: ct.chg("skill.skillParams.3"),
         value: `${datamine.skill.atkDecreaseDuration}`,

--- a/src/Data/Characters/KaedeharaKazuha/index.tsx
+++ b/src/Data/Characters/KaedeharaKazuha/index.tsx
@@ -54,7 +54,7 @@ const datamine = {
     enerCost: skillParam_gen.burst[b++][0],
   },
   passive1: {
-    asorbAdd: skillParam_gen.passive1[p1++][0],
+    absorbAdd: skillParam_gen.passive1[p1++][0],
   },
   passive2: {
     elemas_dmg_: skillParam_gen.passive2[p2++][0],
@@ -128,11 +128,11 @@ const dmgFormulas = {
   burst: {
     dmg: dmgNode("atk", datamine.burst.dmg, "burst"),
     dot: dmgNode("atk", datamine.burst.dot, "burst"),
-    ...Object.fromEntries(absorbableEle.map(key =>
-      [key, equal(condBurstAbsorption, key, dmgNode("atk", datamine.burst.add, "burst", { hit: { ele: constant(key) } }))]))
+    absorb: unequal(condBurstAbsorption, undefined, dmgNode("atk", datamine.burst.add, "burst", { hit: { ele: condBurstAbsorption } }))
   },
-  passive1: Object.fromEntries(absorbableEle.map(key =>
-    [key, equal(condSkillAbsorption, key, customDmgNode(prod(input.total.atk, datamine.passive1.asorbAdd), "plunging", { hit: { ele: constant(key) } }))])),
+  passive1: {
+    absorb: unequal(condSkillAbsorption, undefined, customDmgNode(prod(input.total.atk, datamine.passive1.absorbAdd), "plunging", { hit: { ele: condSkillAbsorption } }))
+  },
   passive2: asc4,
   constellation6: {
     normal_dmg_: c6NormDmg_,
@@ -272,7 +272,7 @@ const sheet: ICharacterSheet = {
       states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
         name: <ColorText color={eleKey}>{stg(`element.${eleKey}`)}</ColorText>,
         fields: [{
-          node: infoMut(dmgFormulas.burst[eleKey], { name: ct.chg(`burst.skillParams.2`) }),
+          node: infoMut(dmgFormulas.burst.absorb, { name: ct.chg(`burst.skillParams.2`) }),
         }]
       }]))
     }), ct.condTem("constellation2", { // C2 self
@@ -309,7 +309,7 @@ const sheet: ICharacterSheet = {
       states: Object.fromEntries(absorbableEle.map(eleKey => [eleKey, {
         name: <ColorText color={eleKey}>{stg(`element.${eleKey}`)}</ColorText>,
         fields: [{
-          node: infoMut(dmgFormulas.passive1[eleKey], { name: stg(`addEleDMG`) }),
+          node: infoMut(dmgFormulas.passive1.absorb, { name: stg(`addEleDMG`) }),
         }]
       }]))
     })]),

--- a/src/Data/Characters/TravelerAnemoF/anemo.tsx
+++ b/src/Data/Characters/TravelerAnemoF/anemo.tsx
@@ -88,7 +88,7 @@ export default function anemo(key: CharacterSheetKey, charKey: CharacterKey, dmg
     },
     burst: {
       dmg: dmgNode("atk", datamine.burst.dmg, "burst"),
-      absorb: dmgNode("atk", datamine.burst.absorbDmg, "burst", { hit: { ele: condBurstAbsorption } }),
+      absorb: unequal(condBurstAbsorption, undefined, dmgNode("atk", datamine.burst.absorbDmg, "burst", { hit: { ele: condBurstAbsorption } })),
     },
     passive1: {
       dmg: greaterEq(input.asc, 1, customDmgNode(prod(input.total.atk, datamine.passive1.dmg), "elemental", { hit: { ele: constant(elementKey) } })),


### PR DESCRIPTION
## Fixes
* Resolve #747 - Fix Aloy translation error
* Resolve #746 - Fix Anemo Traveler burst absorption showing incorrectly
* Resolve #742 - Fix Moonpiercer translation
* Resolve #741 - Translate artifact names in dropdowns
* Resolve #581 - Consolidate Kazuha absorption targets

Consolidating Kazuha absorption targets will remove absorptions from any existing multi-targets. It will also break importing any older targets. Feels like we should DB migrate, but it is a very minor thing to migrate so maybe not.