### PR TITLE
Change constellation header colors to blue on talent tab

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTalent.tsx
@@ -74,7 +74,7 @@ export default function CharacterTalentPane() {
     <DropdownButton
       fullWidth
       title={`Constellation Lv. ${constellation}`}
-      color={'success'}
+      color="primary"
       sx={{ borderRadius: 0 }}
     >
       {range(0, maxConstellationCount).map((i) => (


### PR DESCRIPTION
## Describe your changes

Change constellation header colors to blue on talent tab.

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/22307142/5c165244-f41d-4660-99e1-9d6137bd05af)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
