### PR TITLE
Optimize pipeline build using nx caching

### DIFF
--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -103,5 +103,5 @@
     }
   },
   "tags": [],
-  "implicitDependencies": ["localization", "pipeline-runner","dm-localization"]
+  "implicitDependencies": ["localization", "pipeline-runner", "dm-localization"]
 }

--- a/libs/dm-localization/project.json
+++ b/libs/dm-localization/project.json
@@ -20,7 +20,7 @@
         "buildTarget": "dm-localization:build",
         "watch": false
       },
-      "dependsOn": ["build"]
+      "outputs": ["{workspaceRoot}/dist/libs/dm-localization/assets"]
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/libs/dm/.gitignore
+++ b/libs/dm/.gitignore
@@ -1,2 +1,3 @@
 GenshinData
 Texture2D
+version.hash

--- a/libs/dm/project.json
+++ b/libs/dm/project.json
@@ -30,6 +30,7 @@
   "tags": [],
   "namedInputs": {
     "production":[
+      "{projectRoot}/version.hash",
       "{projectRoot}/src/**/*",
       "{projectRoot}/scripts/**/*",
       "sharedGlobals",

--- a/libs/dm/scripts/loadDM.ts
+++ b/libs/dm/scripts/loadDM.ts
@@ -3,11 +3,18 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const projectDir = path.resolve(__dirname, "..")
+const hashFilePath = `${projectDir}/version.hash`
 
 if (fs.existsSync(`${projectDir}/GenshinData`)) {
-  console.log(`${projectDir} exists. Fetching and reseting repo...`);
+  console.log(`${projectDir} exists. Fetching...`);
   execSync(`git fetch`, { cwd: `${projectDir}/GenshinData` })
-  execSync(`git reset --hard origin/master`, { cwd: `${projectDir}/GenshinData` })
+  const curVersion = execSync(`git rev-parse origin/master`)?.toString() ?? "ERR"
+  const fileHash = (fs.existsSync(hashFilePath) && fs.readFileSync(hashFilePath)?.toString()) || ""
+  if (!fileHash || curVersion !== fileHash) {
+    console.log(`Resetting GenshinData to new version...`);
+    fs.writeFileSync(hashFilePath, curVersion)
+    execSync(`git reset --hard origin/master`, { cwd: `${projectDir}/GenshinData` })
+  }
 } else {
   console.log(`${projectDir}/GenshinData doesn't exist, cloning repo...`);
   execSync(`git clone https://gitlab.com/Dimbreath/gamedata.git --depth 1 GenshinData`, { cwd: projectDir })

--- a/libs/g-assets-gen/project.json
+++ b/libs/g-assets-gen/project.json
@@ -19,8 +19,7 @@
       "options": {
         "buildTarget": "g-assets-gen:build",
         "watch": false
-      },
-      "dependsOn": ["build"]
+      }
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/libs/g-assets-gen/src/lib/loadImages.ts
+++ b/libs/g-assets-gen/src/lib/loadImages.ts
@@ -30,7 +30,7 @@ export default function loadImages() {
     }
     fs.mkdirSync(path.dirname(dest), { recursive: true })
     fs.copyFile(src, dest, (err) => {
-      if (err) throw err;
+      if (err) console.error(err);
     });
   }
 

--- a/libs/pipeline-runner/project.json
+++ b/libs/pipeline-runner/project.json
@@ -19,8 +19,7 @@
       "options": {
         "buildTarget": "pipeline-runner:build",
         "watch": false
-      },
-      "dependsOn": ["build"]
+      }
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/libs/waverider/project.json
+++ b/libs/waverider/project.json
@@ -46,10 +46,7 @@
       "options": {
         "jestConfig": "libs/waverider/jest.config.ts",
         "passWithNoTests": true
-      },
-      "dependsOn": [
-        "genfiles"
-      ]
+      }
     }
   },
   "tags": []

--- a/nx.json
+++ b/nx.json
@@ -5,13 +5,17 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e", "genfiles"]
+        "cacheableOperations": ["build", "pipeline", "lint", "test", "e2e", "genfiles"]
       }
     }
   },
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
+    "pipeline": {
+      "dependsOn": ["build"],
       "inputs": ["production", "^production"]
     },
     "e2e": {

--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "pipeline", "lint", "test", "e2e", "genfiles"]
+        "cacheableOperations": ["build", "pipeline", "lint", "test", "e2e"]
       }
     }
   },


### PR DESCRIPTION
`dm` module now retains a file with current git commit hash, and if the commit hash doesn't change, the rest of the modules will not be rebuilt. 

This means that if there are no changes, the frontend nor its dependency modules will be rebuilt. (the only task that isnt cacheable is the `loadDM` task, which is checking for new version of GenshinData.
<img width="461" alt="image" src="https://user-images.githubusercontent.com/1754901/221384040-33896dff-c9bb-4df3-a1f7-4ee4f1ac65b3.png">
