### PR TITLE
Make `pando` debug-check explicit

### DIFF
--- a/libs/pando/src/index.ts
+++ b/libs/pando/src/index.ts
@@ -1,2 +1,3 @@
 export * from './node'
 export * from './tag'
+export { setDebugMode } from './util'

--- a/libs/pando/src/node/calc.ts
+++ b/libs/pando/src/node/calc.ts
@@ -10,7 +10,7 @@ import {
   TagMapSubsetValues,
   mergeTagMapValues,
 } from '../tag'
-import { assertUnreachable, extract, tagString } from '../util'
+import { assertUnreachable, extract, isDebug, tagString } from '../util'
 import { arithmetic, branching } from './formula'
 import type { AnyNode, NumNode, ReRead, Read, StrNode } from './type'
 
@@ -54,7 +54,7 @@ export class Calculator<M = any> {
     const result = this.calculated.refExact(cache.id)
     if (result.length) return result[0]!
 
-    if (process.env['NODE_ENV'] === 'production')
+    if (!isDebug('calc'))
       result.push({
         pre: cache
           .subset()
@@ -159,7 +159,7 @@ export class Calculator<M = any> {
                 } nodes while reading tag ${tagString(
                   newCache.tag
                 )} with no accumulator`
-                if (process.env['NODE_ENV'] !== 'production') {
+                if (isDebug('calc')) {
                   throw new Error(
                     errorMsg +
                       ': ' +

--- a/libs/pando/src/tag/compilation.ts
+++ b/libs/pando/src/tag/compilation.ts
@@ -1,3 +1,4 @@
+import { isDebug } from '../util'
 import { debugTag } from './debug'
 import { TagMapKeys } from './keys'
 import type { Tag, TagCategory, TagValue } from './type'
@@ -82,7 +83,7 @@ export function compileTagMapValues<V>(
     }
     if (!current['']) current[''] = []
     current[''].push(value)
-    if (process.env['NODE_ENV'] === 'development') {
+    if (isDebug('tag_db')) {
       if (!current[debugTag]) current[debugTag] = []
       current[debugTag].push(tag)
     }

--- a/libs/pando/src/tag/keys.ts
+++ b/libs/pando/src/tag/keys.ts
@@ -1,3 +1,4 @@
+import { isDebug } from '../util'
 import type { RawTagMapKeys } from './compilation'
 import type { Tag } from './type'
 
@@ -26,7 +27,7 @@ export class TagMapKeys {
       } = entry
       id[offset] |= word! // non-existent `value` is treated as zero
 
-      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
+      if (isDebug('tag_db') && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return id
@@ -49,7 +50,7 @@ export class TagMapKeys {
       id[offset] |= word! // non-existent `value` is treated as zero
       maskArr[offset] |= mask
 
-      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
+      if (isDebug('tag_db') && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return { id, mask: maskArr }
@@ -74,7 +75,7 @@ export class TagMapKeys {
       if (value === null) continue
       id[offset] |= word! // non-existent `value` is treated as zero
 
-      if (process.env['NODE_ENV'] !== 'production' && word === undefined)
+      if (isDebug('tag_db') && word === undefined)
         throw `NonExistent tag ${category}:${value}`
     }
     return { id, firstReplacedByte }

--- a/libs/pando/src/tag/subset.ts
+++ b/libs/pando/src/tag/subset.ts
@@ -1,3 +1,4 @@
+import { isDebug } from '../util'
 import type { RawTagMapValues } from './compilation'
 import { debugTag } from './debug'
 import type { TagID, TagMapKeys } from './keys'
@@ -58,7 +59,7 @@ class Internal<V> {
     const { '': values, ...remaining } = compiled
     this.children = new Map()
     this.values = values ?? []
-    if (process.env['NODE_ENV'] === 'production') {
+    if (isDebug('tag_db')) {
       this.tags = remaining[debugTag] ?? []
       delete remaining[debugTag]
     }
@@ -104,7 +105,7 @@ export class TagMapSubsetCache<V> {
   }
   /** List the tags associated with `subset` results. Works only in debug and test modes */
   tags(): Tag[] {
-    if (process.env['NODE_ENV'] === 'production')
+    if (!isDebug('tag_db'))
       throw new Error('Tags are not tracked in production')
     return this.internal.entries.flatMap((x) => x.tags)
   }

--- a/libs/pando/src/util/index.ts
+++ b/libs/pando/src/util/index.ts
@@ -1,5 +1,15 @@
 import type { Tag } from '../tag'
 
+type DebugMode = boolean
+
+let debugMode = false
+export function setDebugMode(mode: DebugMode) {
+  debugMode = mode
+}
+export function isDebug(_: 'calc' | 'tag_db'): boolean {
+  return debugMode
+}
+
 export function assertUnreachable(value: never): never {
   throw new Error(`Should not reach this with value ${value}`)
 }


### PR DESCRIPTION
## Describe your changes

Instead of using `process.env[NODE_ENV]`, which is framework dependent (see #1264), this moves the debug check into an explicit variable, which can be set by downstream users using `setDebugMode`.

The original design is to have the `isDebug` flag in `calc`, but there are multiple free functions accessing this env variable as well, so I move it into module-wide variable.

Currently, it can only be toggled on or off, but it can be separate into "calculator debug" and "tag database debug" if needed.

## Issue or discord link

https://discord.com/channels/785153694478893126/819643218446254100/1171934532899971172

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.