### PR TITLE
fix crash from artifacts with zero lines

### DIFF
--- a/apps/frontend/src/app/Components/Artifact/ArtifactFilterDisplay.tsx
+++ b/apps/frontend/src/app/Components/Artifact/ArtifactFilterDisplay.tsx
@@ -70,7 +70,7 @@ export default function ArtifactFilterDisplay({ filterOption, filterOptionDispat
     if (filteredIds.includes(id)) ct[sk].current++
   })), [database, filteredIds])
 
-  const linesTotal = useMemo(() => catTotal(["1", "2", "3", "4"], ct => Object.entries(database.arts.data).forEach(([id, art]) => {
+  const linesTotal = useMemo(() => catTotal(["0", "1", "2", "3", "4"], ct => Object.entries(database.arts.data).forEach(([id, art]) => {
     const lns = art.substats.filter(s => s.value).length
     ct[lns].total++
     if (filteredIds.includes(id)) ct[lns].current++

--- a/apps/frontend/src/app/PageArtifact/ArtifactSort.ts
+++ b/apps/frontend/src/app/PageArtifact/ArtifactSort.ts
@@ -88,7 +88,7 @@ export function artifactFilterConfigs(effFilterSet: Set<SubstatKey> = new Set(al
         if (filterKey && !art.substats.some(substat => substat.key === filterKey)) return false;
       return true
     },
-    lines: (art, filter) => filter.includes(art.substats.filter(s => s.value).length),
+    lines: (art, filter) => [0, ...filter].includes(art.substats.filter(s => s.value).length),
   }
 }
 export const artifactSortMap: Partial<Record<ArtifactSortKey, ArtifactSortKey[]>> = {


### PR DESCRIPTION
Funky scanner issue, this is intended not to whitescreen the site if this happens. 
Will need to have discussion on whether a "zero line" artifact should be an "invalid" artifact, due to only 1*/2* artifact can have 0 lines, and currently low rarity artifacts are not supported in GO.