### PR TITLE
Add ability to override Gilded Dreams teammates

### DIFF
--- a/apps/frontend/src/app/Formula/utils.ts
+++ b/apps/frontend/src/app/Formula/utils.ts
@@ -25,6 +25,7 @@ type AnyNode = NumNode | StrNode
 export const todo: OptNode = constant(NaN, { name: 'TODO' })
 export const one = percent(1),
   naught = percent(0)
+export const zero = constant(0)
 export const none = constant('none')
 
 export function constant(value: number, info?: Info): ConstantNode<number>

--- a/libs/localization/assets/locales/en/artifact_GildedDreams.json
+++ b/libs/localization/assets/locales/en/artifact_GildedDreams.json
@@ -1,0 +1,4 @@
+{
+  "overrideSameCond": "Override same element teammates",
+  "overrideOtherCond": "Override other element teammates"
+}

--- a/libs/localization/assets/locales/en/sheet.json
+++ b/libs/localization/assets/locales/en/sheet.json
@@ -20,6 +20,8 @@
   "uses_other": "{{count}} Uses",
   "opponents_one": "{{count}} Opponent",
   "opponents_other": "{{count}} Opponents",
+  "members_one": "{{count}} Member",
+  "members_other": "{{count}} Members",
   "afterDefeatEnemy": "After defeating an opponent",
   "hitOp": {
     "none": "After hitting an opponent",


### PR DESCRIPTION
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/33c8dca1-07ee-4afc-9e19-9269bf67f251)
You can do impossible situations like 3 "other element" and 3 "same element", but I'll just leave that to user to not mess it up.

If you only override "same element" but have teammates of other elements, it will still use the automatically generated "other element" value until you override it as well.