### PR TITLE
Fix Roll Value for substats not showing

### DIFF
--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor/Components/SubstatInput.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor/Components/SubstatInput.tsx
@@ -217,7 +217,7 @@ export default function SubstatInput({
                   i18nKey="editor.substat.eff"
                   color="text.secondary"
                 >
-                  Efficiency:{' '}
+                  {'Efficiency: '}
                   <PercentBadge
                     valid={true}
                     max={rollNum * 100}


### PR DESCRIPTION
We got hit by https://github.com/prettier/prettier/issues/7711 which broke `react-i18next`