### PR TITLE
Remove dupe ProspectorsDrill

### DIFF
--- a/libs/consts/src/weapon.ts
+++ b/libs/consts/src/weapon.ts
@@ -120,7 +120,6 @@ export const allWeaponPolearmKeys = [
   'VortexVanquisher',
   'WavebreakersFin',
   'WhiteTassel',
-  'ProspectorsDrill',
 ] as const
 export type WeaponPoleArmKey = (typeof allWeaponPolearmKeys)[number]
 


### PR DESCRIPTION
## Describe your changes

Fix a bug where Prospectors Drill would show up multiple times

## Issue or discord link

- https://discord.com/channels/785153694478893126/1171917243362328597

## Testing/validation

Selecting 4* + polearm filter in the weapon screen does not show multiple Prospector's Drill anymore

Before:
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/2e1a6a2e-fa84-48de-84fc-0ca200a5a1da)

After:
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/a96fd29c-6522-4bb7-b327-d0da2e1102cf)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
