### PR TITLE
fix bug in linearUB: negative stats

### DIFF
--- a/apps/frontend/src/app/Solver/GOSolver/polyUB.test.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/polyUB.test.ts
@@ -76,6 +76,10 @@ const exampleArts: ArtifactsBySlot = {
     hydroDmg_: 0.288,
     critDMG_: 0.5,
     critRate_: 0.05,
+    zc1: -1,
+    zc2: -10,
+    zc3: -0.44,
+    zc4: -1,
   },
   values: {
     flower: [
@@ -89,6 +93,7 @@ const exampleArts: ArtifactsBySlot = {
           atk: 31,
           enerRech_: 0.227,
           OceanHuedClam: 1,
+          zc1: 1,
         },
       },
       {
@@ -101,6 +106,7 @@ const exampleArts: ArtifactsBySlot = {
           atk: 32,
           enerRech_: 0.207,
           OceanHuedClam: 1,
+          zc2: 10,
         },
       },
       {
@@ -113,6 +119,7 @@ const exampleArts: ArtifactsBySlot = {
           critRate_: 0.031,
           def_: 0.066,
           HeartOfDepth: 1,
+          zc3: 2,
         },
       },
     ],
@@ -127,6 +134,7 @@ const exampleArts: ArtifactsBySlot = {
           eleMas: 37,
           hp: 568,
           OceanHuedClam: 1,
+          zc4: -0.002,
         },
       },
       {
@@ -139,6 +147,7 @@ const exampleArts: ArtifactsBySlot = {
           eleMas: 39,
           hp: 508,
           OceanHuedClam: 1,
+          zc4: -0.0005,
         },
       },
       {
@@ -151,6 +160,7 @@ const exampleArts: ArtifactsBySlot = {
           eleMas: 40,
           atk_: 0.262,
           HeartOfDepth: 1,
+          zc4: 0.002,
         },
       },
     ],
@@ -165,6 +175,7 @@ const exampleArts: ArtifactsBySlot = {
           eleMas: 56,
           hp_: 0.105,
           OceanHuedClam: 1,
+          zc2: 22,
         },
       },
       {
@@ -177,6 +188,7 @@ const exampleArts: ArtifactsBySlot = {
           eleMas: 52,
           hp_: 0.115,
           OceanHuedClam: 1,
+          zc2: 21.95,
         },
       },
       {
@@ -251,6 +263,7 @@ const exampleArts: ArtifactsBySlot = {
           hp_: 0.178,
           atk: 15,
           eleMas: 18,
+          zc1: 2,
         },
       },
       {
@@ -262,6 +275,7 @@ const exampleArts: ArtifactsBySlot = {
           critDMG_: 0.155,
           atk_: 0.105,
           eleMas: 56,
+          zc1: 2,
         },
       },
     ],
@@ -500,6 +514,20 @@ describe('polyUB', () => {
           compute([art])[1] - prettyMuchZero
         )
       })
+    })
+    test('zero-crossing bounds', () => {
+      const z1 = customRead(['dyn', 'zc1']),
+        z2 = customRead(['dyn', 'zc2']),
+        z3 = customRead(['dyn', 'zc3']),
+        z4 = customRead(['dyn', 'zc4'])
+      doTest(
+        z1,
+        z2,
+        z3,
+        z4,
+        prod(z1, z2, z3, z4),
+        sum(prod(z1, z2), prod(-0.3, z3, z4), z2)
+      )
     })
   })
   describe('errors', () => {

--- a/apps/frontend/src/app/Solver/GOSolver/solveLP.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/solveLP.ts
@@ -39,13 +39,13 @@ export function solveLP(c: number[], Ab: number[][]) {
 
   const pivotHistory: Pivot[] = [] // Keep track of all chosen pivots for backtracking later
 
-  while (tableau.some((t, i) => i < rows - 1 && t[cols - 1] < 0)) {
+  while (tableau.some((t, i) => i < rows - 1 && t[cols - 1] < -zero)) {
     const piv = findPiv2(tableau)
     pivotHistory.push(piv)
     pivotInplace(tableau, piv)
   }
 
-  while (tableau[rows - 1].some((t, j) => j < cols - 1 && t < 0)) {
+  while (tableau[rows - 1].some((t, j) => j < cols - 1 && t < -zero)) {
     const piv = findPiv1(tableau)
     pivotHistory.push(piv)
     pivotInplace(tableau, piv)
@@ -83,7 +83,7 @@ function findPiv1(A: number[][]) {
     c = A[0].length
   let minloc = { i: -1, j: -1, cmp: Infinity }
   for (let j = 0; j < c - 1; j++) {
-    if (A[r - 1][j] >= 0) continue
+    if (A[r - 1][j] >= -zero) continue
     for (let i = 0; i < r - 1; i++) {
       if (A[i][j] > zero) {
         const cmp = A[i][c - 1] / A[i][j]
@@ -103,7 +103,7 @@ function findPiv2(A: number[][]) {
     c = A[0].length
   let minloc = { i: -1, j: -1, cmp: Infinity }
   for (let i = 0; i < r - 1; i++) {
-    if (A[i][c - 1] >= 0) continue
+    if (A[i][c - 1] >= -zero) continue
     for (let j = 0; j < c - 1; j++) {
       if (A[i][j] < -zero) {
         const cmp = A[i][c - 1] / A[i][j]


### PR DESCRIPTION
Somebody encountered a bug that the solver crashes when there are negative stats involved in the formula. Bug happened because LP Simplex solver enforces $x \geq 0$ for all the decision variables.

Fixed by re-parameterizing the input LP. Re-scaling the upper and lower bounds for each stat so that $[l, u]\subseteq [-1,1]$ allows us to place a natural $|w_i| \leq 1$ constraint on the linearUB solution, and we can further derive that $c\geq -n$ for upper-bounding & $c\leq n$ for lower-bounding.

This lets us re-parameterize $\xi_i = 1-w_i$ and $k=n\pm c$ so that the $\xi_i\geq 0$ and $k\geq 0$ imposed by the simplex method don't affect the solution.