### PR TITLE
Use SSH for cloning

### DIFF
--- a/libs/dm/scripts/loadDM.ts
+++ b/libs/dm/scripts/loadDM.ts
@@ -12,5 +12,5 @@ if (fs.existsSync(`${projectDir}/GenshinData`)) {
     console.log("./GenshinData exists & doesn't need update");
 } else {
   console.log("./GenshinData doesn't exist, cloning repo...");
-  execSync(`cd ${projectDir} && git clone https://github.com/dimbreath/GenshinData.git --depth 1`)
+  execSync(`cd ${projectDir} && git clone git@github.com:Dimbreath/GenshinData.git --depth 1`)
 }


### PR DESCRIPTION
Switch to SSH for cloning instead of HTTPS so that it no longer [asks for passwords](https://docs.github.com/en/get-started/getting-started-with-git/why-is-git-always-asking-for-my-password).