### PR TITLE
Tweaks to strings, especially of artifact sets I'd missed and new ones since last PR!

### DIFF
--- a/apps/frontend/src/app/Data/Characters/Alhaitham/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/Alhaitham/index.tsx
@@ -226,7 +226,7 @@ const sheet: ICharacterSheet = {
         unit: "s",
         fixed: 1
       }, {
-        node: infoMut(dmgFormulas.skill.mirrorDmg1, { name: ct.chg(`skill.skillParams.2`) })
+        node: infoMut(dmgFormulas.skill.mirrorDmg1, { name: ct.ch(`projectionDmg`) })
       }, {
         text: ct.chg("skill.skillParams.5"),
         value: dm.skill.mirrorRemovalInterval,

--- a/apps/frontend/src/app/Data/Characters/KamisatoAyaka/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/KamisatoAyaka/index.tsx
@@ -271,7 +271,7 @@ const sheet: ICharacterSheet = {
       states: {
         afterApplySprint: {
           fields: [{
-            text: ct.ch("staminaRestore"),
+            text: st("stamRestored"),
             value: dm.passive2.stamina,
           }, {
             node: afterApplySprintCryo

--- a/libs/localization/assets/locales/en/artifact_ArchaicPetra.json
+++ b/libs/localization/assets/locales/en/artifact_ArchaicPetra.json
@@ -1,3 +1,3 @@
 {
-  "condName": "Obtaining Crystallize Shard"
+  "condName": "After obtaining a Crystallize Shard"
 }

--- a/libs/localization/assets/locales/en/artifact_BlizzardStrayer.json
+++ b/libs/localization/assets/locales/en/artifact_BlizzardStrayer.json
@@ -1,5 +1,5 @@
 {
-  "condName": "Attack Enemy",
+  "condName": "Enemy is",
   "condCryo": "Affected By Cryo",
   "condFrozen": "Frozen"
 }

--- a/libs/localization/assets/locales/en/artifact_Instructor.json
+++ b/libs/localization/assets/locales/en/artifact_Instructor.json
@@ -1,3 +1,3 @@
 {
-  "condName": "Triggering an Elemental Reaction"
+  "condName": "After taking Elemental DMG"
 }

--- a/libs/localization/assets/locales/en/artifact_Lavawalker.json
+++ b/libs/localization/assets/locales/en/artifact_Lavawalker.json
@@ -1,3 +1,3 @@
 {
-  "condName": "Enemies that are <pyro>Burning</pyro> or affected by <pyro>Pyro</pyro>"
+  "condName": "Enemies is <pyro>Burning</pyro> or affected by <pyro>Pyro</pyro>"
 }

--- a/libs/localization/assets/locales/en/artifact_Thundersoother.json
+++ b/libs/localization/assets/locales/en/artifact_Thundersoother.json
@@ -1,3 +1,3 @@
 {
-  "condName": "Enemies that are affected by <electro>Electro</electro>"
+  "condName": "Enemy is affected by <electro>Electro</electro>"
 }

--- a/libs/localization/assets/locales/en/char_Alhaitham.json
+++ b/libs/localization/assets/locales/en/char_Alhaitham.json
@@ -4,5 +4,5 @@
   "mirrorsConsumed": "Mirrors consumed after unleashing <strong>Particular Field: Fetters of Phenomena</strong>",
   "projectionDmg": "Projection Attack DMG",
   "projectionAttack_dmg_": "Projection Attack DMG Bonus",
-  "excessMirror": "After a Chisel-Light Mirror is generated when their amount has reached its limit"
+  "excessMirror": "After generating a Chisel-Light Mirror when their amount has reached its limit"
 }

--- a/libs/localization/assets/locales/en/char_Alhaitham.json
+++ b/libs/localization/assets/locales/en/char_Alhaitham.json
@@ -1,7 +1,8 @@
 {
-  "withMirrors": "In possession of any Chisel-Light Mirrors",
-  "debateStacks": "Debate stacks",
-  "mirrorsConsumed": "Mirrors consumed after <strong>Particular Field: Fetters of Phenomena</strong> is unleashed",
+  "withMirrors": "In possession of Chisel-Light Mirrors",
+  "debateStacks": "After generating Chisel-Light Mirrors",
+  "mirrorsConsumed": "After unleashing <strong>Particular Field: Fetters of Phenomena</strong> and consuming Mirrors",
+  "projectionDmg": "Projection Attack DMG",
   "projectionAttack_dmg_": "Projection Attack DMG Bonus",
-  "excessMirror": "After a Chisel-Light Mirror is generated when their numbers have already maxed out"
+  "excessMirror": "After a Chisel-Light Mirror is generated when they have reached their maximum amount"
 }

--- a/libs/localization/assets/locales/en/char_Alhaitham.json
+++ b/libs/localization/assets/locales/en/char_Alhaitham.json
@@ -1,8 +1,8 @@
 {
   "withMirrors": "In possession of Chisel-Light Mirrors",
   "debateStacks": "After generating Chisel-Light Mirrors",
-  "mirrorsConsumed": "After unleashing <strong>Particular Field: Fetters of Phenomena</strong> and consuming Mirrors",
+  "mirrorsConsumed": "Mirrors consumed after unleashing <strong>Particular Field: Fetters of Phenomena</strong>",
   "projectionDmg": "Projection Attack DMG",
   "projectionAttack_dmg_": "Projection Attack DMG Bonus",
-  "excessMirror": "After a Chisel-Light Mirror is generated when they have reached their maximum amount"
+  "excessMirror": "After a Chisel-Light Mirror is generated when their amount has reached its limit"
 }

--- a/libs/localization/assets/locales/en/char_KamisatoAyaka.json
+++ b/libs/localization/assets/locales/en/char_KamisatoAyaka.json
@@ -3,7 +3,6 @@
   "afterSkill": "After using <strong>Kamisato Art: Hyouka</strong>",
   "afterBurst": "After using <strong>Kamisato Art: Soumetsu</strong>",
   "afterSprintCryo": "After applying <cryo>Cryo</cryo> Sprinting",
-  "staminaRestore": "Stamina Restored",
   "snowflakeDMG": "Snowflake DMG",
   "dmgBySnowflake": "Enemy's been hit by Frostflake Seki no To",
   "c6Active": "Under the Usurahi Butou effect"

--- a/libs/localization/assets/locales/en/elementalResonance.json
+++ b/libs/localization/assets/locales/en/elementalResonance.json
@@ -4,8 +4,7 @@
   },
   "SprawlingGreenery": {
     "cond2ele": "After triggering Burn, Catalyze, or Bloom reactions",
-    "cond3ele": "After triggering Aggravate, Spread, Hyperbloom, or Burgeon reactions",
-    "eleMas": "Sprawling Greenery Elemental Mastery"
+    "cond3ele": "After triggering Aggravate, Spread, Hyperbloom, or Burgeon reactions"
   },
   "EnduringRock": {
     "hitCond": "After dealing DMG to enemies while protected by a shield"

--- a/libs/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/localization/assets/locales/en/page_character_optimize.json
@@ -26,8 +26,8 @@
     "title": "Use Excluded Artifacts",
     "usingNum_one": "Using <1>{{count}}</1> excluded artifacts",
     "usingNum_other": "Using <1>{{count}}</1> excluded artifacts",
-    "excNum_one": "Excluded <1>{{count}}</1> artifacts",
-    "excNum_other": "Excluded <1>{{count}}</1> artifacts"
+    "excNum_one": "<1>{{count}}</1> artifact is excluded",
+    "excNum_other": "<1>{{count}}</1> artifacts are excluded"
   },
   "useEquipped": {
     "title": "Use Equipped Artifacts",

--- a/libs/localization/assets/locales/en/sheet.json
+++ b/libs/localization/assets/locales/en/sheet.json
@@ -95,7 +95,6 @@
   "stacks": "Stacks",
   "teamBuff": "Team Buff",
   "maxStacks": "Maximum stacks",
-  "members": "Members",
   "protectedByShield": "Protected by a shield",
   "protectedByShieldCrystal": "Protected by a shield created by Crystallize",
   "staminaDec_": "Stamina Consumption Decrease",

--- a/libs/localization/assets/locales/en/sheet.json
+++ b/libs/localization/assets/locales/en/sheet.json
@@ -28,7 +28,7 @@
     "normalOrCharged": "After hitting an opponent with a Normal/Charged Attack",
     "plunging": "After hitting an opponent with a Plunging Attack",
     "normalChargedOrPlunging": "After hitting an opponent with a Normal/Charged/Plunging Attack",
-    "normalEle": "After hitting an opponent with an Elemental Normal Attack hit",
+    "normalEle": "After dealing Elemental DMG through a Normal Attack",
     "skill": "After hitting an opponent with an Elemental Skill",
     "burst": "After hitting an opponent with an Elemental Burst",
     "skillOrBurst": "After hitting an opponent with an Elemental Skill/Burst",


### PR DESCRIPTION
Basically the title. I tried to have all changes in a single commit but that has something that might not work, where I attempted to make Ayaka display a different string, messed with the actual code. So please look at that.
I also added a new string for Alhaitham in order to adequately describe his Projection Attacks. This new string is made to go where GO currently displays "1-Mirror Projection Attack DMG", but the DMG will be the same for all Mirror stacks. **Please replace the old string with the new "projectionDmg" string.** Didn't know how to do it myself.

Thamkss!