### PR TITLE
Create Dropdown menu for Constellations as the constellations header

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
@@ -54,9 +54,10 @@ export default function CharacterTalentPane() {
 
   const theme = useTheme()
   const grlg = useMediaQuery(theme.breakpoints.up('lg'))
+  const maxConstellationCount = 6
   const constellationCards = useMemo(
     () =>
-      range(1, 6).map((i) => (
+      range(1, maxConstellationCount).map((i) => (
         <SkillDisplayCard
           talentKey={`constellation${i}` as TalentSheetElementKey}
           subtitle={`Constellation Lv. ${i}`}
@@ -69,6 +70,30 @@ export default function CharacterTalentPane() {
       )),
     [constellation, characterDispatch]
   )
+  const constellationHeader = (
+    <DropdownButton
+      fullWidth
+      title={`Constellation Lv. ${constellation}`}
+      color={'success'}
+      sx={{ borderRadius: 0 }}
+    >
+      {range(0, maxConstellationCount).map((i) => (
+        <MenuItem
+          key={i}
+          selected={constellation === i}
+          disabled={constellation === i}
+          onClick={() =>
+            characterDispatch({
+              constellation: i,
+            })
+          }
+        >
+          Constellation Lv. {i}
+        </MenuItem>
+      ))}
+    </DropdownButton>
+  )
+
   return (
     <>
       <ReactionDisplay />
@@ -82,13 +107,7 @@ export default function CharacterTalentPane() {
             lg={3}
             sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
           >
-            <CardLight>
-              <CardContent>
-                <Typography variant="h6" sx={{ textAlign: 'center' }}>
-                  Constellation Lv. {constellation}
-                </Typography>
-              </CardContent>
-            </CardLight>
+            <CardLight>{constellationHeader}</CardLight>
             {constellationCards.map((c, i) => (
               <Box key={i} sx={{ opacity: constellation >= i + 1 ? 1 : 0.5 }}>
                 {c}
@@ -136,13 +155,7 @@ export default function CharacterTalentPane() {
         {!grlg && (
           <Grid item xs={12} md={12} lg={3} container spacing={1}>
             <Grid item xs={12}>
-              <CardLight>
-                <CardContent>
-                  <Typography variant="h6" sx={{ textAlign: 'center' }}>
-                    Constellation Lv. {constellation}
-                  </Typography>
-                </CardContent>
-              </CardLight>
+              <CardLight>{constellationHeader}</CardLight>
             </Grid>
             {constellationCards.map((c, i) => (
               <Grid

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
@@ -1,3 +1,4 @@
+import { maxConstellationCount } from '@genshin-optimizer/consts'
 import {
   Box,
   CardActionArea,
@@ -54,7 +55,6 @@ export default function CharacterTalentPane() {
 
   const theme = useTheme()
   const grlg = useMediaQuery(theme.breakpoints.up('lg'))
-  const maxConstellationCount = 6
   const constellationCards = useMemo(
     () =>
       range(1, maxConstellationCount).map((i) => (

--- a/libs/consts/src/character.ts
+++ b/libs/consts/src/character.ts
@@ -40,6 +40,8 @@ export const allMoveKeys = [
 ] as const
 export type MoveKey = (typeof allMoveKeys)[number]
 
+export const maxConstellationCount = 6 as const
+
 export const characterSpecializedStatKeys = [
   'hp_',
   'atk_',


### PR DESCRIPTION
## Describe your changes

* Resolves #1295.
* Matched constellations header to be the same as the talents' headers.
* Used green color (`success`) for constellations header rather than blue color (`primary`) that talents' header uses.

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/22307142/0c711864-e1ca-4e47-b3be-dd9073b3fb96)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
