### PR TITLE
Make sure `BackgroundWorker` yields during `split`

### DIFF
--- a/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
@@ -25,7 +25,7 @@ async function handleEvent(e: MessageEvent<WorkerCommand>): Promise<void> {
         data.maxIterateSize
       )) {
         postMessage({ command: 'iterate', filter })
-        await Promise.resolve() // in case a `threshold` is sent over
+        await new Promise((r) => setTimeout(r)) // in case a `threshold` is sent over
       }
       break
     case 'iterate':

--- a/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
@@ -29,8 +29,8 @@ async function handleEvent(e: MessageEvent<WorkerCommand>): Promise<void> {
         //
         // Make sure to use task-based mechanisms such as `setTimeout` so that
         // this function suspends until the next event loop. If we instead use
-        // micro-task-based mechanisms such as `Promise.resolved`, the
-        // suspension will not be long enough.
+        // microtask-based ones such as `Promise.resolved`, the suspension will
+        // not be long enough.
         await new Promise((r) => setTimeout(r))
       }
       break

--- a/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/BackgroundWorker.ts
@@ -25,7 +25,13 @@ async function handleEvent(e: MessageEvent<WorkerCommand>): Promise<void> {
         data.maxIterateSize
       )) {
         postMessage({ command: 'iterate', filter })
-        await new Promise((r) => setTimeout(r)) // in case a `threshold` is sent over
+        // Suspend here in case a `threshold` is sent over
+        //
+        // Make sure to use task-based mechanisms such as `setTimeout` so that
+        // this function suspends until the next event loop. If we instead use
+        // micro-task-based mechanisms such as `Promise.resolved`, the
+        // suspension will not be long enough.
+        await new Promise((r) => setTimeout(r))
       }
       break
     case 'iterate':


### PR DESCRIPTION
The previous implementation used a resolved promises, which got coerced into sync. Yielding is necessary for performance reason as the solver may broadcast a threshold while the splitting process is ongoing. Incorporating these thresholds early can help with splitting efficiency/performance.