### PR TITLE
Resolve #812 - Add additional opt targets, fix display of some

### DIFF
--- a/src/Data/Characters/KujouSara/index.tsx
+++ b/src/Data/Characters/KujouSara/index.tsx
@@ -85,6 +85,9 @@ const dmgFormulas = {
     titanbreaker: dmgNode("atk", dm.burst.titanBreakerDmg, "burst"),
     stormcluster: dmgNode("atk", dm.burst.stormClusterDmg, "burst"),
   },
+  passive2: {
+    energyRegen: greaterEq(input.asc, 4, prod(input.total.enerRech_, dm.passive2.energyGen), { name: ct.ch("a4.enerRest"), fixed: 2 })
+  },
   constellation2: {
     dmg: greaterEq(input.constellation, 2, prod(dmgNode("atk", dm.skill.dmg, "skill"), percent(dm.constellation2.crowfeatherDmg))),
   }
@@ -187,9 +190,7 @@ const sheet: ICharacterSheet = {
       passive1: ct.talentTem("passive1"),
       passive2: ct.talentTem("passive2", [ct.fieldsTem("passive2", {
         fields: [{
-          text: ct.ch("a4.enerRest"),
-          value: data => data.get(input.total.enerRech_).value * dm.passive2.energyGen,
-          fixed: 2
+          node: dmgFormulas.passive2.energyRegen
         }]
       })]),
       passive3: ct.talentTem("passive3"),

--- a/src/Data/Characters/KukiShinobu/index.tsx
+++ b/src/Data/Characters/KukiShinobu/index.tsx
@@ -106,6 +106,10 @@ const dmgFormulas = {
   burst: {
     singleDmg: dmgNode("hp", dm.burst.singleDmg, "burst"),
   },
+  passive2: {
+    a4Skill_dmgInc,
+    a4Skill_healInc,
+  },
   constellation4: {
     markDmg: greaterEq(input.constellation, 4, customDmgNode(prod(percent(dm.constellation4.markDmg), input.total.hp), "skill", { hit: { ele: constant(elementKey) } })),
   },

--- a/src/Data/Characters/Mona/index.tsx
+++ b/src/Data/Characters/Mona/index.tsx
@@ -81,8 +81,6 @@ const dm = {
   }
 } as const
 
-const hydro_dmg_ = greaterEq(input.asc, 4, prod(input.premod.enerRech_, percent(dm.passive2.percentage)))
-
 const [condOmenPath, condOmen] = cond(key, "Omen")
 const all_dmg_ = equal("on", condOmen, subscript(input.total.burstIndex, dm.burst.dmgBonus, { unit: "%" }))
 
@@ -113,7 +111,10 @@ const dmgFormulas = {
     dmg: dmgNode("atk", dm.burst.dmg, "burst")
   },
   passive1: {
-    dmg: prod(dmgNode("atk", dm.skill.dmg, "skill"), percent(dm.passive1.percentage))
+    dmg: greaterEq(input.asc, 1, prod(dmgNode("atk", dm.skill.dmg, "skill"), percent(dm.passive1.percentage)))
+  },
+  passive2: {
+    hydro_dmg_: greaterEq(input.asc, 4, prod(input.premod.enerRech_, percent(dm.passive2.percentage)))
   }
 }
 
@@ -127,7 +128,7 @@ export const data = dataObjForCharacterSheet(key, elementKey, "mondstadt", data_
   },
   premod: {
     charged_dmg_,
-    hydro_dmg_,
+    hydro_dmg_: dmgFormulas.passive2.hydro_dmg_,
   },
   teamBuff: {
     premod: {
@@ -242,7 +243,7 @@ const sheet: ICharacterSheet = {
       })]),
       passive2: ct.talentTem("passive2", [ct.fieldsTem("passive2", {
         fields: [{
-          node: hydro_dmg_
+          node: dmgFormulas.passive2.hydro_dmg_
         }]
       })]),
       passive3: ct.talentTem("passive3"),

--- a/src/Data/Characters/RaidenShogun/index.tsx
+++ b/src/Data/Characters/RaidenShogun/index.tsx
@@ -131,8 +131,6 @@ function burstResolve(mvArr: number[], initial = false) {
   )
 }
 
-const passive2ElecDmgBonus = greaterEq(input.asc, 4, prod(sum(input.premod.enerRech_, percent(-1)), (dm.passive2.electroDmg_bonus * 100)))
-
 const [condC4Path, condC4] = cond(key, "c4")
 const c4AtkBonus_ = greaterEq(input.constellation, 4,
   equal("c4", condC4, unequal(input.activeCharKey, input.charKey, dm.constellation4.atk_bonus))
@@ -165,6 +163,10 @@ const dmgFormulas = {
     plungeLow: burstResolve(dm.burst.plungeLow),
     plungeHigh: burstResolve(dm.burst.plungeHigh),
   },
+  passive2: {
+    passive2ElecDmgBonus: greaterEq(input.asc, 4, prod(sum(input.premod.enerRech_, percent(-dm.passive2.er)), percent(dm.passive2.electroDmg_bonus), 100)),
+    energyRestore: greaterEq(input.asc, 4, prod(sum(input.total.enerRech_, percent(-dm.passive2.er)), percent(dm.passive2.energyGen), 100), { name: ct.ch("a4.enerRest"), unit: "%" })
+  }
 }
 const nodeC3 = greaterEq(input.constellation, 3, 3)
 const nodeC5 = greaterEq(input.constellation, 5, 3)
@@ -176,7 +178,7 @@ export const data = dataObjForCharacterSheet(key, "electro", "inazuma", data_gen
   },
   premod: {
     burst_dmg_: skillEye_,
-    electro_dmg_: passive2ElecDmgBonus,
+    electro_dmg_: dmgFormulas.passive2.passive2ElecDmgBonus,
   },
   teamBuff: {
     premod: {
@@ -319,11 +321,9 @@ const sheet: ICharacterSheet = {
     passive1: ct.talentTem("passive1"),
     passive2: ct.talentTem("passive2", [ct.fieldsTem("passive2", {
       fields: [{
-        text: ct.ch("a4.enerRest"),
-        value: (data) => (data.get(input.total.enerRech_).value * 100 - 100) * (dm.passive2.energyGen * 100),
-        unit: "%"
+        node: dmgFormulas.passive2.energyRestore
       }, {
-        node: passive2ElecDmgBonus,
+        node: dmgFormulas.passive2.passive2ElecDmgBonus,
       }]
     })]),
     passive3: ct.talentTem("passive3"),

--- a/src/Data/Characters/Rosaria/index.tsx
+++ b/src/Data/Characters/Rosaria/index.tsx
@@ -75,12 +75,13 @@ const [condC1Path, condC1] = cond(key, "RosariaC1")
 const [condC6Path, condC6] = cond(key, "DilucC6")
 
 const nodeA1CritInc = equal(condA1, "on", greaterEq(input.asc, 1, dm.passive1.crInc))
-const nodeA4CritBonusDisp = equal(condA4, "on",
-  greaterEq(input.asc, 4, min(
+const nodeA4OptTarget = greaterEq(input.asc, 4, min(
     prod(percent(dm.passive2.crBonus), input.premod.critRate_),
     percent(dm.passive2.maxBonus)
-  ))
+  ),
+  { ...KeyMap.info("critRate_"), isTeamBuff: true }
 )
+const nodeA4CritBonusDisp = equal(condA4, "on", nodeA4OptTarget)
 const nodeA4CritBonus = unequal(target.charKey, key, nodeA4CritBonusDisp)
 
 const nodeC1AtkSpd = equal(condC1, "on", greaterEq(input.constellation, 1, dm.constellation1.atkSpdInc))
@@ -104,6 +105,9 @@ const dmgFormulas = {
     hit2: dmgNode("atk", dm.burst.hit2, "burst"),
     dotDmg: dmgNode("atk", dm.burst.dotDmg, "burst"),
   },
+  passive2: {
+    nodeA4OptTarget
+  }
 }
 
 const nodeC3 = greaterEq(input.constellation, 3, 3)
@@ -266,6 +270,9 @@ const sheet: ICharacterSheet = {
           }]
         }
       }
+    }), ct.fieldsTem("passive2", {
+      canShow: equal(input.activeCharKey, key, 1),
+      fields: [{ node: dmgFormulas.passive2.nodeA4OptTarget }]
     })]),
     passive3: ct.talentTem("passive3"),
     constellation1: ct.talentTem("constellation1", [ct.condTem("constellation1", {

--- a/src/Data/Characters/Sucrose/index.tsx
+++ b/src/Data/Characters/Sucrose/index.tsx
@@ -74,9 +74,11 @@ const [condSkillHitOpponentPath, condSkillHitOpponent] = cond(key, "skillHit")
 const asc1Disp = greaterEq(input.asc, 1, dm.passive1.eleMas)
 const asc1 = objectKeyMap(absorbableEle, ele => unequal(target.charKey, key, // Not applying to Sucrose
   equal(target.charEle, condSwirls[ele], asc1Disp), { ...KeyMap.info("eleMas"), isTeamBuff: true })) // And element matches the swirl
-const asc4Disp = equal("hit", condSkillHitOpponent,
-  greaterEq(input.asc, 4,
-    prod(percent(dm.passive2.eleMas_), input.premod.eleMas)))
+const asc4OptNode = greaterEq(input.asc, 4,
+  prod(percent(dm.passive2.eleMas_), input.premod.eleMas),
+  { ...KeyMap.info("eleMas"), isTeamBuff: true }
+)
+const asc4Disp = equal("hit", condSkillHitOpponent, asc4OptNode)
 const asc4 = unequal(target.charKey, key, asc4Disp)
 const c6Base = greaterEq(input.constellation, 6, percent(0.2))
 
@@ -99,6 +101,9 @@ export const dmgFormulas = {
     ...Object.fromEntries(absorbableEle.map(key =>
       [key, equal(condAbsorption, key, dmgNode("atk", dm.burst.dmg_, "burst", { hit: { ele: constant(key) } }))]))
   },
+  passive2: {
+    asc4OptNode
+  }
 }
 
 const nodeC3 = greaterEq(input.constellation, 3, 3)
@@ -242,6 +247,9 @@ const sheet: ICharacterSheet = {
             }],
           }
         }
+      }), ct.fieldsTem("passive2", {
+        canShow: equal(input.activeCharKey, key, 1),
+        fields: [{ node: dmgFormulas.passive2.asc4OptNode }]
       })]),
       passive3: ct.talentTem("passive3"),
       constellation1: ct.talentTem("constellation1"),

--- a/src/Data/Characters/YaeMiko/index.tsx
+++ b/src/Data/Characters/YaeMiko/index.tsx
@@ -60,8 +60,6 @@ const dm = {
 
 } as const
 
-const nodeAsc4 = greaterEq(input.asc, 4, prod(input.total.eleMas, percent(dm.passive2.eleMas_dmg_, { fixed: 2 })))
-
 const [condC4Path, condC4] = cond(key, "c4")
 const nodeC4 = greaterEq(input.constellation, 4, equal("hit", condC4, dm.constellation4.ele_dmg_))
 
@@ -85,6 +83,9 @@ const dmgFormulas = {
     dmg: dmgNode("atk", dm.burst.dmg, "burst"),
     tenkoDmg: dmgNode("atk", dm.burst.tenkoDmg, "burst"),
   },
+  passive2: {
+    nodeAsc4: greaterEq(input.asc, 4, prod(input.total.eleMas, percent(dm.passive2.eleMas_dmg_, { fixed: 2 })))
+  }
 }
 const nodeC3 = greaterEq(input.constellation, 3, 3)
 const nodeC5 = greaterEq(input.constellation, 5, 3)
@@ -94,7 +95,7 @@ const data = dataObjForCharacterSheet(key, elementKey, "liyue", data_gen, dmgFor
     burst: nodeC5
   },
   total: {
-    skill_dmg_: nodeAsc4,
+    skill_dmg_: dmgFormulas.passive2.nodeAsc4,
   },
   teamBuff: {
     premod: {
@@ -173,7 +174,7 @@ const sheet: ICharacterSheet = {
         }]
       }]),
       passive1: ct.talentTem("passive1"),
-      passive2: ct.talentTem("passive2", [{ fields: [{ node: nodeAsc4 }] }]),
+      passive2: ct.talentTem("passive2", [{ fields: [{ node: dmgFormulas.passive2.nodeAsc4 }] }]),
       passive3: ct.talentTem("passive3"),
       constellation1: ct.talentTem("constellation1"),
       constellation2: ct.talentTem("constellation2"),


### PR DESCRIPTION
* Resolve #812 - Add additional opt targets for dynamic character passives
* Add display fields on Rosaria and Sucrose talent sheet for their non-self teambuff buffs, for easier viewing