### PR TITLE
Fix Nahida A1/A4 issues

### DIFF
--- a/src/Data/Characters/Nahida/index.tsx
+++ b/src/Data/Characters/Nahida/index.tsx
@@ -123,7 +123,7 @@ const a1InBurst_eleMasDisp = greaterEq(input.asc, 1,
 )
 const a1InBurst_eleMas = equal(input.activeCharKey, target.charKey, a1InBurst_eleMasDisp)
 
-const a4Karma_dmg_ = greaterEq(input.asc, 4,
+const a4Karma_dmg_ = infoMut(greaterEq(input.asc, 4,
   min(
     prod(
       percent(dm.passive2.eleMas_dmg_),
@@ -133,10 +133,10 @@ const a4Karma_dmg_ = greaterEq(input.asc, 4,
       )
     ),
     percent(dm.passive2.eleMas_dmg_ * dm.passive2.eleMas_maxCounted)
-  ),
+  )),
   { unit: "%" }
 )
-const a4Karma_critRate_ = greaterEq(input.asc, 4,
+const a4Karma_critRate_ = infoMut(greaterEq(input.asc, 4,
   min(
     prod(
       percent(dm.passive2.eleMas_critRate_),
@@ -146,7 +146,7 @@ const a4Karma_critRate_ = greaterEq(input.asc, 4,
       )
     ),
     percent(dm.passive2.eleMas_critRate_ * dm.passive2.eleMas_maxCounted)
-  ),
+  )),
   { unit: "%" }
 )
 

--- a/src/Data/Characters/Nahida/index.tsx
+++ b/src/Data/Characters/Nahida/index.tsx
@@ -113,12 +113,12 @@ const burst_durationInc = equal(condPartyInBurst, "on", greaterEq(hydroLevel, 1,
 
 const [condA1ActiveInBurstPath, condA1ActiveInBurst] = cond(key, "condA1ActiveInBurst")
 const a1InBurst_eleMasDisp = greaterEq(input.asc, 1,
-  equal(condA1ActiveInBurst, "on",
+  equal(condA1ActiveInBurst, "on", equal(condPartyInBurst, "on",
     min(
       prod(percent(dm.passive1.eleMas_), tally.maxEleMas),
       dm.passive1.maxEleMas
     )
-  ),
+  )),
   { ...KeyMap.info("eleMas"), isTeamBuff: true }
 )
 const a1InBurst_eleMas = equal(input.activeCharKey, target.charKey, a1InBurst_eleMasDisp)


### PR DESCRIPTION
* Resolve #847 - Automatically disable Nahida A1 when party is not in burst
* Resolve #851 - Fix Nahida A4 min targets not acting as a percentage