### PR TITLE
Fix main stat padding and add location to ArtifactTooltip

### DIFF
--- a/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
+++ b/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
@@ -61,9 +61,9 @@ export default function ArtifactCardNano({ artifactId, slotKey: pSlotKey, mainSt
           }} />}
         </Box>
         {/* mainstats */}
-        <Chip size="small" sx={{ position: "absolute", bottom: 0, mb: 1, backgroundColor: color }}
+        <Chip size="small" sx={{ position: "absolute", bottom: 0, mb: 1, backgroundColor: color, p: 1 }}
           icon={<BootstrapTooltip placement="top" title={<Typography><StatColoredWithUnit statKey={mainStatKey} /></Typography>} disableInteractive>
-            <Box lineHeight={0}><StatIcon statKey={mainStatKey} iconProps={{ fontSize: "small" }} /></Box>
+            <Box lineHeight={0}><StatIcon statKey={mainStatKey} iconProps={{ style: { padding: "4px" }}} /></Box>
           </BootstrapTooltip>}
           label={<Typography sx={{ mx: -0.7 }}><ColorText color={mainStatLevel !== level ? "warning" : undefined}>{cacheValueString(Artifact.mainStatValue(mainStatKey, rarity, mainStatLevel) ?? 0, KeyMap.unit(mainStatKey))}{mainStatUnit}</ColorText></Typography>} />
       </Box>

--- a/apps/frontend/src/app/Components/Artifact/ArtifactTooltip.tsx
+++ b/apps/frontend/src/app/Components/Artifact/ArtifactTooltip.tsx
@@ -1,13 +1,20 @@
+import { characterAsset } from "@genshin-optimizer/g-assets";
 import { Box, Skeleton, Typography } from "@mui/material";
-import { Suspense } from "react";
+import BusinessCenterIcon from "@mui/icons-material/BusinessCenter";
+import { Suspense, useContext } from "react";
+import { useTranslation } from "react-i18next";
 import { getArtSheet } from "../../Data/Artifacts";
 import Artifact from "../../Data/Artifacts/Artifact";
+import { DatabaseContext } from "../../Database/Database";
 import KeyMap, { cacheValueString } from "../../KeyMap";
 import StatIcon from "../../KeyMap/StatIcon";
+import useDBMeta from "../../ReactHooks/useDBMeta";
 import { iconInlineProps } from "../../SVGIcons";
 import { ICachedArtifact, ICachedSubstat } from "../../Types/artifact";
+import { charKeyToCharName } from "../../Types/consts";
 import { clamp } from "../../Util/Util";
 import BootstrapTooltip from "../BootstrapTooltip";
+import ThumbSide from "../Character/ThumbSide";
 import SqBadge from "../SqBadge";
 import { StarsDisplay } from "../StarDisplay";
 import SlotIcon from "./SlotIcon";
@@ -25,6 +32,9 @@ export default function ArtifactTooltip({ art, children }: { art: ICachedArtifac
   </BootstrapTooltip>
 }
 function ArtifactData({ art }: { art: ICachedArtifact }) {
+  const { t } = useTranslation(["ui", "charNames_gen"])
+  const { database } = useContext(DatabaseContext)
+  const { gender } = useDBMeta()
   const sheet = getArtSheet(art.setKey)
   const { slotKey, level, rarity, mainStatKey, substats } = art
   const slotName = sheet.getSlotName(slotKey)
@@ -41,5 +51,15 @@ function ArtifactData({ art }: { art: ICachedArtifact }) {
     </Box>
 
     <Typography color="success.main">{sheet.name}</Typography>
+    {art.location
+      ? <Typography color="secondary.main" sx={{ display: "flex", alignItems: "center" }}>
+        <ThumbSide src={characterAsset(database.chars.LocationToCharacterKey(art.location), "iconSide", gender)} sx={{ pr: 1 }} />
+        {t(`charNames_gen:${charKeyToCharName(database.chars.LocationToCharacterKey(art.location), gender)}`)}
+      </Typography>
+      : <Typography color="secondary.main" sx={{ display: "flex", alignItems: "center" }}>
+        <BusinessCenterIcon />
+        {t("ui:inventory")}
+      </Typography>
+    }
   </Box>
 }


### PR DESCRIPTION
* Fix main stat padding on ArtifactCardNano
* Add location information to ArtifactTooltip
    * Above is helpful when looking at graph builds to see if a graph build has artifacts used by others without having to add it to the list.