### PR TITLE
Avoid unnecessary rerender

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/index.tsx
@@ -82,7 +82,11 @@ export default function CharacterDisplay() {
         fallback={<Skeleton variant="rectangular" width="100%" height={1000} />}
       >
         {characterKey && (
-          <CharacterDisplayCard key={characterKey} characterKey={characterKey} onClose={onClose} />
+          <CharacterDisplayCard
+            key={characterKey}
+            characterKey={characterKey}
+            onClose={onClose}
+          />
         )}
       </Suspense>
     </Box>

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/index.tsx
@@ -82,7 +82,7 @@ export default function CharacterDisplay() {
         fallback={<Skeleton variant="rectangular" width="100%" height={1000} />}
       >
         {characterKey && (
-          <CharacterDisplayCard characterKey={characterKey} onClose={onClose} />
+          <CharacterDisplayCard key={characterKey} characterKey={characterKey} onClose={onClose} />
         )}
       </Suspense>
     </Box>

--- a/apps/frontend/src/app/ReactHooks/useCharacter.tsx
+++ b/apps/frontend/src/app/ReactHooks/useCharacter.tsx
@@ -6,11 +6,9 @@ export default function useCharacter(
   characterKey: CharacterKey | '' | undefined = ''
 ) {
   const { database } = useContext(DatabaseContext)
-  const [character, updateCharacter] = useState(
-    database.chars.get(characterKey)
-  )
+  const [character, setCharacter] = useState(database.chars.get(characterKey))
   useEffect(
-    () => updateCharacter(database.chars.get(characterKey)),
+    () => setCharacter(database.chars.get(characterKey)),
     [database, characterKey]
   )
   useEffect(
@@ -18,10 +16,10 @@ export default function useCharacter(
       characterKey
         ? database.chars.follow(
             characterKey,
-            (k, r, v) => r === 'update' && updateCharacter(v)
+            (k, r, v) => r === 'update' && setCharacter(v)
           )
         : undefined,
-    [characterKey, updateCharacter, database]
+    [characterKey, setCharacter, database]
   )
   return character
 }


### PR DESCRIPTION
Still suboptimal, but better than nothing
Fix #1101 
Fix #1001

`CharacterDisplayCard` was rerendering with an outdated `character`, use a key to get a new component