### PR TITLE
Minor changes to artifact exclusion toggle in optimize page.

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ExcludeArt.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ExcludeArt.tsx
@@ -64,7 +64,7 @@ export default function ExcludeArt({
     (id: string) => {
       buildSettingDispatch({
         artExclusion: [...artExclusion, id],
-        useExcludedArts: true,
+        useExcludedArts: false,
       })
     },
     [buildSettingDispatch, artExclusion]
@@ -73,7 +73,7 @@ export default function ExcludeArt({
     (id: string) => {
       buildSettingDispatch({
         artExclusion: artExclusion.filter((i) => i !== id),
-        useExcludedArts: true,
+        useExcludedArts: false,
       })
     },
     [buildSettingDispatch, artExclusion]
@@ -146,16 +146,25 @@ export default function ExcludeArt({
       <ButtonGroup sx={{ display: 'flex', width: '100%' }}>
         <Button
           onClick={toggleArtExclusion}
-          disabled={disabled}
+          disabled={disabled || !numExcludedArt}
           startIcon={
-            useExcludedArts ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />
+            useExcludedArts ? <CheckBoxOutlineBlankIcon /> : <CheckBoxIcon />
           }
-          color={useExcludedArts ? 'success' : 'secondary'}
+          color={useExcludedArts ? 'secondary' : 'success'}
           sx={{ flexGrow: 1 }}
         >
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Box>{t('excludeArt.button_text')}</Box>
-            <SqBadge sx={{ whiteSpace: 'normal' }}>
+            <SqBadge
+              sx={{ whiteSpace: 'normal' }}
+              color={
+                !numExcludedArt
+                  ? 'secondary'
+                  : useExcludedArts
+                  ? 'warning'
+                  : 'primary'
+              }
+            >
               {useExcludedArts ? (
                 <Trans t={t} i18nKey="excludeArt.usingNum">
                   Using {{ totalStr: excludedTotal } as TransObject} excluded

--- a/libs/localization/Translated/chs.json
+++ b/libs/localization/Translated/chs.json
@@ -1309,7 +1309,7 @@
       "excludeArtifactTip": "如果排除了某件圣遗物，则该角色生成配装时不会使用该圣遗物。",
       "excluded": "这件圣遗物已排除。",
       "included": "这件圣遗物未排除。",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/cht.json
+++ b/libs/localization/Translated/cht.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/de.json
+++ b/libs/localization/Translated/de.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/es.json
+++ b/libs/localization/Translated/es.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/fr.json
+++ b/libs/localization/Translated/fr.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/id.json
+++ b/libs/localization/Translated/id.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Mengecualikan artefak akan mencegah generator build menggunakannya untuk karakter ini.",
       "excluded": "Artefak ini dikecualikan.",
       "included": "Artefak ini tidak dikecualikan.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/ko.json
+++ b/libs/localization/Translated/ko.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "성유물을 제외시키면 이 캐릭터의 조합 생성에 포함되지 않습니다.",
       "excluded": "이 성유물은 제외되었습니다.",
       "included": "이 성유물은 제외되지 않았습니다.",
-      "button_text": "제외된 성유물 사용",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "<1>{{totalStr}}</1>개의 제외된 성유물 사용중"
     },
     "excludeChar": {

--- a/libs/localization/Translated/pt.json
+++ b/libs/localization/Translated/pt.json
@@ -1309,7 +1309,7 @@
       "excludeArtifactTip": "Bloquear um artefato impedirá o gerador de Builds de usá-lo para este personagem.",
       "excluded": "Este artefato está bloqueado.",
       "included": "Este artefato não está bloqueado.",
-      "button_text": "Usar Artefatos Bloqueados",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Usando <1>{{totalStr}}</1> artefato(s) bloqueado(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/ru.json
+++ b/libs/localization/Translated/ru.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/Translated/vi.json
+++ b/libs/localization/Translated/vi.json
@@ -1303,7 +1303,7 @@
       "excludeArtifactTip": "Excluding an artifact will prevent the build generator from using it for this character.",
       "excluded": "This artifact is excluded.",
       "included": "This artifact is not excluded.",
-      "button_text": "Use Excluded Artifacts",
+      "button_txt": "Exclude Artifacts",
       "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)"
     },
     "excludeChar": {

--- a/libs/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/localization/assets/locales/en/page_character_optimize.json
@@ -26,7 +26,7 @@
   "excludeArt": {
     "title_exclude": "Excluded Artifacts",
     "title_tooltip": "Add artifacts to this character's exclusion list. Artifacts in the exclusion list will not be considered for build generation.",
-    "button_text": "Exclude Artifacts",
+    "button_txt": "Exclude Artifacts",
     "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)",
     "excNum_one": "<0>{{count}}</0> artifact is excluded",
     "excNum_other": "<0>{{count}}</0> artifacts are excluded",

--- a/libs/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/localization/assets/locales/en/page_character_optimize.json
@@ -26,7 +26,7 @@
   "excludeArt": {
     "title_exclude": "Excluded Artifacts",
     "title_tooltip": "Add artifacts to this character's exclusion list. Artifacts in the exclusion list will not be considered for build generation.",
-    "button_text": "Use Excluded Artifacts",
+    "button_text": "Exclude Artifacts",
     "usingNum": "Using <1>{{totalStr}}</1> excluded artifact(s)",
     "excNum_one": "<0>{{count}}</0> artifact is excluded",
     "excNum_other": "<0>{{count}}</0> artifacts are excluded",


### PR DESCRIPTION
Reverses the toggle, so that exclusion list is used when toggle is on:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/1754901/233819430-80b014b7-78df-4fec-ac34-c3f8783d780b.png">
And when the toggle is off, the exclusion list is not used:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/1754901/233819438-e4dc0317-adaf-4f4b-80b1-438245cd74bb.png">
And the toggle is disabled when exclusion list is empty:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/1754901/233819513-dfffe8f4-c415-4a20-afb2-a5db1bfdcbdd.png">

Also, resolves #1088 by making it so that when an artifact is added to the exclusion list, the exclusion list is enabled.