### PR TITLE
Fix Baizhu A1 and Furina C1 display

### DIFF
--- a/apps/frontend/src/app/Data/Characters/Furina/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/Furina/index.tsx
@@ -100,8 +100,8 @@ const dm = {
     max_interval_dec_: skillParam_gen.passive2[3][0],
   },
   constellation1: {
-    fanfareLimitInc: skillParam_gen.constellation1[0],
-    bonusFanfare: skillParam_gen.constellation1[1],
+    bonusFanfare: skillParam_gen.constellation1[0],
+    fanfareLimitInc: skillParam_gen.constellation1[1],
   },
   constellation2: {
     idk: skillParam_gen.constellation2[0],

--- a/libs/gi-localization/assets/locales/en/sheet.json
+++ b/libs/gi-localization/assets/locales/en/sheet.json
@@ -74,6 +74,7 @@
   "addlCharges": "Additional Skill Charges",
   "charOnField": "Character is on-field",
   "timeOnField": "Time spent on-field",
+  "activeChar": "Active Character",
   "charOffField": "Character is off-field",
   "activeCharField": "Character is inside the ability's field",
   "opponentsField": "Opponent is inside the ability's field",

--- a/libs/gi-localization/assets/locales/en/sheet.json
+++ b/libs/gi-localization/assets/locales/en/sheet.json
@@ -74,7 +74,7 @@
   "addlCharges": "Additional Skill Charges",
   "charOnField": "Character is on-field",
   "timeOnField": "Time spent on-field",
-  "activeChar": "Active Character",
+  "activeChar": "Active character",
   "charOffField": "Character is off-field",
   "activeCharField": "Character is inside the ability's field",
   "opponentsField": "Opponent is inside the ability's field",


### PR DESCRIPTION
## Describe your changes

Baizhu C1 conditional displayed like this. The string for this has been added back (it was previously changed alongside its key)
![image](https://github.com/frzyc/genshin-optimizer/assets/121315943/2d72270e-3680-40ff-aeff-8f8d4fafda8e)
Furina C1 conditional used to be displayed like this (values are inverted). DM names have been inverted to correct.
![image](https://github.com/frzyc/genshin-optimizer/assets/121315943/a0e0035a-ce64-4fa7-b220-128cd3d4fe00)


## Issue or discord link
- Furina: https://discord.com/channels/785153694478893126/1172303061717360670
- Baizhu: https://discord.com/channels/785153694478893126/1174577424323842128

## Testing/validation
![image](https://github.com/frzyc/genshin-optimizer/assets/121315943/c258f122-17e6-4d97-8479-d9a5be64853a)
Furina C1 dm looks like this. so I changed the value names to the proper this
![image](https://github.com/frzyc/genshin-optimizer/assets/121315943/6f64648e-56d3-4562-b7ea-d8e91ad26c95)
instead of the opposite.
![image](https://github.com/frzyc/genshin-optimizer/assets/121315943/0421adf4-264d-4ac7-aff6-e0ddd035e960)
Furina C1 works. Baizhu doesn't. Idk why and I cry
## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
