### PR TITLE
Simplify nx task graph

### DIFF
--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -85,8 +85,7 @@
           "buildTarget": "frontend:build-webpack:production",
           "hmr": false
         }
-      },
-      "dependsOn": ["build-webpack"]
+      }
     },
     "lint": {},
     "test": {}

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -85,7 +85,8 @@
           "buildTarget": "frontend:build-webpack:production",
           "hmr": false
         }
-      }
+      },
+      "dependsOn": ["build-webpack"]
     },
     "lint": {},
     "test": {}

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -86,7 +86,7 @@
           "hmr": false
         }
       },
-      "dependsOn": ["build-webpack"]
+      "dependsOn": ["^gen-file"]
     },
     "lint": {},
     "test": {}

--- a/apps/gi-frontend/project.json
+++ b/apps/gi-frontend/project.json
@@ -21,7 +21,8 @@
           "buildTarget": "gi-frontend:build-vite:production",
           "hmr": false
         }
-      }
+      },
+      "dependsOn": ["build-vite"]
     },
     "preview": {
       "executor": "@nx/vite:preview-server",

--- a/apps/gi-frontend/project.json
+++ b/apps/gi-frontend/project.json
@@ -22,7 +22,7 @@
           "hmr": false
         }
       },
-      "dependsOn": ["build-vite"]
+      "dependsOn": ["^gen-file"]
     },
     "preview": {
       "executor": "@nx/vite:preview-server",

--- a/apps/sr-frontend/project.json
+++ b/apps/sr-frontend/project.json
@@ -22,7 +22,8 @@
           "buildTarget": "sr-frontend:build-vite:production",
           "hmr": false
         }
-      }
+      },
+      "dependsOn": ["build-vite"]
     },
     "preview": {
       "executor": "@nx/vite:preview-server",

--- a/apps/sr-frontend/project.json
+++ b/apps/sr-frontend/project.json
@@ -23,7 +23,7 @@
           "hmr": false
         }
       },
-      "dependsOn": ["build-vite"]
+      "dependsOn": ["^gen-file"]
     },
     "preview": {
       "executor": "@nx/vite:preview-server",

--- a/libs/dm/project.json
+++ b/libs/dm/project.json
@@ -15,7 +15,7 @@
         }
       ]
     },
-    "genfile": {},
+    "gen-file": {},
     "build": {},
     "build-ts": {
       "options": {

--- a/libs/gi-assets/project.json
+++ b/libs/gi-assets/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "tags": [],
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/gi-assets:gen-assets",
       "outputs": ["{workspaceRoot}/${projectRoot}/src/gen/**/*"]
     },

--- a/libs/gi-dm-localization/project.json
+++ b/libs/gi-dm-localization/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/gi-dm-localization/src",
   "projectType": "application",
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/gi-dm-localization:gen-locale",
       "outputs": ["{projectRoot}/assets/locales"]
     },

--- a/libs/gi-localization/project.json
+++ b/libs/gi-localization/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/gi-localization/src",
   "projectType": "library",
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/gi-localization:gen-locale",
       "outputs": [
         "{projectRoot}/Translated",

--- a/libs/gi-stats/project.json
+++ b/libs/gi-stats/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/gi-stats/src",
   "projectType": "library",
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/gi-stats:gen-stats",
       "outputs": [
         "{projectRoot}/Data/**/*",

--- a/libs/silly-wisher-names/project.json
+++ b/libs/silly-wisher-names/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/silly-wisher-names/src",
   "projectType": "library",
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/silly-wisher-names:gen-assets",
       "outputs": ["{projectRoot}/assets/locales", "{projectRoot}/Translated"]
     },

--- a/libs/sr-assets/project.json
+++ b/libs/sr-assets/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "tags": [],
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/sr-assets:gen-assets",
       "outputs": ["{workspaceRoot}/${projectRoot}/src/gen/**/*"]
     },

--- a/libs/sr-dm/project.json
+++ b/libs/sr-dm/project.json
@@ -15,7 +15,7 @@
         }
       ]
     },
-    "genfile": {},
+    "gen-file": {},
     "build": {},
     "build-ts": {
       "options": {

--- a/libs/sr-stats/project.json
+++ b/libs/sr-stats/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/sr-stats/src",
   "projectType": "library",
   "targets": {
-    "genfile": {
+    "gen-file": {
       "executor": "@genshin-optimizer/sr-stats:gen-stats",
       "outputs": [
         "{projectRoot}/Data/**/*",

--- a/nx.json
+++ b/nx.json
@@ -35,7 +35,7 @@
       "inputs": ["production", "^production"]
     },
     "build-webpack": {
-      "dependsOn": ["gen-file", "^gen-file", "^build"],
+      "dependsOn": ["gen-file", "^gen-file"],
       "inputs": ["production", "^production"]
     },
     "build-vite": {

--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,7 @@
       "options": {
         "cacheableOperations": [
           "load-dm",
-          "genfile",
+          "gen-file",
           "build",
           "build-webpack",
           "build-vite",
@@ -24,9 +24,9 @@
       "executor": "@genshin-optimizer/plugin:sync-repo",
       "outputs": ["{workspaceRoot}/{options.outputPath}.hash"]
     },
-    "genfile": {
+    "gen-file": {
       "executor": "nx:noop",
-      "dependsOn": ["load-dm", "^genfile"],
+      "dependsOn": ["load-dm", "^gen-file"],
       "inputs": ["production", "^production"]
     },
     "build": {
@@ -35,7 +35,7 @@
       "inputs": ["production", "^production"]
     },
     "build-webpack": {
-      "dependsOn": ["genfile", "^genfile", "^build"],
+      "dependsOn": ["gen-file", "^gen-file", "^build"],
       "inputs": ["production", "^production"]
     },
     "build-vite": {
@@ -53,7 +53,7 @@
           "mode": "production"
         }
       },
-      "dependsOn": ["genfile", "^genfile", "^build"],
+      "dependsOn": ["gen-file", "^gen-file", "^build"],
       "inputs": ["production", "^production"]
     },
     "build-ts": {
@@ -64,7 +64,7 @@
         "main": "{projectRoot}/src/index.ts",
         "tsConfig": "{projectRoot}/tsconfig.lib.json"
       },
-      "dependsOn": ["genfile", "^genfile", "^build"],
+      "dependsOn": ["gen-file", "^gen-file", "^build"],
       "inputs": ["production", "^production"]
     },
     "e2e": {
@@ -78,7 +78,7 @@
         "fix": true
       },
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
-      "dependsOn": ["genfile", "^genfile"]
+      "dependsOn": ["gen-file", "^gen-file"]
     },
     "test": {
       "executor": "@nx/jest:jest",
@@ -89,7 +89,7 @@
         "reportsDirectory": "{workspaceRoot}/coverage/{projectRoot}",
         "passWithNoTests": true
       },
-      "dependsOn": ["genfile", "^genfile"],
+      "dependsOn": ["gen-file", "^gen-file"],
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     },
     "publish": {

--- a/nx.json
+++ b/nx.json
@@ -35,7 +35,7 @@
       "inputs": ["production", "^production"]
     },
     "build-webpack": {
-      "dependsOn": ["genfile", "^genfile", "^build", "^pipeline"],
+      "dependsOn": ["genfile", "^genfile", "^build"],
       "inputs": ["production", "^production"]
     },
     "build-vite": {
@@ -53,7 +53,7 @@
           "mode": "production"
         }
       },
-      "dependsOn": ["genfile", "^genfile", "^build", "^pipeline"],
+      "dependsOn": ["genfile", "^genfile", "^build"],
       "inputs": ["production", "^production"]
     },
     "build-ts": {
@@ -64,7 +64,7 @@
         "main": "{projectRoot}/src/index.ts",
         "tsConfig": "{projectRoot}/tsconfig.lib.json"
       },
-      "dependsOn": ["genfile", "^genfile", "^build", "^pipeline"],
+      "dependsOn": ["genfile", "^genfile", "^build"],
       "inputs": ["production", "^production"]
     },
     "e2e": {
@@ -78,7 +78,7 @@
         "fix": true
       },
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
-      "dependsOn": ["genfile", "^genfile", "^pipeline"]
+      "dependsOn": ["genfile", "^genfile"]
     },
     "test": {
       "executor": "@nx/jest:jest",
@@ -89,7 +89,7 @@
         "reportsDirectory": "{workspaceRoot}/coverage/{projectRoot}",
         "passWithNoTests": true
       },
-      "dependsOn": ["genfile", "^genfile", "^pipeline"],
+      "dependsOn": ["genfile", "^genfile"],
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     },
     "publish": {


### PR DESCRIPTION
## Describe your changes

House cleaning on nx graph.

Barring unique tasks, we should have 4 main "stages": `serve`, `build`, `genFile`, `load-dm`.

- `build <- genFile <- load-dm`
- `serve <- genFile <- load-dm`

TODO list:
- [x] do not make `serve` depend on `build`
- [x] Eliminate `pipeline` task (should all be `genFile`
- [x] rename `genFile` to `gen-file`
- [x] document all the main tasks, as well as the nx structure in a wiki/readme


## Issue or discord link

Resolves #1325

## Testing/validation

Updated `build`
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/78a5b6fc-e0d3-4811-9b37-aeca2ba18a3e)

Updated `serve`
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/803733aa-e621-4748-ab5e-d071025fb2de)

Updated wiki:
https://github.com/frzyc/genshin-optimizer/wiki/Notes-on-nx-configuration

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.