### PR TITLE
Connect error from background worker to ui side

### DIFF
--- a/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
@@ -9,7 +9,7 @@ declare function postMessage(command: WorkerCommand | WorkerResult): void
 
 let splitWorker: SplitWorker, computeWorker: ComputeWorker
 
-onmessage = async (e: MessageEvent<WorkerCommand>) => {
+async function handleEvent(e: MessageEvent<WorkerCommand>): Promise<void> {
   const { data } = e, { command } = data
   switch (command) {
     case "split":
@@ -54,6 +54,13 @@ onmessage = async (e: MessageEvent<WorkerCommand>) => {
     default: assertUnreachable(command)
   }
   postMessage({ resultType: 'done' })
+}
+onmessage = async (e: MessageEvent<WorkerCommand>) => {
+  try {
+    await handleEvent(e)
+  } catch (e) {
+    postMessage({ resultType: 'err', message: (e as any).message })
+  }
 }
 
 export interface SplitWorker {

--- a/apps/frontend/src/app/Solver/GOSolver/GOSolver.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/GOSolver.ts
@@ -18,6 +18,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
         case 'interim': this.interim(r, w); break
         case 'finalize': this.finalizedResults.push(r); break
         case 'count': this.status.total = r.count; break
+        case 'err': this.onError(r); break
       }
     })
     const { exclusion, topN } = problem

--- a/apps/frontend/src/app/Solver/coordinator.ts
+++ b/apps/frontend/src/app/Solver/coordinator.ts
@@ -60,7 +60,7 @@ export class WorkerCoordinator<Command extends { command: string, resultType?: n
     }
   }
 
-  onError(e: ErrorEvent) {
+  onError(e: { message: string }) {
     this.cancel(new Error(`Worker Error: ${e.message}`))
   }
   onMessage(msg: Command | Response, worker: Worker) {

--- a/apps/frontend/src/app/Solver/index.d.ts
+++ b/apps/frontend/src/app/Solver/index.d.ts
@@ -13,7 +13,7 @@ export type OptProblemInput = {
 }
 
 export type WorkerCommand = Setup | Split | Iterate | Threshold | Finalize | Count
-export type WorkerResult = Interim | CountResult | FinalizeResult | Done
+export type WorkerResult = Interim | CountResult | FinalizeResult | Done | Error
 
 export interface Setup {
   command: "setup"
@@ -48,6 +48,10 @@ export interface Count {
 }
 export interface Done {
   resultType: 'done'
+}
+export interface Error {
+  resultType: 'err'
+  message: string
 }
 export interface CountResult {
   resultType: "count"


### PR DESCRIPTION
This makes sure that errors thrown from any worker triggers cancellation at `GOSolver`. It used to silently ignore error if thrown from the event handler.