### PR TITLE
Fix parsing slowness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,11 +25,7 @@
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@nrwl/nx/typescript"],
       "parserOptions": {
-        "project": [
-          "apps/*/tsconfig.json",
-          "apps/*/tsconfig.*?.json",
-          "libs/*/tsconfig.*?.json"
-        ]
+        "project": "./tsconfig.eslint.json"
       },
       "rules": {
         "@typescript-eslint/consistent-type-exports": "warn",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           yarn install --immutable --immutable-cache
       - name: Run lint
         run: |
-          NODE_OPTIONS="--max-old-space-size=4096" yarn run nx run-many --target=lint --max-warnings=0
+          yarn run nx run-many --target=lint --max-warnings=0
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["./apps/**/*", "./libs/**/*"]
+}


### PR DESCRIPTION
* Resolve #1108 

I'm still not sure on the specifics, but there must be some large dependency or something inside the `waverider` module that was causing the slowness. Maybe some reliance on `typescript` module or something that is large, according to Google. Either way, we were getting hit by [this bug](https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-552990973) because of our parser setup. This caused slowness and memory usage issues. I did the fix in that thread a few comments down and it is significantly faster to parse and lint `waverider` module, and as a result, this also fixes slowness in the `formula` module