### PR TITLE
Fix misc sheet issues

### DIFF
--- a/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
+++ b/src/Data/Weapons/Polearm/EngulfingLightning/index.tsx
@@ -38,6 +38,7 @@ const sheet: IWeaponSheet = {
       node: atk_,
     }],
   }, {
+    teamBuff: true,
     value: condPassive,
     path: condPassivePath,
     header: headerTemplate(key, icon, iconAwaken, st("conditional")),


### PR DESCRIPTION
## Fixes
* Resolve #786 - Set Engulfing Lightning as teambuff for Shenhe quills
* Resolve #753 - Allow Sucrose A1 to be toggled for multiple elements simultaneously