### PR TITLE
Adjust maxIterateSize

### DIFF
--- a/apps/frontend/src/app/Solver/GOSolver/GOSolver.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/GOSolver.ts
@@ -12,7 +12,7 @@ import { pruneAll, pruneExclusion } from '../common'
 import { WorkerCoordinator } from '../coordinator'
 
 export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
-  private maxIterateSize = 4_000_000
+  private maxIterateSize = 32_000_000
   private status: Record<'tested' | 'failed' | 'skipped' | 'total', number>
   private exclusion: Count['exclusion']
   private topN: number


### PR DESCRIPTION
Increase enumerate threshold from 4M to 32M. Up to 2x speedup depending on problem on my local machine.

Currently the runtime bottleneck is the splitting process. Increasing the enumeration simultaneously 1. increases the work of the enumeration workers and 2. decreases the level that the splitter needs to go to. In effect, it better balances the time spent between splitting and enumerating. However, the optimal value for this constant will be system-dependent & thread-count dependent.