### PR TITLE
Convert DropdownButton to use Popper-based Menu

### DIFF
--- a/apps/frontend/src/app/Components/DropdownMenu/DropdownButton.tsx
+++ b/apps/frontend/src/app/Components/DropdownMenu/DropdownButton.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowDown } from "@mui/icons-material";
-import { Button, ButtonProps, Menu, Skeleton } from "@mui/material";
+import { Button, ButtonProps, ClickAwayListener, Grow, MenuList, Paper, Popper, Skeleton } from "@mui/material";
 import { Suspense, useCallback, useState } from "react";
 
 export type DropdownButtonProps = Omit<ButtonProps, "title"> & {
@@ -31,20 +31,43 @@ export default function DropdownButton({ title, children, id = "dropdownbtn", ..
     >
       {title}
     </Button>
-    <Menu
+    <Popper
       id="basic-menu"
       anchorEl={anchorEl}
       open={open}
-      onClose={handleClose}
-      MenuListProps={{
-        'aria-labelledby': id,
-      }}
+      placement="bottom-start"
+      transition
       onClick={handleClose}
     >
-      {/* set Skeleton to be really high so the taller dropdowns can still be placed properly... */}
-      <Suspense fallback={<Skeleton width="100%" height="1000" />}>
-        {children}
-      </Suspense>
-    </Menu>
+      {({ TransitionProps, placement }) => (
+        <Grow
+          {...TransitionProps}
+          style={{
+            transformOrigin:
+              placement === 'bottom-start' ? 'left top' : 'left bottom',
+          }}
+        >
+          {/* Replicating previous menu paper */}
+          <Paper sx={{
+            maxHeight: "calc(100% - 96px)",
+            backgroundImage: "linear-gradient(rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.12))",
+            boxShadow: "rgb(0 0 0 / 20%) 0px 5px 5px -3px, rgb(0 0 0 / 14%) 0px 8px 10px 1px, rgb(0 0 0 / 12%) 0px 3px 14px 2px",
+            paddingTop: "1px",
+            paddingBottom: "1px"
+          }}>
+            <ClickAwayListener onClickAway={handleClose}>
+              <div> {/* div needed for ClickAwayListener to function */}
+                {/* set Skeleton to be really high so the taller dropdowns can still be placed properly... */}
+                <Suspense fallback={<Skeleton width="100%" height="1000" />}>
+                  <MenuList aria-labelledby={id}>
+                    {children}
+                  </MenuList>
+                </Suspense>
+              </div>
+            </ClickAwayListener>
+          </Paper>
+        </Grow>
+      )}
+    </Popper>
   </Suspense>
 }


### PR DESCRIPTION
* Resolve #936 

Convert DropdownButton to use a custom-created menu-like component that uses `Popper` instead of `Popover`. Difference is that `Popper` does not create an uninteractable overlay across the entire page, and also allows scrolling, which makes the site feel more natural.  
Worth noting that the race condition issue actually isn't fixed. If you look at the DOM, you can still see the Popper will get stuck sometimes after selecting something from the dropdown. However, you are still able to interact with the site, and the stuck dropdown is no longer interactable. So for the end user, the bug is fixed. The next time you interact with a menu, the previous Popper will clean itself up.

Component lifted from https://mui.com/material-ui/react-menu/#menulist-composition