### PR TITLE
fix ref issues with wrapping icons in tooltips

### DIFF
--- a/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
+++ b/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
@@ -62,12 +62,10 @@ export default function ArtifactCardNano({ artifactId, slotKey: pSlotKey, mainSt
         </Box>
         {/* mainstats */}
         <Chip size="small" sx={{ position: "absolute", bottom: 0, mb: 1, backgroundColor: color }}
-          label={<Typography sx={{ display: "flex", gap: 0.5, px: 1, zIndex: 1 }}>
-            <BootstrapTooltip placement="top" title={<Typography><StatColoredWithUnit statKey={mainStatKey} /></Typography>} disableInteractive>
-              <StatIcon statKey={mainStatKey} />
-            </BootstrapTooltip>
-            <ColorText color={mainStatLevel !== level ? "warning" : undefined}>{cacheValueString(Artifact.mainStatValue(mainStatKey, rarity, mainStatLevel) ?? 0, KeyMap.unit(mainStatKey))}{mainStatUnit}</ColorText>
-          </Typography>} />
+          icon={<BootstrapTooltip placement="top" title={<Typography><StatColoredWithUnit statKey={mainStatKey} /></Typography>} disableInteractive>
+            <Box lineHeight={0}><StatIcon statKey={mainStatKey} iconProps={{ fontSize: "small" }} /></Box>
+          </BootstrapTooltip>}
+          label={<Typography sx={{ mx: -0.7 }}><ColorText color={mainStatLevel !== level ? "warning" : undefined}>{cacheValueString(Artifact.mainStatValue(mainStatKey, rarity, mainStatLevel) ?? 0, KeyMap.unit(mainStatKey))}{mainStatUnit}</ColorText></Typography>} />
       </Box>
       {/* substats */}
       <Box display="flex" flexDirection="column" justifyContent="space-between" sx={{ p: 1, }}>
@@ -82,9 +80,9 @@ function SubstatDisplay({ stat }: { stat: ICachedSubstat }) {
   const rollColor = `roll${clamp(numRolls, 1, 6)}`
   const unit = KeyMap.unit(stat.key)
   return (<Box display="flex" gap={1} alignContent="center">
-    <Typography sx={{ flexGrow: 1, display: "flex", gap: 0.5, alignItems:"center" }} color={(numRolls ? `${rollColor}.main` : "error.main") as any} component="span">
+    <Typography sx={{ flexGrow: 1, display: "flex", gap: 0.5, alignItems: "center" }} color={(numRolls ? `${rollColor}.main` : "error.main") as any} component="span">
       <BootstrapTooltip placement="top" title={<Typography>{stat.key && <StatColoredWithUnit statKey={stat.key} />}</Typography>} disableInteractive>
-        <StatIcon statKey={stat.key} iconProps={{ fontSize: "inherit" }} />
+        <Box lineHeight={0}><StatIcon statKey={stat.key} iconProps={{ fontSize: "inherit" }} /></Box>
       </BootstrapTooltip>
       <span>{`${cacheValueString(stat.value, KeyMap.unit(stat.key))}${unit}`}</span>
     </Typography>

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/MainStatSelectionCard.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/MainStatSelectionCard.tsx
@@ -53,7 +53,7 @@ export default function MainStatSelectionCard({ disabled = false, filteredArtIds
       <CardContent sx={{ flexGrow: 1 }}>
         <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
           <BootstrapTooltip placement="top" title={<Typography>{t(`slotName.flower`)}</Typography>}>
-            <FlowerIcon fontSize='inherit' />
+            <Box lineHeight={0}><FlowerIcon fontSize='inherit' /></Box>
           </BootstrapTooltip>
           <Box flexGrow={1}>
             <SqBadge color="info"><HpIcon {...iconInlineProps} /> {tots.flower.hp}</SqBadge>
@@ -81,7 +81,7 @@ export default function MainStatSelectionCard({ disabled = false, filteredArtIds
         <CardContent sx={{ pt: 1, pb: 1 }}>
           <Box sx={{ display: "flex", gap: 1, alignItems: "center", pb: 1 }}>
             <BootstrapTooltip placement="top" title={<Typography>{t(`slotName.${slotKey}`)}</Typography>}>
-              <SlotIcon slotKey={slotKey} iconProps={{ fontSize: 'inherit' }} />
+              <Box lineHeight={0}><SlotIcon slotKey={slotKey} iconProps={{ fontSize: 'inherit' }} /></Box>
             </BootstrapTooltip>
             <Box flexGrow={1}>
               <SqBadge color="info">{slotTots[slotKey]}</SqBadge>


### PR DESCRIPTION
`StatIcon` component doesn't pass down refs to the Icons, couldn't get `ForwardRef` to work nicely, wrapping the icons in a `Box` for now.