### PR TITLE
Fix artifact display headers

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
@@ -463,16 +463,11 @@ function ArtifactSectionCard() {
           {setEffects &&
             Object.entries(setEffects).flatMap(([setKey, setNumKeyArr]) =>
               setNumKeyArr.map((setNumKey) => (
-                <CardDark
+                <SetEffectDisplay
                   key={setKey + setNumKey}
-                  sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
-                >
-                  <SetEffectDisplay
-                    key={setKey + setNumKey}
-                    setKey={setKey}
-                    setNumKey={setNumKey}
-                  />
-                </CardDark>
+                  setKey={setKey}
+                  setNumKey={setNumKey}
+                />
               ))
             )}
         </Stack>


### PR DESCRIPTION
Before
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/4bb52eff-d01a-4021-8764-b9c284f1f34a)

After
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/43df9ed9-42b0-428f-8057-d56b417f772f)

Notice the gap between the 4-set cards. This is only visible on Vourublahblah's glow