### PR TITLE
Make sure repo hash is included in caching

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,2 @@
+!libs/dm/GenshinData.hash
+!libs/sr-dm/StarRailData.hash

--- a/libs/dm/project.json
+++ b/libs/dm/project.json
@@ -24,17 +24,5 @@
     },
     "lint": {}
   },
-  "tags": [],
-  "namedInputs": {
-    "production": [
-      "{projectRoot}/version.hash",
-      "{projectRoot}/src/**/*",
-      "{projectRoot}/scripts/**/*",
-      "sharedGlobals",
-      "{projectRoot}/.eslintrc.json",
-      "{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
-      "{projectRoot}/tsconfig.spec.json",
-      "{projectRoot}/jest.config.[jt]s"
-    ]
-  }
+  "tags": []
 }

--- a/libs/sr-dm/project.json
+++ b/libs/sr-dm/project.json
@@ -24,17 +24,5 @@
     },
     "lint": {}
   },
-  "tags": [],
-  "namedInputs": {
-    "production": [
-      "{projectRoot}/version.hash",
-      "{projectRoot}/src/**/*",
-      "{projectRoot}/scripts/**/*",
-      "sharedGlobals",
-      "{projectRoot}/.eslintrc.json",
-      "{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
-      "{projectRoot}/tsconfig.spec.json",
-      "{projectRoot}/jest.config.[jt]s"
-    ]
-  }
+  "tags": []
 }


### PR DESCRIPTION
The repo hash for `sync-repo` plugin has been ignored due to `.gitignore`.
This PR forces nx to include the hash files using `.nxignore`, and remove other unnecessary nx configurations.