### PR TITLE
Update apps and libs module types

### DIFF
--- a/apps/frontend-e2e/tsconfig.json
+++ b/apps/frontend-e2e/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "module": "ESNext"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
 }

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "esModuleInterop": false,
+    "module": "ESNext",
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitAny": false,
     "exactOptionalPropertyTypes": false,

--- a/apps/gi-frontend-e2e/tsconfig.json
+++ b/apps/gi-frontend-e2e/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "module": "ESNext"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
 }

--- a/apps/gi-frontend/tsconfig.json
+++ b/apps/gi-frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "esModuleInterop": false,
     "jsxImportSource": "@emotion/react",
     "types": ["vite/client", "vitest"],
+    "module": "ESNext",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },

--- a/apps/sr-frontend-e2e/tsconfig.json
+++ b/apps/sr-frontend-e2e/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "module": "ESNext"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
 }

--- a/apps/sr-frontend/tsconfig.json
+++ b/apps/sr-frontend/tsconfig.json
@@ -7,6 +7,7 @@
     "useDefineForClassFields": true,
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
+    "module": "ESNext",
     "isolatedModules": true,
     "esModuleInterop": true,
     "noEmit": true,

--- a/libs/gi-formula/tsconfig.json
+++ b/libs/gi-formula/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "allowSyntheticDefaultImports": true,
-    "module": "ES2022"
+    "allowSyntheticDefaultImports": true
   },
   "files": [],
   "include": [],

--- a/libs/pando/src/node/calc.ts
+++ b/libs/pando/src/node/calc.ts
@@ -54,7 +54,7 @@ export class Calculator<M = any> {
     const result = this.calculated.refExact(cache.id)
     if (result.length) return result[0]!
 
-    if (import.meta.env.PROD)
+    if (process.env['NODE_ENV'] === 'production')
       result.push({
         pre: cache
           .subset()
@@ -159,7 +159,7 @@ export class Calculator<M = any> {
                 } nodes while reading tag ${tagString(
                   newCache.tag
                 )} with no accumulator`
-                if (!import.meta.env.PROD) {
+                if (process.env['NODE_ENV'] !== 'production') {
                   throw new Error(
                     errorMsg +
                       ': ' +

--- a/libs/pando/src/tag/compilation.ts
+++ b/libs/pando/src/tag/compilation.ts
@@ -82,7 +82,7 @@ export function compileTagMapValues<V>(
     }
     if (!current['']) current[''] = []
     current[''].push(value)
-    if (import.meta.env.DEV) {
+    if (process.env['NODE_ENV'] === 'development') {
       if (!current[debugTag]) current[debugTag] = []
       current[debugTag].push(tag)
     }

--- a/libs/pando/src/tag/keys.ts
+++ b/libs/pando/src/tag/keys.ts
@@ -26,7 +26,7 @@ export class TagMapKeys {
       } = entry
       id[offset] |= word! // non-existent `value` is treated as zero
 
-      if (!import.meta.env.PROD && word === undefined)
+      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return id
@@ -49,7 +49,7 @@ export class TagMapKeys {
       id[offset] |= word! // non-existent `value` is treated as zero
       maskArr[offset] |= mask
 
-      if (!import.meta.env.PROD && word === undefined)
+      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return { id, mask: maskArr }
@@ -74,7 +74,7 @@ export class TagMapKeys {
       if (value === null) continue
       id[offset] |= word! // non-existent `value` is treated as zero
 
-      if (!import.meta.env.PROD && word === undefined)
+      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return { id, firstReplacedByte }

--- a/libs/pando/src/tag/subset.ts
+++ b/libs/pando/src/tag/subset.ts
@@ -58,7 +58,7 @@ class Internal<V> {
     const { '': values, ...remaining } = compiled
     this.children = new Map()
     this.values = values ?? []
-    if (import.meta.env.PROD) {
+    if (process.env['NODE_ENV'] === 'production') {
       this.tags = remaining[debugTag] ?? []
       delete remaining[debugTag]
     }
@@ -104,7 +104,7 @@ export class TagMapSubsetCache<V> {
   }
   /** List the tags associated with `subset` results. Works only in debug and test modes */
   tags(): Tag[] {
-    if (import.meta.env.PROD)
+    if (process.env['NODE_ENV'] === 'production')
       throw new Error('Tags are not tracked in production')
     return this.internal.entries.flatMap((x) => x.tags)
   }

--- a/libs/pando/tsconfig.json
+++ b/libs/pando/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "types": ["vite/client"],
-    "module": "es2022"
+    "types": ["vite/client"]
   },
   "files": [],
   "include": [],

--- a/libs/pando/tsconfig.lib.json
+++ b/libs/pando/tsconfig.lib.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node", "vite/client"],
-    "module": "es2022"
+    "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts", "vitest.config.ts"]

--- a/libs/sr-formula/tsconfig.json
+++ b/libs/sr-formula/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "module": "ES2022"
+    "esModuleInterop": true
   },
   "files": [],
   "include": [],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es2015",
-    "module": "esnext",
+    "module": "CommonJS",
     "lib": ["es2021", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
We have many internal problems when a CommonJS project is trying to import ESM projects. This PR converts all `libs` projects to CommonJS modules and all `apps` projects to ESNext modules. (some `apps` projects require ESNext features).

#1264 may be relevant.

Local builds may need to reset nx cache (`nx reset`).