### PR TITLE
Add nightly deployment action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,52 @@
+name: Deploy Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '8 20 * * *' # Midnight-ish NA time. Offset from the hour to hopefully avoid job delays
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Set git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Yarn install
+        run: |
+          yarn install --immutable --immutable-cache
+      - name: Setup .env
+        run: |
+          printf '%s' "$ENVFILE" > apps/frontend/.env.local
+        env:
+          ENVFILE: ${{ secrets.ENVFILE }}
+      - name: Build genshin-optimizer
+        run: |
+          NX_URL_GITHUB_GO_CURRENT_VERSION="https://github.com/${{ github.repository }}/commit/$(git rev-parse HEAD)" \
+          yarn run nx run frontend:build:production --base-href="nightly"
+      - name: Checkout gh-pages
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Move to gh-pages
+        run: |
+          mkdir --parents "gh-pages/nightly"
+          rm -rfv "gh-pages/nightly" || true
+          mv "dist/apps/frontend" "gh-pages/nightly"
+      - name: Make commit to deploy
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./nightly
+          git commit -m "Nightly build"
+          git push origin gh-pages
+        working-directory: gh-pages


### PR DESCRIPTION
* Add a scheduled action to deploy master nightly to a separate URL `https://frzyc.github.io/genshin-optimizer/nightly`
* Also allows deploying manually
* Partially resolves #1060