### PR TITLE
Fix crashes with invalid graph target and translate some strings

### DIFF
--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -88,7 +88,8 @@
   "thread_other": "<0>{{count}}</0> Threads",
   "targetSelector": {
     "selectOptTarget": "Select an Optimization Target",
-    "selectGraphTarget": "Select a Graph Target"
+    "selectGraphTarget": "Select a Graph Target",
+    "invalidTarget": "INVALID TARGET"
   },
   "selectTargetFirst": "Select an Optimization Target first"
 }

--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -91,5 +91,9 @@
     "selectGraphTarget": "Select a Graph Target",
     "invalidTarget": "INVALID TARGET"
   },
-  "selectTargetFirst": "Select an Optimization Target first"
+  "selectTargetFirst": "Select an Optimization Target first",
+  "generateButton": {
+    "cancel": "Cancel",
+    "generateBuilds": "Generate Builds"
+  }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -1,13 +1,15 @@
 import { CheckBox, CheckBoxOutlineBlank, Download, Replay } from '@mui/icons-material';
 import { Button, CardContent, Collapse, Divider, Grid, styled, Typography } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CartesianGrid, ComposedChart, Label, Legend, Line, ResponsiveContainer, Scatter, XAxis, YAxis, ZAxis } from 'recharts';
 import BootstrapTooltip from '../../../../../Components/BootstrapTooltip';
 import CardDark from '../../../../../Components/Card/CardDark';
 import CardLight from '../../../../../Components/Card/CardLight';
 import InfoTooltip from '../../../../../Components/InfoTooltip';
+import { DataContext } from '../../../../../Context/DataContext';
 import { NumNode } from '../../../../../Formula/type';
+import { objPathValue } from '../../../../../Util/Util';
 import { Build } from '../common';
 import OptimizationTargetSelector from './OptimizationTargetSelector';
 
@@ -26,6 +28,7 @@ type ChartCardProps = {
 type Point = { x: number, y: number, min?: number }
 export default function ChartCard({ chartData, plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
+  const { data } = useContext(DataContext)
   const [showDownload, setshowDownload] = useState(false)
   const [showMin, setshowMin] = useState(true)
 
@@ -59,6 +62,9 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
     return { displayData: increasingX, downloadData }
   }, [chartData])
 
+  const plotBaseNode = plotBase && objPathValue(data?.getDisplay(), plotBase)
+  const invalidTarget = !plotBase || !plotBaseNode || plotBaseNode.isEmpty
+
   return <CardLight>
     <CardContent>
       <Grid container spacing={1} alignItems="center">
@@ -79,7 +85,7 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
         </Grid>
         <Grid item>
           <BootstrapTooltip title={!plotBase ? "" : t("ui:reset")} placement="top">
-            <span><Button color="error" onClick={() => setPlotBase(undefined)} disabled={!plotBase}>
+            <span><Button color="error" onClick={() => setPlotBase(undefined)} disabled={invalidTarget}>
               <Replay />
             </Button></span>
           </BootstrapTooltip>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -63,7 +63,11 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
   }, [chartData])
 
   const plotBaseNode = plotBase && objPathValue(data?.getDisplay(), plotBase)
-  const invalidTarget = !plotBase || !plotBaseNode || plotBaseNode.isEmpty
+  const invalidTarget = !plotBaseNode || plotBaseNode.isEmpty
+
+  const buttonText = invalidTarget
+    ? t("page_character_optimize:targetSelector.invalidTarget")
+    : t("page_character_optimize:targetSelector.selectGraphTarget")
 
   return <CardLight>
     <CardContent>
@@ -77,7 +81,7 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
               <OptimizationTargetSelector
                 optimizationTarget={plotBase}
                 setTarget={target => setPlotBase(target)}
-                defaultText={t("page_character_optimize:targetSelector.selectGraphTarget")}
+                defaultText={buttonText}
                 disabled={disabled}
               />
             </span>
@@ -85,7 +89,7 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
         </Grid>
         <Grid item>
           <BootstrapTooltip title={!plotBase ? "" : t("ui:reset")} placement="top">
-            <span><Button color="error" onClick={() => setPlotBase(undefined)} disabled={invalidTarget}>
+            <span><Button color="error" onClick={() => setPlotBase(undefined)} disabled={!plotBase}>
               <Replay />
             </Button></span>
           </BootstrapTooltip>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -154,7 +154,6 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
 }
 
 function getLabelFromNode(node: NumNode, t: any) {
-  console.log(node)
   return typeof node.info?.name === "string"
     ? node.info.name
     : `${t(`${node.info?.name?.props.ns}:${node.info?.name?.props.key18}`)}${node.info?.textSuffix ? ` ${node.info?.textSuffix}` : ""}`

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
@@ -37,7 +37,7 @@ export default function OptimizationTargetSelector({ optimizationTarget, setTarg
 
   const invalidTarget = !optimizationTarget || !displayHeader || !node
     // Make sure the opt target is valid, if we are not in multi-target
-    || (!ignoreGlobal && optimizationTarget && data.getDisplay()?.[optimizationTarget[0]][optimizationTarget[1]]?.isEmpty)
+    || (!ignoreGlobal && node.isEmpty)
 
   const prevariant = invalidTarget ? "secondary" : node.info.variant
   const variant = prevariant === "invalid" ? undefined : prevariant

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -422,7 +422,7 @@ export default function TabBuild() {
               onClick={generatingBuilds ? () => cancelToken.current() : generateBuilds}
               startIcon={generatingBuilds ? <Close /> : <TrendingUp />}
               sx={{ borderRadius: "0px 4px 4px 0px" }}
-            >{generatingBuilds ? "Cancel" : "Generate Builds"}</Button>
+            >{generatingBuilds ? t("generateButton.cancel") : t("generateButton.generateBuilds")}</Button>
           </span>
         </BootstrapTooltip>
       </ButtonGroup>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -19,7 +19,7 @@ import { mergeData, uiDataForTeam } from '../../../../Formula/api';
 import { uiInput as input } from '../../../../Formula/index';
 import { optimize } from '../../../../Formula/optimization';
 import { NumNode } from '../../../../Formula/type';
-import { UIData } from '../../../../Formula/uiData';
+import { NodeDisplay, UIData } from '../../../../Formula/uiData';
 import useCharacterReducer from '../../../../ReactHooks/useCharacterReducer';
 import useCharSelectionCallback from '../../../../ReactHooks/useCharSelectionCallback';
 import useForceUpdate from '../../../../ReactHooks/useForceUpdate';
@@ -73,6 +73,7 @@ export default function TabBuild() {
   const { buildResult: { builds, buildDate }, buildResultDispatch } = useBuildResult(characterKey)
   const teamData = useTeamData(characterKey, mainStatAssumptionLevel)
   const { characterSheet, target: data } = teamData?.[characterKey as CharacterKey] ?? {}
+  const optimizationTargetNode = optimizationTarget && objPathValue(data?.getDisplay(), optimizationTarget)
   const isSM = ["xs", "sm"].includes(useMediaQueryUp())
 
   //register changes in artifact database
@@ -132,8 +133,9 @@ export default function TabBuild() {
 
     const minimum = [...valueFilter.map(x => x.minimum), -Infinity]
     const status: Omit<BuildStatus, "type"> = { tested: 0, failed: 0, skipped: 0, total: NaN, startTime: performance.now() }
-    if (plotBase) {
-      unoptimizedNodes.push(objPathValue(workerData.display ?? {}, plotBase))
+    const plotBaseNumNode: NumNode = plotBase && objPathValue(workerData.display ?? {}, plotBase)
+    if (plotBaseNumNode) {
+      unoptimizedNodes.push(plotBaseNumNode)
       minimum.push(-Infinity)
     }
 
@@ -145,7 +147,7 @@ export default function TabBuild() {
     }))
     nodes = optimize(nodes, {}, _ => false)
 
-    const plotBaseNode = plotBase ? nodes.pop() : undefined
+    const plotBaseNode = plotBaseNumNode ? nodes.pop() : undefined
     let optimizationTargetNode = nodes.pop()!
 
     const wrap = { buildValues: Array(maxBuildsToShow).fill(0).map(_ => ({ src: "", val: -Infinity })) }
@@ -270,17 +272,16 @@ export default function TabBuild() {
       status.skipped = 0
       status.total = 0
     } else {
-      if (plotBase) {
+      if (plotBaseNumNode) {
         const plotData = mergePlot(results.map(x => x.plotData!))
-        const plotBaseNode = objPathValue(workerData.display ?? {}, plotBase) as NumNode
         let data = Object.values(plotData)
         if (targetNode.info?.unit === "%")
           data = data.map(({ value, plot }) => ({ value: value * 100, plot })) as Build[]
-        if (plotBaseNode.info?.unit === "%")
+        if (plotBaseNumNode.info?.unit === "%")
           data = data.map(({ value, plot }) => ({ value, plot: (plot ?? 0) * 100 })) as Build[]
         setchartData({
           valueNode: targetNode,
-          plotNode: plotBaseNode,
+          plotNode: plotBaseNumNode,
           data
         })
       }
@@ -416,7 +417,7 @@ export default function TabBuild() {
         <BootstrapTooltip placement="top" title={!optimizationTarget ? t("selectTargetFirst") : ""}>
           <span>
             <Button
-              disabled={!characterKey || !optimizationTarget || !objPathValue(data?.getDisplay(), optimizationTarget)}
+              disabled={!characterKey || !optimizationTarget || !optimizationTargetNode || optimizationTargetNode.isEmpty}
               color={generatingBuilds ? "error" : "success"}
               onClick={generatingBuilds ? () => cancelToken.current() : generateBuilds}
               startIcon={generatingBuilds ? <Close /> : <TrendingUp />}


### PR DESCRIPTION
## Fixes
* Remove console.log
* Fix reset button for ChartCard showing incorrectly
* Fix crash when graphing against an invalid target; add more guardrails for graphing/optimizing an invalid target
* Translate some more strings

## Technical
* Revise bad code for OptimizationTargetSelector

Ideally, I would like to invalidate `plotBase` when it is going to result in an empty graph, but not sure the best way to do that, so I just added some text and try to disable the graph when possible. The graph can still generate an empty one if:
1. Set Nahida to A4
2. Graph against tri-karma crit rate
3. Set Nahida to something less than A4
4. Optimize
5. Empty graph will appear