### PR TITLE
Improve reaffine

### DIFF
--- a/apps/frontend/src/app/Formula/utils.ts
+++ b/apps/frontend/src/app/Formula/utils.ts
@@ -409,6 +409,20 @@ export function resetData(
   return { operation: 'data', operands: [base], data, reset: true, info }
 }
 
+export function dynRead(
+  name: string,
+  accu: ReadNode<number>['accu'] = 'add',
+  info?: Info
+): ReadNode<number> {
+  return {
+    operation: 'read',
+    operands: [],
+    path: ['dyn', name],
+    accu,
+    type: 'number',
+    info,
+  }
+}
 export function customRead(
   path: readonly string[],
   info?: Info

--- a/apps/frontend/src/app/Solver/common.ts
+++ b/apps/frontend/src/app/Solver/common.ts
@@ -5,7 +5,7 @@ import { allOperations, constantFold } from '../Formula/optimization'
 import type { ConstantNode } from '../Formula/type'
 import {
   constant,
-  customRead,
+  dynRead,
   max,
   min,
   sum,
@@ -199,7 +199,7 @@ function reaffine(
       node,
       !forceRename && node.operation === 'read' && node.path[0] === 'dyn'
         ? node
-        : { ...customRead(['dyn', `${nextDynKey()}`]), accu: 'add' as const },
+        : dynRead(nextDynKey()),
     ])
   )
   nodes = mapFormulas(

--- a/apps/frontend/src/app/Solver/common.ts
+++ b/apps/frontend/src/app/Solver/common.ts
@@ -3,14 +3,7 @@ import { forEachNodes, mapFormulas } from '../Formula/internal'
 import type { OptNode } from '../Formula/optimization'
 import { allOperations, constantFold } from '../Formula/optimization'
 import type { ConstantNode } from '../Formula/type'
-import {
-  constant,
-  dynRead,
-  max,
-  min,
-  sum,
-  threshold,
-} from '../Formula/utils'
+import { constant, dynRead, max, min, sum, threshold } from '../Formula/utils'
 import type { ArtifactSetKey, SlotKey } from '../Types/consts'
 import { allSlotKeys } from '../Types/consts'
 import { assertUnreachable, objectKeyMap, objectMap, range } from '../Util/Util'


### PR DESCRIPTION
Modified `reaffine` to break non-affine sums. 

Example:
```
1 + atk + 1500*atk% + 1500*threshold(Glad, 2, 18%, 0)
  => [0] + 1500*threshold(Glad, 2, 18%, 0)
```