### PR TITLE
Make newTab detection more lenient

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -70,8 +70,10 @@ function ScrollTop({ children }: { children: React.ReactElement }) {
 
 function App() {
   const dbIndex = parseInt(localStorage.getItem('dbIndex') || '1')
-  const [databases, setDatabases] = useState(() =>
-    ([1, 2, 3, 4] as const).map((index) => {
+  const [databases, setDatabases] = useState(() => {
+    localStorage.removeItem('GONewTabDetection')
+    localStorage.setItem('GONewTabDetection', 'debug')
+    return ([1, 2, 3, 4] as const).map((index) => {
       if (index === dbIndex) {
         return new ArtCharDatabase(index, new DBLocalStorage(localStorage))
       } else {
@@ -83,7 +85,7 @@ function App() {
         return db
       }
     })
-  )
+  })
   const setDatabase = useCallback(
     (index: number, db: ArtCharDatabase) => {
       const dbs = [...databases]

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -21,7 +21,7 @@ root.render(
 
 // Detect a storage event, and unmount the main page to show a newTab event.
 function handleStorage(this: Window, event: StorageEvent) {
-  if(event.key!=='GONewTabDetection') return
+  if (event.key !== 'GONewTabDetection') return
   if (mode === 'newtab') return
   mode = 'newtab'
   this.document.title = 'ERROR'

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -21,7 +21,7 @@ root.render(
 
 // Detect a storage event, and unmount the main page to show a newTab event.
 function handleStorage(this: Window, event: StorageEvent) {
-  if (event.key === 'i18next.translate.boo') return
+  if(event.key!=='GONewTabDetection') return
   if (mode === 'newtab') return
   mode = 'newtab'
   this.document.title = 'ERROR'


### PR DESCRIPTION
## Describe your changes
Make the new tab detection only detect a specific key that only GO uses. Should eliminate all the new tab errors caused by other extensions.
<!--- Provide a general summary of your changes -->

## Issue or discord link

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

- Resolve https://github.com/frzyc/genshin-optimizer/issues/1308, https://github.com/frzyc/genshin-optimizer/issues/1306
- https://discord.com/channels/785153694478893126/785176548428087306/1163284275328725062
- 

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
