### PR TITLE
Overhaul graph functionality

### DIFF
--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -17,7 +17,9 @@
     "downloadData": "Download Data",
     "optTarget": "Optimization Target",
     "minStatReqThr": "Minimum Stat Requirement Threshold",
-    "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. the selected Graph Target. The graph will show the maximum Optimization Target value per 0.01 of the selected Graph Target. Enabling this is optional, and doing so will slow down build times"
+    "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. the selected Graph Target. The graph will show the maximum Optimization Target value per 0.01 of the selected Graph Target. Enabling this is optional, and doing so will slow down build times",
+    "currentBuild": "Current Build",
+    "highlightedBuilds": "Highlighted Builds"
   },
   "levelFilter": "Artifact Level Filter",
   "useExcluded": {

--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -19,7 +19,8 @@
     "statReqThr": "Stat Requirement Threshold Line",
     "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. the selected Graph Target. The graph will show the maximum Optimization Target value per 0.01 of the selected Graph Target. Enabling this is optional, and doing so will slow down build times",
     "currentBuild": "Current Build",
-    "highlightedBuilds": "Highlighted Builds"
+    "highlightedBuilds": "Highlighted Builds",
+    "buildAlreadyInList": "Build is already in the list"
   },
   "levelFilter": "Artifact Level Filter",
   "useExcluded": {

--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -13,10 +13,10 @@
   "tcGraph": {
     "vs": "Graph Optimization Target vs.",
     "notSel": "Not Selected",
-    "showMinStatThr": "Show Min Stat Threshold",
+    "showStatThr": "Show Stat Threshold Line",
     "downloadData": "Download Data",
-    "optTarget": "Optimization Target",
-    "minStatReqThr": "Minimum Stat Requirement Threshold",
+    "generatedBuilds": "Generated Builds",
+    "statReqThr": "Stat Requirement Threshold Line",
     "desc": "Using data from the builder, this will generate a graph to visualize Optimization Target vs. the selected Graph Target. The graph will show the maximum Optimization Target value per 0.01 of the selected Graph Target. Enabling this is optional, and doing so will slow down build times",
     "currentBuild": "Current Build",
     "highlightedBuilds": "Highlighted Builds"

--- a/public/locales/en/page_character_optimize.json
+++ b/public/locales/en/page_character_optimize.json
@@ -95,5 +95,10 @@
   "generateButton": {
     "cancel": "Cancel",
     "generateBuilds": "Generate Builds"
-  }
+  },
+  "removeBuildButton": "Remove Build",
+  "theorycraftButton": "Theorycraft",
+  "currentlyEquippedBuild": "Currently Equipped",
+  "addBuildToList": "Add build to list",
+  "graphBuildLabel": "Graph #<1>{{count}}</1>"
 }

--- a/src/Context/GraphContext.tsx
+++ b/src/Context/GraphContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react"
+import { NumNode } from "../Formula/type"
+import { Build } from "../PageCharacter/CharacterDisplay/Tabs/TabOptimize/common"
+
+export type ChartData = {
+  valueNode: NumNode,
+  plotNode: NumNode,
+  data: Build[]
+}
+export type GraphContextObj = {
+  chartData?: ChartData
+  setChartData: (data: ChartData | undefined) => void
+  graphBuilds: string[][] | undefined
+  setGraphBuilds: (builds: string[][] | undefined) => void
+}
+export const GraphContext = createContext({} as GraphContextObj)

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetBadges.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetBadges.tsx
@@ -1,0 +1,45 @@
+import { Box, Typography } from "@mui/material"
+import { useMemo } from "react"
+import ArtifactSetTooltip from "../../../../../Components/Artifact/ArtifactSetTooltip"
+import { artifactSlotIcon } from "../../../../../Components/Artifact/SlotNameWIthIcon"
+import SqBadge from "../../../../../Components/SqBadge"
+import { ArtifactSheet } from "../../../../../Data/Artifacts/ArtifactSheet"
+import usePromise from "../../../../../ReactHooks/usePromise"
+import { ICachedArtifact } from "../../../../../Types/artifact"
+import { ArtifactSetKey, SlotKey } from "../../../../../Types/consts"
+
+type ArtifactSetBadgesProps = {
+  artifacts: ICachedArtifact[],
+  currentlyEquipped?: boolean
+}
+export function ArtifactSetBadges({ artifacts, currentlyEquipped = false }: ArtifactSetBadgesProps) {
+  const setToSlots: Partial<Record<ArtifactSetKey, SlotKey[]>> = useMemo(() => artifacts
+    .filter(arti => arti)
+    .reduce((acc, curr) => {
+      acc[curr.setKey] ? acc[curr.setKey].push(curr.slotKey) : acc[curr.setKey] = [curr.slotKey]
+      return acc
+    }, {}),
+    [artifacts]
+  )
+  return <>{Object.entries(setToSlots)
+    .sort(([_k1, slotarr1], [_k2, slotarr2]) => slotarr2.length - slotarr1.length)
+    .map(([key, slotarr]) =>
+      <ArtifactSetBadge key={key} setKey={key} currentlyEquipped={currentlyEquipped} slotarr={slotarr} />
+    )
+  }</>
+
+}
+function ArtifactSetBadge({ setKey, currentlyEquipped = false, slotarr }: { setKey: ArtifactSetKey, currentlyEquipped: boolean, slotarr: SlotKey[] }) {
+  const artifactSheet = usePromise(() => ArtifactSheet.get(setKey), [])
+  if (!artifactSheet) return null
+  const numInSet = slotarr.length
+  const setActive = Object.keys(artifactSheet.setEffects).map((setKey) => parseInt(setKey)).filter(setNum => setNum <= numInSet)
+  return <Box>
+    <ArtifactSetTooltip artifactSheet={artifactSheet} numInSet={numInSet} >
+      <SqBadge sx={{ height: "100%" }} color={currentlyEquipped ? "success" : "primary"} ><Typography >
+        {slotarr.map(slotKey => artifactSlotIcon(slotKey))} {artifactSheet.name ?? ""}
+        {setActive.map(n => <SqBadge sx={{ ml: 0.5 }} key={n} color="success">{n}</SqBadge>)}
+      </Typography></SqBadge>
+    </ArtifactSetTooltip>
+  </Box>
+}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -25,14 +25,14 @@ type NewOld = {
 }
 
 type BuildDisplayItemProps = {
-  index?: number,
+  label?: string,
   compareBuild: boolean,
   disabled?: boolean,
   extraButtonsRight?: JSX.Element,
   extraButtonsLeft?: JSX.Element,
 }
 //for displaying each artifact build
-export default function BuildDisplayItem({ index, compareBuild, extraButtonsRight, extraButtonsLeft, disabled }: BuildDisplayItemProps) {
+export default function BuildDisplayItem({ label, compareBuild, extraButtonsRight, extraButtonsLeft, disabled }: BuildDisplayItemProps) {
   const { character: { key: characterKey, equippedArtifacts } } = useContext(CharacterContext)
   const { buildSetting: { mainStatAssumptionLevel } } = useBuildSetting(characterKey)
   const { database } = useContext(DatabaseContext)
@@ -85,7 +85,7 @@ export default function BuildDisplayItem({ index, compareBuild, extraButtonsRigh
       {newOld && <CompareArtifactModal newOld={newOld} mainStatAssumptionLevel={mainStatAssumptionLevel} onClose={close} />}
       <CardContent>
         <Box display="flex" gap={1} sx={{ pb: 1 }} flexWrap="wrap">
-          {index !== undefined && <SqBadge color="info"><Typography><strong>#{index + 1}{currentlyEquipped ? " (Equipped)" : ""}</strong></Typography></SqBadge>}
+          {label !== undefined && <SqBadge color="info"><Typography><strong>{label}{currentlyEquipped ? " (Equipped)" : ""}</strong></Typography></SqBadge>}
           <ArtifactSetBadges artifacts={artifacts} currentlyEquipped={currentlyEquipped} />
           <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "flex-end" }}>
           </Box>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -25,7 +25,7 @@ type NewOld = {
 }
 
 type BuildDisplayItemProps = {
-  label?: string,
+  label?: Displayable,
   compareBuild: boolean,
   disabled?: boolean,
   extraButtonsRight?: JSX.Element,

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -37,7 +37,7 @@ type Point = {
 export default function ChartCard({ plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
   const { data } = useContext(DataContext)
-  const { chartData, graphBuilds, setGraphBuilds } = useContext(GraphContext)
+  const { chartData } = useContext(GraphContext)
   const [showDownload, setshowDownload] = useState(false)
   const [showMin, setshowMin] = useState(true)
 
@@ -128,7 +128,7 @@ export default function ChartCard({ plotBase, setPlotBase, disabled = false, sho
           </CardContent>
         </CardDark>
       </Collapse>
-      <Chart displayData={displayData} plotNode={chartData.plotNode} valueNode={chartData.valueNode} showMin={showMin} graphBuilds={graphBuilds} setGraphBuilds={setGraphBuilds} />
+      <Chart displayData={displayData} plotNode={chartData.plotNode} valueNode={chartData.valueNode} showMin={showMin} />
     </CardContent>}
   </CardLight >
 }
@@ -146,14 +146,13 @@ function DataDisplay({ data, }: { data?: object }) {
   }} />
 }
 
-function Chart({ displayData, plotNode, valueNode, showMin, graphBuilds, setGraphBuilds }: {
+function Chart({ displayData, plotNode, valueNode, showMin }: {
   displayData: Point[]
   plotNode: NumNode
   valueNode: NumNode
   showMin: boolean
-  graphBuilds: string[][] | undefined
-  setGraphBuilds: (builds: string[][] | undefined) => void
 }) {
+  const { graphBuilds, setGraphBuilds } = useContext(GraphContext)
   const { t } = useTranslation("page_character_optimize")
   const [selectedPoint, setSelectedPoint] = useState<Point>()
   const chartOnClick = useCallback(props => {
@@ -212,6 +211,7 @@ function Chart({ displayData, plotNode, valueNode, showMin, graphBuilds, setGrap
         fill="#8884d8"
         isAnimationActive={false}
         shape={<CustomDot selectedPoint={selectedPoint} />}
+        data={displayData}
       />
       <Brush height={30} gap={5}/>
       {showMin && <Line

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -1,6 +1,6 @@
 import { CheckBox, CheckBoxOutlineBlank, Download, Replay } from '@mui/icons-material';
-import { Button, CardContent, Collapse, Divider, Grid, Stack, styled, Typography } from '@mui/material';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { Button, CardContent, Collapse, Divider, Grid, Skeleton, Stack, styled, Typography } from '@mui/material';
+import { Suspense, useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Brush, CartesianGrid, ComposedChart, DotProps, Label, Legend, Line, ResponsiveContainer, Scatter, Tooltip, TooltipProps, XAxis, YAxis, ZAxis } from 'recharts';
 import ArtifactCardPico from '../../../../../Components/Artifact/ArtifactCardPico';
@@ -314,6 +314,7 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
     ),
     [database.arts, selectedPoint]
   )
+
   const currentlyEquipped = artifactsBySlot && allSlotKeys.every(slotKey => artifactsBySlot[slotKey]?.id === data.get(input.art[slotKey].id).value)
 
   if (tooltipProps.active && selectedPoint) {
@@ -323,7 +324,9 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
           {currentlyEquipped && <SqBadge color="info"><strong>{t("artifact:filterLocation.currentlyEquipped")}</strong></SqBadge>}
           <Stack direction="row" alignItems="start">
             <Stack spacing={0.5}>
-              <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
+              <Suspense fallback={<Skeleton width={300} height={50} />}>
+                <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
+              </Suspense>
             </Stack>
             <Grid item flexGrow={1} />
             <CloseButton onClick={() => setSelectedPoint(undefined)} />
@@ -331,7 +334,9 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
           <Grid container direction="row" spacing={0.75} columns={5}>
             {allSlotKeys.map(key =>
               <Grid item key={key} xs={1}>
-                <ArtifactCardPico artifactObj={artifactsBySlot[key]} slotKey={key} />
+                <Suspense fallback={<Skeleton width={75} height={75} />}>
+                  <ArtifactCardPico artifactObj={artifactsBySlot[key]} slotKey={key} />
+                </Suspense>
               </Grid>
             )}
           </Grid>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -31,6 +31,8 @@ type ChartCardProps = {
   chartData?: ChartData
   plotBase?: string[]
   setPlotBase: (path: string[] | undefined) => void
+  graphBuilds: string[][] | undefined
+  setGraphBuilds: (builds: string[][] | undefined) => void
   disabled?: boolean
   showTooltip?: boolean
 }
@@ -40,7 +42,7 @@ type Point = {
   artifactIds: string[]
   min?: number
 }
-export default function ChartCard({ chartData, plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
+export default function ChartCard({ chartData, plotBase, setPlotBase, graphBuilds, setGraphBuilds, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
   const { data } = useContext(DataContext)
   const [showDownload, setshowDownload] = useState(false)
@@ -133,7 +135,7 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
           </CardContent>
         </CardDark>
       </Collapse>
-      <Chart displayData={displayData} plotNode={chartData.plotNode} valueNode={chartData.valueNode} showMin={showMin} />
+      <Chart displayData={displayData} plotNode={chartData.plotNode} valueNode={chartData.valueNode} showMin={showMin} graphBuilds={graphBuilds} setGraphBuilds={setGraphBuilds} />
     </CardContent>}
   </CardLight >
 }
@@ -150,17 +152,21 @@ function DataDisplay({ data, }: { data?: object }) {
     target.selectionEnd = target.value.length;
   }} />
 }
-function Chart({ displayData, plotNode, valueNode, showMin }: {
+
+function Chart({ displayData, plotNode, valueNode, showMin, graphBuilds, setGraphBuilds }: {
   displayData: Point[]
   plotNode: NumNode
   valueNode: NumNode
   showMin: boolean
+  graphBuilds: string[][] | undefined
+  setGraphBuilds: (builds: string[][] | undefined) => void
 }) {
   const { t } = useTranslation("page_character_optimize")
   const [selectedPoint, setSelectedPoint] = useState<Point>()
-  const chartOnClick = useCallback((props) => {
+  const chartOnClick = useCallback(props => {
     if (props && props.chartX && props.chartY) setSelectedPoint(getNearestPoint(props.chartX, props.chartY, 20, displayData))
   }, [setSelectedPoint, displayData])
+  const addBuildToList = useCallback((build: string[]) => setGraphBuilds([build, ...(graphBuilds ?? [])]), [setGraphBuilds, graphBuilds])
 
   // Below works because character translation should already be loaded
   const xLabelValue = getLabelFromNode(plotNode, t)
@@ -199,6 +205,7 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
           yUnit={valueNode.info?.unit}
           selectedPoint={selectedPoint}
           setSelectedPoint={setSelectedPoint}
+          addBuildToList={addBuildToList}
         />}
         trigger="click"
         wrapperStyle={{ pointerEvents: "auto", cursor: "auto" }}
@@ -298,8 +305,9 @@ type CustomTooltipProps = TooltipProps<number, string> & {
   yUnit: Unit | undefined
   selectedPoint: Point | undefined
   setSelectedPoint: (pt: Point | undefined) => void
+  addBuildToList: (build: string[]) => void
 }
-function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelectedPoint, ...tooltipProps }: CustomTooltipProps) {
+function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelectedPoint, addBuildToList, ...tooltipProps }: CustomTooltipProps) {
   const { database } = useContext(DatabaseContext)
   const { data } = useContext(DataContext)
   const { t } = useTranslation("artifact")
@@ -342,6 +350,7 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
           </Grid>
           <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
           <Typography>{yLabel}: {valueString(yUnit === "%" ? selectedPoint.y / 100 : selectedPoint.y, yUnit)}</Typography>
+          <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>TODO: Translate Add Build To List</Button>
         </Stack>
       </CardContent>
     </CardDark>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -166,7 +166,7 @@ function Chart({ displayData, plotNode, valueNode, showMin, graphBuilds, setGrap
   const chartOnClick = useCallback(props => {
     if (props && props.chartX && props.chartY) setSelectedPoint(getNearestPoint(props.chartX, props.chartY, 20, displayData))
   }, [setSelectedPoint, displayData])
-  const addBuildToList = useCallback((build: string[]) => setGraphBuilds([build, ...(graphBuilds ?? [])]), [setGraphBuilds, graphBuilds])
+  const addBuildToList = useCallback((build: string[]) => setGraphBuilds([...(graphBuilds ?? []), build]), [setGraphBuilds, graphBuilds])
 
   // Below works because character translation should already be loaded
   const xLabelValue = getLabelFromNode(plotNode, t)
@@ -310,7 +310,7 @@ type CustomTooltipProps = TooltipProps<number, string> & {
 function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelectedPoint, addBuildToList, ...tooltipProps }: CustomTooltipProps) {
   const { database } = useContext(DatabaseContext)
   const { data } = useContext(DataContext)
-  const { t } = useTranslation("artifact")
+  const { t } = useTranslation("page_character_optimize")
 
   const artifactsBySlot: { [slot: string]: ICachedArtifact } = useMemo(() =>
     selectedPoint && selectedPoint.artifactIds && Object.fromEntries(selectedPoint.artifactIds
@@ -329,7 +329,7 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
     return <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
       <CardContent>
         <Stack spacing={1}>
-          {currentlyEquipped && <SqBadge color="info"><strong>{t("artifact:filterLocation.currentlyEquipped")}</strong></SqBadge>}
+          {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
           <Stack direction="row" alignItems="start">
             <Stack spacing={0.5}>
               <Suspense fallback={<Skeleton width={300} height={50} />}>
@@ -350,7 +350,7 @@ function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelecte
           </Grid>
           <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
           <Typography>{yLabel}: {valueString(yUnit === "%" ? selectedPoint.y / 100 : selectedPoint.y, yUnit)}</Typography>
-          <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>TODO: Translate Add Build To List</Button>
+          <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
         </Stack>
       </CardContent>
     </CardDark>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -11,6 +11,7 @@ import CloseButton from '../../../../../Components/CloseButton';
 import InfoTooltip from '../../../../../Components/InfoTooltip';
 import SqBadge from '../../../../../Components/SqBadge';
 import { DataContext } from '../../../../../Context/DataContext';
+import { GraphContext } from '../../../../../Context/GraphContext';
 import { DatabaseContext } from '../../../../../Database/Database';
 import { input } from '../../../../../Formula';
 import { NumNode } from '../../../../../Formula/type';
@@ -18,21 +19,12 @@ import { Unit, valueString } from '../../../../../KeyMap';
 import { ICachedArtifact } from '../../../../../Types/artifact';
 import { allSlotKeys } from '../../../../../Types/consts';
 import { objPathValue } from '../../../../../Util/Util';
-import { Build } from '../common';
 import { ArtifactSetBadges } from './ArtifactSetBadges';
 import OptimizationTargetSelector from './OptimizationTargetSelector';
 
-export type ChartData = {
-  valueNode: NumNode,
-  plotNode: NumNode,
-  data: Build[]
-}
 type ChartCardProps = {
-  chartData?: ChartData
   plotBase?: string[]
   setPlotBase: (path: string[] | undefined) => void
-  graphBuilds: string[][] | undefined
-  setGraphBuilds: (builds: string[][] | undefined) => void
   disabled?: boolean
   showTooltip?: boolean
 }
@@ -42,9 +34,10 @@ type Point = {
   artifactIds: string[]
   min?: number
 }
-export default function ChartCard({ chartData, plotBase, setPlotBase, graphBuilds, setGraphBuilds, disabled = false, showTooltip = false }: ChartCardProps) {
+export default function ChartCard({ plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
   const { data } = useContext(DataContext)
+  const { chartData, graphBuilds, setGraphBuilds } = useContext(GraphContext)
   const [showDownload, setshowDownload] = useState(false)
   const [showMin, setshowMin] = useState(true)
 

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard.tsx
@@ -20,12 +20,17 @@ export type ChartData = {
 }
 type ChartCardProps = {
   chartData?: ChartData
-  plotBase?: string[],
+  plotBase?: string[]
   setPlotBase: (path: string[] | undefined) => void
   disabled?: boolean
   showTooltip?: boolean
 }
-type Point = { x: number, y: number, min?: number }
+type Point = {
+  x: number
+  y: number
+  artifactIds: string[]
+  min?: number
+}
 export default function ChartCard({ chartData, plotBase, setPlotBase, disabled = false, showTooltip = false }: ChartCardProps) {
   const { t } = useTranslation(["page_character_optimize", "ui"])
   const { data } = useContext(DataContext)
@@ -34,7 +39,7 @@ export default function ChartCard({ chartData, plotBase, setPlotBase, disabled =
 
   const { displayData, downloadData } = useMemo(() => {
     if (!chartData) return { displayData: null, downloadData: null }
-    const points = chartData.data.map(({ value: y, plot: x }) => ({ x, y })) as Point[]
+    const points = chartData.data.map(({ value: y, plot: x, artifactIds }) => ({ x, y, artifactIds })) as Point[]
     const increasingX: Point[] = points.sort((a, b) => a.x - b.x)
     const minimumData: Point[] = []
     for (const point of increasingX) {

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
@@ -1,0 +1,50 @@
+import { DotProps } from "recharts"
+import { EnhancedPoint, getEnhancedPointY } from "./EnhancedPoint"
+
+type CustomShapeType = "circle" | "diamond" | "square"
+type CustomDotProps = DotProps & {
+  selectedPoint: EnhancedPoint | undefined
+  payload?: EnhancedPoint
+  radiusSelected?: number
+  radiusUnselected?: number
+  colorSelected?: string
+  colorUnselected: string
+  shape?: CustomShapeType
+}
+export default function CustomDot({ cx, cy, payload, selectedPoint, radiusSelected = 6, radiusUnselected = 3, colorSelected = "red", colorUnselected, shape = "circle" }: CustomDotProps) {
+  if (!cx || !cy || !payload) {
+    return null
+  }
+
+  const isSelected = selectedPoint && selectedPoint.x === payload.x
+    && getEnhancedPointY(selectedPoint) === getEnhancedPointY(payload)
+
+  return (
+    <g
+      className="custom-dot"
+      data-chart-x={cx}
+      data-chart-y={cy}
+      data-x-value={payload.x}
+      data-y-value={getEnhancedPointY(payload)}
+      data-radius={isSelected ? radiusUnselected : radiusSelected}
+    >
+      {!isSelected
+        ? <CustomShape shape={shape} cx={cx} cy={cy} r={radiusUnselected} fill={colorUnselected} />
+        : <>
+          <CustomShape shape={shape} cx={cx} cy={cy} r={radiusSelected / 2} fill={colorSelected} />
+          <CustomShape shape={shape} cx={cx} cy={cy} r={radiusSelected} fill="none" stroke={colorSelected} />
+        </>
+      }
+    </g>
+  )
+}
+function CustomShape({ shape, cx, cy, r, fill, stroke}: { shape: CustomShapeType, cx: number, cy: number, r: number, fill?: string, stroke?: string }) {
+  switch(shape) {
+    case "circle":
+      return <circle cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} />
+    case "square":
+      return <rect x={cx-r} y={cy-r} width={r*2} height={r*2} fill={fill} stroke={stroke} />
+    case "diamond":
+      return <polygon points={`${cx},${cy+r*2.5} ${cx+r*1.5},${cy} ${cx},${cy-r*2.5} ${cx-r*1.5},${cy}`} fill={fill} stroke={stroke} />
+  }
+}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
@@ -29,22 +29,22 @@ export default function CustomDot({ cx, cy, payload, selectedPoint, radiusSelect
       data-radius={isSelected ? radiusUnselected : radiusSelected}
     >
       {!isSelected
-        ? <CustomShape shape={shape} cx={cx} cy={cy} r={radiusUnselected} fill={colorUnselected} />
+        ? <CustomShape id="customShapeUnselected" shape={shape} cx={cx} cy={cy} z={1} r={radiusUnselected} fill={colorUnselected} />
         : <>
-          <CustomShape shape={shape} cx={cx} cy={cy} r={radiusSelected / 2} fill={colorSelected} />
-          <CustomShape shape={shape} cx={cx} cy={cy} r={radiusSelected} fill="none" stroke={colorSelected} />
+          <CustomShape id="customShapeSelected" shape={shape} cx={cx} cy={cy} z={50} r={radiusSelected / 2} fill={colorSelected} />
+          <CustomShape id="customShapeBorder" shape={shape} cx={cx} cy={cy} z={50} r={radiusSelected} fill="none" stroke={colorSelected} />
         </>
       }
     </g>
   )
 }
-function CustomShape({ shape, cx, cy, r, fill, stroke}: { shape: CustomShapeType, cx: number, cy: number, r: number, fill?: string, stroke?: string }) {
+function CustomShape({ shape, id, cx, cy, z, r, fill, stroke}: { shape: CustomShapeType, id?: string, cx: number, cy: number, z: number, r: number, fill?: string, stroke?: string }) {
   switch(shape) {
     case "circle":
-      return <circle cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} />
+      return <circle id={id} cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} />
     case "square":
-      return <rect x={cx-r} y={cy-r} width={r*2} height={r*2} fill={fill} stroke={stroke} />
+      return <rect id={id} x={cx-r} y={cy-r} width={r*2} height={r*2} fill={fill} stroke={stroke} />
     case "diamond":
-      return <polygon points={`${cx},${cy+r*2.5} ${cx+r*1.5},${cy} ${cx},${cy-r*2.5} ${cx-r*1.5},${cy}`} fill={fill} stroke={stroke} />
+      return <polygon id={id} points={`${cx},${cy+r*2.5} ${cx+r*1.5},${cy} ${cx},${cy-r*2.5} ${cx-r*1.5},${cy}`} fill={fill} stroke={stroke} />
   }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
@@ -1,5 +1,5 @@
 import { DotProps } from "recharts"
-import { EnhancedPoint, getEnhancedPointY } from "./EnhancedPoint"
+import EnhancedPoint from "./EnhancedPoint"
 
 type CustomShapeType = "circle" | "diamond" | "square"
 type CustomDotProps = DotProps & {
@@ -16,8 +16,7 @@ export default function CustomDot({ cx, cy, payload, selectedPoint, radiusSelect
     return null
   }
 
-  const isSelected = selectedPoint && selectedPoint.x === payload.x
-    && getEnhancedPointY(selectedPoint) === getEnhancedPointY(payload)
+  const isSelected = selectedPoint && selectedPoint.x === payload.x && selectedPoint.y === payload.y
 
   return (
     <g
@@ -25,7 +24,7 @@ export default function CustomDot({ cx, cy, payload, selectedPoint, radiusSelect
       data-chart-x={cx}
       data-chart-y={cy}
       data-x-value={payload.x}
-      data-y-value={getEnhancedPointY(payload)}
+      data-y-value={payload.y}
       data-radius={isSelected ? radiusUnselected : radiusSelected}
     >
       {!isSelected

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomDot.tsx
@@ -29,16 +29,16 @@ export default function CustomDot({ cx, cy, payload, selectedPoint, radiusSelect
       data-radius={isSelected ? radiusUnselected : radiusSelected}
     >
       {!isSelected
-        ? <CustomShape id="customShapeUnselected" shape={shape} cx={cx} cy={cy} z={1} r={radiusUnselected} fill={colorUnselected} />
+        ? <CustomShape id="customShapeUnselected" shape={shape} cx={cx} cy={cy} r={radiusUnselected} fill={colorUnselected} />
         : <>
-          <CustomShape id="customShapeSelected" shape={shape} cx={cx} cy={cy} z={50} r={radiusSelected / 2} fill={colorSelected} />
-          <CustomShape id="customShapeBorder" shape={shape} cx={cx} cy={cy} z={50} r={radiusSelected} fill="none" stroke={colorSelected} />
+          <CustomShape id="customShapeSelected" shape={shape} cx={cx} cy={cy} r={radiusSelected / 2} fill={colorSelected} />
+          <CustomShape id="customShapeBorder" shape={shape} cx={cx} cy={cy} r={radiusSelected} fill="none" stroke={colorSelected} />
         </>
       }
     </g>
   )
 }
-function CustomShape({ shape, id, cx, cy, z, r, fill, stroke}: { shape: CustomShapeType, id?: string, cx: number, cy: number, z: number, r: number, fill?: string, stroke?: string }) {
+function CustomShape({ shape, id, cx, cy, r, fill, stroke}: { shape: CustomShapeType, id?: string, cx: number, cy: number, r: number, fill?: string, stroke?: string }) {
   switch(shape) {
     case "circle":
       return <circle id={id} cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} />

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -13,7 +13,7 @@ import { Unit, valueString } from "../../../../../../KeyMap"
 import { ICachedArtifact } from "../../../../../../Types/artifact"
 import { allSlotKeys } from "../../../../../../Types/consts"
 import { ArtifactSetBadges } from "../ArtifactSetBadges"
-import { EnhancedPoint, getEnhancedPointY } from "./EnhancedPoint"
+import EnhancedPoint from "./EnhancedPoint"
 
 type CustomTooltipProps = TooltipProps<number, string> & {
   xLabel: Displayable
@@ -72,7 +72,7 @@ export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPo
               )}
             </Grid>
             <Typography><strong>{xLabel}</strong>: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
-            <Typography><strong>{yLabel}</strong>: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
+            <Typography><strong>{yLabel}</strong>: {valueString(yUnit === "%" ? selectedPoint.y / 100 : selectedPoint.y, yUnit)}</Typography>
             <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
           </Stack>
         </CardContent>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -1,0 +1,77 @@
+import { CardContent, Stack, Skeleton, Grid, Typography, Button } from "@mui/material"
+import { useContext, useMemo, Suspense } from "react"
+import { useTranslation } from "react-i18next"
+import { TooltipProps } from "recharts"
+import ArtifactCardPico from "../../../../../../Components/Artifact/ArtifactCardPico"
+import CardDark from "../../../../../../Components/Card/CardDark"
+import CloseButton from "../../../../../../Components/CloseButton"
+import SqBadge from "../../../../../../Components/SqBadge"
+import { DataContext } from "../../../../../../Context/DataContext"
+import { DatabaseContext } from "../../../../../../Database/Database"
+import { input } from "../../../../../../Formula"
+import { Unit, valueString } from "../../../../../../KeyMap"
+import { ICachedArtifact } from "../../../../../../Types/artifact"
+import { allSlotKeys } from "../../../../../../Types/consts"
+import { ArtifactSetBadges } from "../ArtifactSetBadges"
+import { EnhancedPoint, getEnhancedPointY } from "./EnhancedPoint"
+
+type CustomTooltipProps = TooltipProps<number, string> & {
+  xLabel: Displayable
+  xUnit: Unit | undefined
+  yLabel: Displayable
+  yUnit: Unit | undefined
+  selectedPoint: EnhancedPoint | undefined
+  setSelectedPoint: (pt: EnhancedPoint | undefined) => void
+  addBuildToList: (build: string[]) => void
+}
+export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPoint, setSelectedPoint, addBuildToList, ...tooltipProps }: CustomTooltipProps) {
+  const { database } = useContext(DatabaseContext)
+  const { data } = useContext(DataContext)
+  const { t } = useTranslation("page_character_optimize")
+
+  const artifactsBySlot: { [slot: string]: ICachedArtifact } = useMemo(() =>
+    selectedPoint && selectedPoint.artifactIds && Object.fromEntries(selectedPoint.artifactIds
+      .map(id => {
+        const artiObj = database.arts.get(id)
+        return [artiObj?.slotKey, artiObj]
+      })
+      .filter(arti => arti)
+    ),
+    [database.arts, selectedPoint]
+  )
+
+  const currentlyEquipped = artifactsBySlot && allSlotKeys.every(slotKey => artifactsBySlot[slotKey]?.id === data.get(input.art[slotKey].id).value)
+
+  if (tooltipProps.active && selectedPoint) {
+    return <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
+      <CardContent>
+        <Stack spacing={1}>
+          {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
+          <Stack direction="row" alignItems="start">
+            <Stack spacing={0.5}>
+              <Suspense fallback={<Skeleton width={300} height={50} />}>
+                <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
+              </Suspense>
+            </Stack>
+            <Grid item flexGrow={1} />
+            <CloseButton onClick={() => setSelectedPoint(undefined)} />
+          </Stack>
+          <Grid container direction="row" spacing={0.75} columns={5}>
+            {allSlotKeys.map(key =>
+              <Grid item key={key} xs={1}>
+                <Suspense fallback={<Skeleton width={75} height={75} />}>
+                  <ArtifactCardPico artifactObj={artifactsBySlot[key]} slotKey={key} />
+                </Suspense>
+              </Grid>
+            )}
+          </Grid>
+          <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
+          <Typography>{yLabel}: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
+          <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
+        </Stack>
+      </CardContent>
+    </CardDark>
+  }
+
+  return null
+}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -1,4 +1,4 @@
-import { CardContent, Stack, Skeleton, Grid, Typography, Button } from "@mui/material"
+import { CardContent, Stack, Skeleton, Grid, Typography, Button, ClickAwayListener } from "@mui/material"
 import { useContext, useMemo, Suspense } from "react"
 import { useTranslation } from "react-i18next"
 import { TooltipProps } from "recharts"
@@ -43,34 +43,36 @@ export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPo
   const currentlyEquipped = artifactsBySlot && allSlotKeys.every(slotKey => artifactsBySlot[slotKey]?.id === data.get(input.art[slotKey].id).value)
 
   if (tooltipProps.active && selectedPoint) {
-    return <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
-      <CardContent>
-        <Stack gap={1}>
-          <Stack direction="row" alignItems="start" gap={1}>
-            <Stack spacing={0.5} flexGrow={99}>
-              {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
-              <Suspense fallback={<Skeleton width={300} height={50} />}>
-                <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
-              </Suspense>
-            </Stack>
-            <Grid item flexGrow={1} />
-            <CloseButton onClick={() => setSelectedPoint(undefined)} />
-          </Stack>
-          <Grid container direction="row" spacing={0.75} columns={5}>
-            {allSlotKeys.map(key =>
-              <Grid item key={key} xs={1}>
-                <Suspense fallback={<Skeleton width={75} height={75} />}>
-                  <ArtifactCardPico artifactObj={artifactsBySlot[key]} slotKey={key} />
+    return <ClickAwayListener onClickAway={() => setSelectedPoint(undefined)}>
+      <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
+        <CardContent>
+          <Stack gap={1}>
+            <Stack direction="row" alignItems="start" gap={1}>
+              <Stack spacing={0.5} flexGrow={99}>
+                {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
+                <Suspense fallback={<Skeleton width={300} height={50} />}>
+                  <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
                 </Suspense>
-              </Grid>
-            )}
-          </Grid>
-          <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
-          <Typography>{yLabel}: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
-          <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
-        </Stack>
-      </CardContent>
-    </CardDark>
+              </Stack>
+              <Grid item flexGrow={1} />
+              <CloseButton onClick={() => setSelectedPoint(undefined)} />
+            </Stack>
+            <Grid container direction="row" spacing={0.75} columns={5}>
+              {allSlotKeys.map(key =>
+                <Grid item key={key} xs={1}>
+                  <Suspense fallback={<Skeleton width={75} height={75} />}>
+                    <ArtifactCardPico artifactObj={artifactsBySlot[key]} slotKey={key} />
+                  </Suspense>
+                </Grid>
+              )}
+            </Grid>
+            <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
+            <Typography>{yLabel}: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
+            <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
+          </Stack>
+        </CardContent>
+      </CardDark>
+    </ClickAwayListener>
   }
 
   return null

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -71,8 +71,8 @@ export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPo
                 </Grid>
               )}
             </Grid>
-            <Typography>{xLabel}: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
-            <Typography>{yLabel}: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
+            <Typography><strong>{xLabel}</strong>: {valueString(xUnit === "%" ? selectedPoint.x / 100 : selectedPoint.x, xUnit)}</Typography>
+            <Typography><strong>{yLabel}</strong>: {valueString(yUnit === "%" ? getEnhancedPointY(selectedPoint) / 100 : getEnhancedPointY(selectedPoint), yUnit)}</Typography>
             <Button color="info" onClick={() => addBuildToList(selectedPoint.artifactIds)}>{t("addBuildToList")}</Button>
           </Stack>
         </CardContent>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -1,5 +1,5 @@
-import { CardContent, Stack, Skeleton, Grid, Typography, Button, ClickAwayListener } from "@mui/material"
-import { useContext, useMemo, Suspense } from "react"
+import { Button, CardContent, ClickAwayListener, Grid, Skeleton, Stack, Typography } from "@mui/material"
+import { Suspense, useCallback, useContext, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { TooltipProps } from "recharts"
 import ArtifactCardPico from "../../../../../../Components/Artifact/ArtifactCardPico"
@@ -39,11 +39,16 @@ export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPo
     ),
     [database.arts, selectedPoint]
   )
+  const clickAwayHandler = useCallback((e) => {
+    if (!(e.target.id.includes("customShape") || e.target.id.includes("chartContainer"))) {
+      setSelectedPoint(undefined)
+    }
+  }, [setSelectedPoint])
 
   const currentlyEquipped = artifactsBySlot && allSlotKeys.every(slotKey => artifactsBySlot[slotKey]?.id === data.get(input.art[slotKey].id).value)
 
   if (tooltipProps.active && selectedPoint) {
-    return <ClickAwayListener onClickAway={() => setSelectedPoint(undefined)}>
+    return <ClickAwayListener onClickAway={clickAwayHandler}>
       <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
         <CardContent>
           <Stack gap={1}>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -45,10 +45,10 @@ export default function CustomTooltip({ xLabel, xUnit, yLabel, yUnit, selectedPo
   if (tooltipProps.active && selectedPoint) {
     return <CardDark sx={{ minWidth: "400px", maxWidth: "400px" }} onClick={(e) => e.stopPropagation()}>
       <CardContent>
-        <Stack spacing={1}>
-          {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
-          <Stack direction="row" alignItems="start">
-            <Stack spacing={0.5}>
+        <Stack gap={1}>
+          <Stack direction="row" alignItems="start" gap={1}>
+            <Stack spacing={0.5} flexGrow={99}>
+              {currentlyEquipped && <SqBadge color="info"><strong>{t("currentlyEquippedBuild")}</strong></SqBadge>}
               <Suspense fallback={<Skeleton width={300} height={50} />}>
                 <ArtifactSetBadges artifacts={Object.values(artifactsBySlot)} currentlyEquipped={currentlyEquipped} />
               </Suspense>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
@@ -1,0 +1,11 @@
+export type EnhancedPoint = {
+  x: number
+  y?: number
+  artifactIds: string[]
+  min?: number
+  current?: number
+  highlighted?: number
+}
+export function getEnhancedPointY(pt: EnhancedPoint) {
+  return (pt.y || pt.current || pt.highlighted) as number
+}

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
@@ -1,11 +1,21 @@
-export type EnhancedPoint = {
-  x: number
-  y?: number
-  artifactIds: string[]
-  min?: number
-  current?: number
-  highlighted?: number
-}
-export function getEnhancedPointY(pt: EnhancedPoint) {
-  return (pt.y || pt.current || pt.highlighted) as number
+export default class EnhancedPoint {
+  public x: number
+  public trueY?: number
+  public artifactIds: string[]
+  public min?: number
+  public current?: number
+  public highlighted?: number
+
+  public constructor(x: number, y: number, artifactIds: string[]) {
+    this.x = x
+    this.trueY = y
+    this.artifactIds = artifactIds
+  }
+
+  public get y(): number {
+    return (this.trueY || this.current || this.highlighted) as number
+  }
+  public set y(y: number | undefined) {
+    this.trueY = y
+  }
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -187,7 +187,7 @@ export default function ChartCard({ plotBase, setPlotBase, disabled = false, sho
         step={(sliderMax - sliderMin) / 20}
         valueLabelDisplay="auto"
         valueLabelFormat={n => valueString(chartData.plotNode.info?.unit === "%" ? n / 100 : n, chartData.plotNode.info?.unit)}
-        sx={{ ml: 13, width: "88%" }}
+        sx={{ ml: "6%", width: "93%" }}
       />
     </CardContent>}
   </CardLight >

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -201,7 +201,7 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
   const yLabelValue = getLabelFromNode(valueNode, t)
 
   return <ResponsiveContainer width="100%" height={600}>
-    <ComposedChart data={enhancedDisplayData} onClick={chartOnClick} style={{ cursor: "pointer" }}>
+    <ComposedChart id="chartContainer" data={enhancedDisplayData} onClick={chartOnClick} style={{ cursor: "pointer" }}>
       <CartesianGrid strokeDasharray="3 3" />
       <XAxis
         dataKey="x"

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -1,6 +1,6 @@
 import { CheckBox, CheckBoxOutlineBlank, Download, Replay } from '@mui/icons-material';
 import { Button, CardContent, Collapse, Divider, Grid, Slider, styled, Typography } from '@mui/material';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CartesianGrid, ComposedChart, Label, Legend, LegendType, Line, ResponsiveContainer, Scatter, Tooltip, XAxis, YAxis } from 'recharts';
 import BootstrapTooltip from '../../../../../../Components/BootstrapTooltip';
@@ -45,8 +45,8 @@ export default function ChartCard({ plotBase, setPlotBase, disabled = false, sho
   const { character: { key: characterKey } } = useContext(CharacterContext)
   const { buildResult: { builds } } = useBuildResult(characterKey)
 
-  const [sliderLow, setSliderLow] = useState(0)
-  const [sliderHigh, setSliderHigh] = useState(100)
+  const [sliderLow, setSliderLow] = useState(-Infinity)
+  const [sliderHigh, setSliderHigh] = useState(Infinity)
   const setSlider = useCallback(
     (_e: unknown, value: number | number[]) => {
       if (typeof value === "number") throw new TypeError()
@@ -56,6 +56,7 @@ export default function ChartCard({ plotBase, setPlotBase, disabled = false, sho
     },
     [setSliderLow, setSliderHigh]
   )
+  useEffect(() => { setSliderLow(-Infinity); setSliderHigh(Infinity) }, [chartData])
 
   const { displayData, downloadData, sliderMin, sliderMax } = useMemo(() => {
     if (!chartData) return { displayData: null, downloadData: null }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -169,7 +169,6 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
     const highlightedBuilds = [...builds, ...(graphBuilds ?? [])]
 
     return displayData.map(datum => {
-      // TODO: Also there is a weird bug when you try to add a build to a list with any empty slots?
       const enhancedDatum: EnhancedPoint = {...datum}
       const datumSlotMap = convertArtiIdsToArtiSlotMap(datum.artifactIds, database)
 
@@ -245,7 +244,6 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
         { id: "highlighted", value: t`tcGraph.highlightedBuilds`, type: "square", color: highlightedColor },
         { id: "current", value: t`tcGraph.currentBuild`, type: "diamond", color: currentColor },
       ]}/>
-      {/* TODO: This line disappears strangely with the Brush */}
       {showMin && <Line
         name={t`tcGraph.minStatReqThr`}
         dataKey="min"

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -108,7 +108,7 @@ export default function ChartCard({ plotBase, setPlotBase, disabled = false, sho
         {!!downloadData && <Grid item>
           <Button size='small' startIcon={showMin ? <CheckBox /> : <CheckBoxOutlineBlank />}
             color={showMin ? "success" : "secondary"}
-            onClick={() => setshowMin(!showMin)}>{t`tcGraph.showMinStatThr`}</Button>
+            onClick={() => setshowMin(!showMin)}>{t`tcGraph.showStatThr`}</Button>
         </Grid>}
         {!!downloadData && <Grid item>
           <Button size='small' color="info" startIcon={<Download />} onClick={() => setshowDownload(!showDownload)}>{t`tcGraph.downloadData`}</Button>
@@ -239,13 +239,12 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
         cursor={false}
       />
       <Legend payload={[
-        ...(showMin ? [{ id: "min", value: t`tcGraph.minStatReqThr`, type: "line" as LegendType, color: lineColor }] : []),
-        { id: "y", value: t`tcGraph.optTarget`, type: "circle", color: optTargetColor },
+        ...(showMin ? [{ id: "min", value: t`tcGraph.statReqThr`, type: "line" as LegendType, color: lineColor }] : []),
+        { id: "y", value: t`tcGraph.generatedBuilds`, type: "circle", color: optTargetColor },
         { id: "highlighted", value: t`tcGraph.highlightedBuilds`, type: "square", color: highlightedColor },
         { id: "current", value: t`tcGraph.currentBuild`, type: "diamond", color: currentColor },
       ]}/>
       {showMin && <Line
-        name={t`tcGraph.minStatReqThr`}
         dataKey="min"
         stroke={lineColor}
         type="stepBefore"
@@ -256,23 +255,17 @@ function Chart({ displayData, plotNode, valueNode, showMin }: {
         activeDot={false}
       />}
       <Scatter
-        name={t`tcGraph.optTarget`}
         dataKey="y"
-        fill={optTargetColor}
         isAnimationActive={false}
         shape={<CustomDot selectedPoint={selectedPoint} colorUnselected={optTargetColor} />}
       />
       <Scatter
-        name={t`tcGraph.highlightedBuilds`}
         dataKey="highlighted"
-        fill={highlightedColor}
         isAnimationActive={false}
         shape={<CustomDot shape="square" selectedPoint={selectedPoint} colorUnselected={highlightedColor} />}
       />
       <Scatter
-        name={t`tcGraph.currentBuild`}
         dataKey="current"
-        fill={currentColor}
         isAnimationActive={false}
         shape={<CustomDot shape="diamond" selectedPoint={selectedPoint} colorUnselected={currentColor} />}
       />

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/ComputeWorker.ts
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/ComputeWorker.ts
@@ -52,13 +52,13 @@ export class ComputeWorker {
           const value = result[min.length], { builds, plotData } = self
           let build: Build | undefined
           if (value >= self.threshold) {
-            build = { value, artifactIds: buffer.map(x => x.id) }
+            build = { value, artifactIds: buffer.map(x => x.id).filter(id => id) }
             builds.push(build)
           }
           if (plotData) {
             const x = result[min.length + 1]
             if (!plotData[x] || plotData[x]!.value < value) {
-              if (!build) build = { value, artifactIds: buffer.map(x => x.id) }
+              if (!build) build = { value, artifactIds: buffer.map(x => x.id).filter(id => id) }
               build.plot = x
               plotData[x] = build
             }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -440,7 +440,7 @@ export default function TabBuild() {
         <CardContent>
           <Box display="flex" alignItems="center" gap={1} mb={1} >
             <Typography sx={{ flexGrow: 1 }}>
-              {builds ? <span>Showing <strong>{builds.length}</strong> Builds generated for {characterName}. {!!buildDate && <span>Build generated on: <strong>{(new Date(buildDate)).toLocaleString()}</strong></span>}</span>
+              {builds ? <span>Showing <strong>{builds.length + (graphBuilds ? graphBuilds.length : 0)}</strong> build generated for {characterName}. {!!buildDate && <span>Build generated on: <strong>{(new Date(buildDate)).toLocaleString()}</strong></span>}</span>
                 : <span>Select a character to generate builds.</span>}
             </Typography>
             <Button disabled={!builds.length} color="error" onClick={() => buildResultDispatch({ builds: [], buildDate: 0 })} >Clear Builds</Button>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -443,13 +443,13 @@ export default function TabBuild() {
               {builds ? <span>Showing <strong>{builds.length + (graphBuilds ? graphBuilds.length : 0)}</strong> build generated for {characterName}. {!!buildDate && <span>Build generated on: <strong>{(new Date(buildDate)).toLocaleString()}</strong></span>}</span>
                 : <span>Select a character to generate builds.</span>}
             </Typography>
-            <Button disabled={!builds.length} color="error" onClick={() => buildResultDispatch({ builds: [], buildDate: 0 })} >Clear Builds</Button>
+            <Button disabled={!builds.length} color="error" onClick={() => { setGraphBuilds(undefined); buildResultDispatch({ builds: [], buildDate: 0 }) }} >Clear Builds</Button>
           </Box>
           <Grid container display="flex" spacing={1}>
             <Grid item><HitModeToggle size="small" /></Grid>
             <Grid item><ReactionToggle size="small" /></Grid>
             <Grid item flexGrow={1} />
-            <Grid item><SolidToggleButtonGroup exclusive value={compareData} onChange={(e, v) => characterDispatch({ compareData: v })} size="small">
+            <Grid item><SolidToggleButtonGroup exclusive value={compareData} onChange={(_e, v) => characterDispatch({ compareData: v })} size="small">
               <ToggleButton value={false} disabled={!compareData}>Show new builds</ToggleButton>
               <ToggleButton value={true} disabled={compareData}>Compare vs. equipped</ToggleButton>
             </SolidToggleButtonGroup></Grid>

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -66,6 +66,12 @@ export default function TabBuild() {
   const characterDispatch = useCharacterReducer(characterKey)
   const onClickTeammate = useCharSelectionCallback()
 
+  // Clear state when changing characters
+  useEffect(() => {
+    setchartData(undefined)
+    setBuildStatus({ type: "inactive", tested: 0, failed: 0, skipped: 0, total: 0 })
+  }, [characterKey])
+
   const noArtifact = useMemo(() => !database.arts.values.length, [database])
 
   const { buildSetting, buildSettingDispatch } = useBuildSetting(characterKey)

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -460,7 +460,7 @@ export default function TabBuild() {
         </CardContent>
       </CardLight>
       <OptimizationTargetContext.Provider value={optimizationTarget}>
-        {graphBuilds && <BuildList builds={graphBuilds} characterKey={characterKey} data={data} compareData={compareData} disabled={!!generatingBuilds} getLabel={(index) => `Graph #${index + 1}`} setBuilds={setGraphBuilds} />}
+        {graphBuilds && <BuildList builds={graphBuilds} characterKey={characterKey} data={data} compareData={compareData} disabled={!!generatingBuilds} getLabel={(index) => <Trans t={t} i18nKey="graphBuildLabel" count={index + 1}>Graph #{{count: index + 1}}</Trans>} setBuilds={setGraphBuilds} />}
         <BuildList builds={builds} characterKey={characterKey} data={data} compareData={compareData} disabled={!!generatingBuilds} getLabel={(index) => `#${index + 1}`} />
       </OptimizationTargetContext.Provider>
     </DataContext.Provider>}
@@ -473,7 +473,7 @@ function BuildList({ builds, setBuilds, characterKey, data, compareData, disable
   data?: UIData
   compareData: boolean
   disabled: boolean
-  getLabel: (index: number) => string
+  getLabel: (index: number) => Displayable
 }) {
   const deleteBuild = useCallback((index: number) => {
     if (setBuilds) {
@@ -499,12 +499,13 @@ function BuildList({ builds, setBuilds, characterKey, data, compareData, disable
 }
 function BuildItemWrapper({ index, label, build, compareData, disabled, deleteBuild }: {
   index: number
-  label: string
+  label: Displayable
   build: string[]
   compareData: boolean
   disabled: boolean
   deleteBuild?: (index: number) => void
 }) {
+  const { t } = useTranslation("page_character_optimize")
   const location = useLocation()
   const navigate = useNavigate()
   const toTC = useCallback(() => {
@@ -515,8 +516,8 @@ function BuildItemWrapper({ index, label, build, compareData, disabled, deleteBu
 
   return <BuildDisplayItem label={label} compareBuild={compareData} disabled={disabled}
     extraButtonsLeft={<>
-      <Button color="info" size="small" startIcon={<Science />} onClick={toTC}>Theorycraft</Button>
-      {deleteBuild && <Button color="error" size="small" startIcon={<DeleteForever />} onClick={() => deleteBuild(index)}>TODO TRANSLATE Remove Build</Button>}
+      <Button color="info" size="small" startIcon={<Science />} onClick={toTC}>{t("theorycraftButton")}</Button>
+      {deleteBuild && <Button color="error" size="small" startIcon={<DeleteForever />} onClick={() => deleteBuild(index)}>{t("removeBuildButton")}</Button>}
     </>}
   />
 }

--- a/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -276,9 +276,9 @@ export default function TabBuild() {
         const plotData = mergePlot(results.map(x => x.plotData!))
         let data = Object.values(plotData)
         if (targetNode.info?.unit === "%")
-          data = data.map(({ value, plot }) => ({ value: value * 100, plot })) as Build[]
+          data = data.map(({ value, plot, artifactIds }) => ({ value: value * 100, plot, artifactIds })) as Build[]
         if (plotBaseNumNode.info?.unit === "%")
-          data = data.map(({ value, plot }) => ({ value, plot: (plot ?? 0) * 100 })) as Build[]
+          data = data.map(({ value, plot, artifactIds }) => ({ value, plot: (plot ?? 0) * 100, artifactIds })) as Build[]
         setchartData({
           valueNode: targetNode,
           plotNode: plotBaseNumNode,

--- a/src/PageCharacter/CharacterDisplay/index.tsx
+++ b/src/PageCharacter/CharacterDisplay/index.tsx
@@ -1,6 +1,6 @@
 import { BarChart, Calculate, FactCheck, Groups, Person, Science, TrendingUp } from '@mui/icons-material';
 import { Box, Button, CardContent, Skeleton, Tab, Tabs } from '@mui/material';
-import { Suspense, useCallback, useContext, useMemo } from 'react';
+import { Suspense, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink, Navigate, Route, Routes, useMatch, useNavigate, useParams } from 'react-router-dom';
 import CardDark from '../../Components/Card/CardDark';
@@ -12,6 +12,7 @@ import SqBadge from '../../Components/SqBadge';
 import { CharacterContext, CharacterContextObj } from '../../Context/CharacterContext';
 import { DataContext, dataContextObj } from '../../Context/DataContext';
 import { FormulaDataContext, FormulaDataWrapper } from '../../Context/FormulaDataContext';
+import { ChartData, GraphContext, GraphContextObj } from '../../Context/GraphContext';
 import CharacterSheet from '../../Data/Characters/CharacterSheet';
 import { DatabaseContext } from '../../Database/Database';
 import useBoolState from '../../ReactHooks/useBoolState';
@@ -84,35 +85,55 @@ function CharacterDisplayCard({ characterKey, onClose }: CharacterDisplayCardPro
       characterDispatch
     }
   }, [character, characterSheet, characterDispatch])
+
+  const [chartData, setChartData] = useState(undefined as ChartData | undefined)
+  const [graphBuilds, setGraphBuilds] = useState<string[][]>()
+  const graphContextValue: GraphContextObj | undefined = useMemo(() => {
+    return {
+      chartData,
+      setChartData,
+      graphBuilds,
+      setGraphBuilds
+    }
+  }, [chartData, graphBuilds])
+
+  // Clear state when switching characters
+  useEffect(() => {
+    setChartData(undefined)
+    setGraphBuilds(undefined)
+  }, [characterKey])
+
   return <CardDark >
-    {dataContextValue && characterContextValue ? <CharacterContext.Provider value={characterContextValue}><DataContext.Provider value={dataContextValue}>
-      <FormulaDataWrapper><CardContent sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-        <Box display="flex" >
-          <Box display="flex" gap={1} flexWrap="wrap" flexGrow={1}>
-            <CharSelectDropdown />
-            <TravelerElementSelect />
-            <TravelerGenderSelect />
-            <DetailStatButton />
-            <CustomMultiTargetButton />
-            <FormulasButton />
+    {dataContextValue && characterContextValue && graphContextValue
+      ? <CharacterContext.Provider value={characterContextValue}><DataContext.Provider value={dataContextValue}><GraphContext.Provider value={graphContextValue}>
+        <FormulaDataWrapper><CardContent sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box display="flex" >
+            <Box display="flex" gap={1} flexWrap="wrap" flexGrow={1}>
+              <CharSelectDropdown />
+              <TravelerElementSelect />
+              <TravelerGenderSelect />
+              <DetailStatButton />
+              <CustomMultiTargetButton />
+              <FormulasButton />
+            </Box>
+            {!!onClose && <CloseButton onClick={onClose} />}
           </Box>
-          {!!onClose && <CloseButton onClick={onClose} />}
-        </Box>
-        <Box display="flex" gap={1} flexWrap="wrap">
-          {character && <LevelSelect level={character.level} ascension={character.ascension} setBoth={characterDispatch} />}
-          <HitModeToggle size="small" />
-          <InfusionAuraDropdown />
-          <ReactionToggle size="small" />
-        </Box>
-        <CardLight>
-          <TabNav tab={tab} />
-        </CardLight>
-        <CharacterPanel />
-        <CardLight>
-          <TabNav tab={tab} />
-        </CardLight>
-      </CardContent></FormulaDataWrapper>
-    </DataContext.Provider></CharacterContext.Provider> : <Skeleton variant='rectangular' width='100%' height={1000} />
+          <Box display="flex" gap={1} flexWrap="wrap">
+            {character && <LevelSelect level={character.level} ascension={character.ascension} setBoth={characterDispatch} />}
+            <HitModeToggle size="small" />
+            <InfusionAuraDropdown />
+            <ReactionToggle size="small" />
+          </Box>
+          <CardLight>
+            <TabNav tab={tab} />
+          </CardLight>
+          <CharacterPanel />
+          <CardLight>
+            <TabNav tab={tab} />
+          </CardLight>
+        </CardContent></FormulaDataWrapper>
+      </GraphContext.Provider></DataContext.Provider></CharacterContext.Provider>
+      : <Skeleton variant='rectangular' width='100%' height={1000} />
     }
   </CardDark >
 }


### PR DESCRIPTION
## Enhancements
* Add ability to click points on the graph to preview builds
* Add ability to add those previewed builds to the build list to see all details
* Add ability to crop the graph, essentially allowing zooming in to certain portions of the graph
* Change graph dot color depending on if the build is in the build list, or if it is the currently equipped build

## Fixes
* Resolve #751 - Fix certain build states persisting across character changes
* Resolve #275 - Hoist chart data to `CharacterDisplay`; now chart data will not clear when navigating tabs on the same character
* Translate some more strings 