### PR TITLE
Fix Furina C1 Fanfare Limit

### DIFF
--- a/apps/frontend/src/app/Data/Characters/Furina/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/Furina/index.tsx
@@ -141,7 +141,7 @@ const [condBurstFanfarePath, condBurstFanfare] = cond(key, 'burstFanfare')
 const burstFanfareArr = range(50, dm.burst.maxFanfare, 50)
 const c1FanfareArr = range(
   50,
-  dm.burst.maxFanfare + dm.constellation1.bonusFanfare,
+  dm.burst.maxFanfare + dm.constellation1.fanfareLimitInc,
   50
 )
 const clampedFanfareNum = lookup(
@@ -618,8 +618,10 @@ const sheet: ICharacterSheet = {
             value: (data) =>
               data.get(input.constellation).value >= 1
                 ? `${dm.burst.maxFanfare} + ${
-                    dm.constellation1.bonusFanfare
-                  } = ${dm.burst.maxFanfare + dm.constellation1.bonusFanfare}`
+                    dm.constellation1.fanfareLimitInc
+                  } = ${
+                    dm.burst.maxFanfare + dm.constellation1.fanfareLimitInc
+                  }`
                 : dm.burst.maxFanfare,
           },
           {


### PR DESCRIPTION
## Describe your changes

Furina Burst cond with C1 went up to 450 Fanfare when it should cap at 400. wrong datamined value was referenced.
I am getting sloppier and sloppier with changes.

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
