### PR TITLE
Add functional API to database's set functions.

### DIFF
--- a/apps/frontend/src/app/Database/DataEntries/DisplayArtifactEntry.ts
+++ b/apps/frontend/src/app/Database/DataEntries/DisplayArtifactEntry.ts
@@ -127,7 +127,12 @@ export class DisplayArtifactEntry extends DataEntry<
       probabilityFilter,
     } as IDisplayArtifact
   }
-  set(value: Partial<IDisplayArtifact> | { action: 'reset' }): boolean {
+  set(
+    value:
+      | Partial<IDisplayArtifact>
+      | ((v: IDisplayArtifact) => Partial<IDisplayArtifact> | void)
+      | { action: 'reset' }
+  ): boolean {
     if ('action' in value) {
       if (value.action === 'reset')
         return super.set({ filterOption: initialFilterOption() })

--- a/apps/frontend/src/app/Database/DataEntry.test.ts
+++ b/apps/frontend/src/app/Database/DataEntry.test.ts
@@ -1,0 +1,30 @@
+import { ArtCharDatabase } from './Database'
+import { DBLocalStorage } from './DBStorage'
+
+const dbStorage = new DBLocalStorage(localStorage)
+const dbIndex = 1
+let database = new ArtCharDatabase(dbIndex, dbStorage)
+
+describe('Database', () => {
+  beforeEach(() => {
+    dbStorage.clear()
+    database = new ArtCharDatabase(dbIndex, dbStorage)
+  })
+  test('initialValue', () => {
+    expect(database.dbMeta.get().gender).toEqual('F')
+  })
+  test('DataEntry.set', () => {
+    expect(database.dbMeta.get().name).toEqual('Database 1')
+
+    database.dbMeta.set({ name: 'test' })
+    expect(database.dbMeta.get().name).toEqual('test')
+
+    database.dbMeta.set((dbMeta) => {
+      dbMeta.name = `test ${dbMeta.name}`
+    })
+    expect(database.dbMeta.get().name).toEqual('test test')
+
+    database.dbMeta.set(({ name }) => ({ name: `test ${name}` }))
+    expect(database.dbMeta.get().name).toEqual('test test test')
+  })
+})

--- a/apps/frontend/src/app/Database/DataEntry.ts
+++ b/apps/frontend/src/app/Database/DataEntry.ts
@@ -24,31 +24,45 @@ export class DataEntry<
     this.key = key
     this.init = init
     this.goKey = goKey
-    if (this.database.storage.keys.includes(key)) {
-      this.data = this.toCache(init(this.database))!
-      this.set(this.database.storage.get(key))
-    } else {
-      this.data = this.toCache(init(this.database))!
-      this.setCached(this.data)
-    }
+    this.set(
+      this.database.storage.keys.includes(key)
+        ? this.getStorage()
+        : init(this.database)
+    )
+    this.data = this.get() //initializer
   }
 
   listeners: Callback<CacheValue>[] = []
   get() {
     return this.data
   }
-  validate(obj: any): StorageValue | undefined {
+  validate(obj: unknown): StorageValue | undefined {
     return obj as StorageValue | undefined
   }
   toCache(storageObj: StorageValue): CacheValue | undefined {
-    return { ...storageObj } as any as CacheValue
+    return { ...storageObj } as unknown as CacheValue
   }
   deCache(cacheObj: CacheValue): StorageValue {
-    const { ...storageObj } = cacheObj as any
-    return storageObj as any as StorageValue
+    const { ...storageObj } = cacheObj
+    return storageObj as unknown as StorageValue
   }
-  set(value: Partial<StorageValue>): boolean {
-    const old = this.data
+  getStorage(): StorageValue {
+    return this.database.storage.get(this.key)
+  }
+  set(
+    value:
+      | Partial<StorageValue>
+      | ((v: StorageValue) => Partial<StorageValue> | void)
+  ): boolean {
+    const old = this.getStorage()
+    if (typeof value === 'function') {
+      if (!old) {
+        this.trigger('invalid', value)
+        return false
+      }
+      const temp = value(old)
+      value = temp ? temp : old
+    }
     const validated = this.validate({ ...old, ...value })
     if (!validated) {
       this.trigger('invalid', value)
@@ -70,7 +84,9 @@ export class DataEntry<
     this.trigger('update', cached)
   }
   clear() {
-    this.data = this.toCache(this.init(this.database))!
+    const data = this.toCache(this.init(this.database))
+    if (!data) return
+    this.data = data
     this.setCached(this.data)
     this.listeners = []
   }
@@ -81,8 +97,8 @@ export class DataEntry<
     this.database.storage.set(this.key, this.deCache(this.data))
   }
 
-  trigger(reason: TriggerString, object?: any) {
-    this.listeners.forEach((cb) => cb(reason, object))
+  trigger(reason: TriggerString, object?: unknown) {
+    this.listeners.forEach((cb) => cb(reason, object as CacheValue))
   }
   follow(callback: Callback<CacheValue>) {
     this.listeners.push(callback)
@@ -91,10 +107,10 @@ export class DataEntry<
     }
   }
   exportGOOD(go: Partial<IGO & IGOOD>) {
-    go[this.goKey as any] = this.data
+    go[this.goKey] = this.data
   }
   importGOOD(go: IGO & IGOOD, _result: ImportResult) {
-    const data = go[this.goKey as any]
+    const data = go[this.goKey]
     if (data) this.set(data)
   }
 }

--- a/apps/frontend/src/app/Database/DataManager.test.ts
+++ b/apps/frontend/src/app/Database/DataManager.test.ts
@@ -1,0 +1,31 @@
+import { randomizeArtifact } from '../Util/ArtifactUtil'
+import { ArtCharDatabase } from './Database'
+import { DBLocalStorage } from './DBStorage'
+
+const dbStorage = new DBLocalStorage(localStorage)
+const dbIndex = 1
+let database = new ArtCharDatabase(dbIndex, dbStorage)
+
+describe('Database', () => {
+  beforeEach(() => {
+    dbStorage.clear()
+    database = new ArtCharDatabase(dbIndex, dbStorage)
+  })
+
+  test('DataManager.set', () => {
+    const invalid = database.arts.set('INVALID', () => ({ level: 0 }))
+    expect(invalid).toEqual(false)
+    expect(database.arts.values.length).toEqual(0)
+    const id = 'testid'
+    database.arts.set(id, randomizeArtifact({ level: 0 }))
+    expect(database.arts.get(id)?.level).toEqual(0)
+
+    database.arts.set(id, (art) => {
+      art.level = art.level + 4
+    })
+    expect(database.arts.get(id)?.level).toEqual(4)
+
+    database.arts.set(id, ({ level }) => ({ level: level + 4 }))
+    expect(database.arts.get(id)?.level).toEqual(8)
+  })
+})

--- a/apps/frontend/src/app/Database/DataManager.ts
+++ b/apps/frontend/src/app/Database/DataManager.ts
@@ -64,20 +64,18 @@ export class DataManager<
   }
   set(
     key: CacheKey,
-    value:
+    valueOrFunc:
       | Partial<StorageValue>
       | ((v: StorageValue) => Partial<StorageValue> | void),
     notify = true
   ): boolean {
     const old = this.getStorage(key)
-    if (typeof value === 'function') {
-      if (!old) {
-        this.trigger(key, 'invalid', value)
-        return false
-      }
-      const temp = value(old)
-      value = temp ? temp : old
+    if (typeof valueOrFunc === 'function' && !old) {
+      this.trigger(key, 'invalid', valueOrFunc)
+      return false
     }
+    const value =
+      typeof valueOrFunc === 'function' ? valueOrFunc(old) ?? old : valueOrFunc
     const validated = this.validate({ ...(old ?? {}), ...value }, key)
     if (!validated) {
       this.trigger(key, 'invalid', value)


### PR DESCRIPTION
Generally in current system, you have to effectively keep both the value and setter, if a new value depends on a previous value. Now you can just use the setter, and not maintain a value.

This should reduce some UI cases where a button only sets a value without reading it, but both value and setter is funneled in, causing extra updates when value changes.