### PR TITLE
Update roll efficiency calculation

### DIFF
--- a/apps/frontend/src/app/Data/Artifacts/Artifact.ts
+++ b/apps/frontend/src/app/Data/Artifacts/Artifact.ts
@@ -39,7 +39,9 @@ export default class Artifact {
       )
   )
 
-  //ARTIFACT IN GENERAL
+  /**
+   * @deprecate
+   */
   static getArtifactEfficiency(
     artifact: ICachedArtifact,
     filter: Set<SubstatKey>

--- a/apps/frontend/src/app/Data/Artifacts/Artifact.ts
+++ b/apps/frontend/src/app/Data/Artifacts/Artifact.ts
@@ -59,19 +59,14 @@ export default class Artifact {
       filter.size -
       matchedSlotCount -
       (filter.has(artifact.mainStatKey as any) ? 1 : 0)
-    let maxEfficiency
-    if (emptySlotCount && unusedFilterCount)
-      maxEfficiency =
-        currentEfficiency +
-        Artifact.maxSubstatRollEfficiency[rarity] * rollsRemaining
-    // Rolls into good empty slot
-    else if (matchedSlotCount)
-      maxEfficiency =
-        currentEfficiency +
-        Artifact.maxSubstatRollEfficiency[rarity] *
-          (rollsRemaining - emptySlotCount)
-    // Rolls into existing matched slot
-    else maxEfficiency = currentEfficiency // No possible roll
+
+    let maxEfficiency = currentEfficiency
+    const maxRollEff = Artifact.maxSubstatRollEfficiency[rarity]
+    // Rolls into good empty slots, assuming max-level artifacts have no empty slots
+    maxEfficiency += maxRollEff * Math.min(emptySlotCount, unusedFilterCount)
+    // Rolls into an existing good slot
+    if (matchedSlotCount || (emptySlotCount && unusedFilterCount))
+      maxEfficiency += maxRollEff * (rollsRemaining - emptySlotCount)
 
     return { currentEfficiency, maxEfficiency }
   }

--- a/libs/gi-util/src/artifact/artifact.ts
+++ b/libs/gi-util/src/artifact/artifact.ts
@@ -172,17 +172,14 @@ export function getArtifactEfficiency(
     filter.size -
     matchedSlotCount -
     (filter.has(artifact.mainStatKey as any) ? 1 : 0)
-  let maxEfficiency
-  if (emptySlotCount && unusedFilterCount)
-    maxEfficiency =
-      currentEfficiency + maxSubstatRollEfficiency[rarity] * rollsRemaining
-  // Rolls into good empty slot
-  else if (matchedSlotCount)
-    maxEfficiency =
-      currentEfficiency +
-      maxSubstatRollEfficiency[rarity] * (rollsRemaining - emptySlotCount)
-  // Rolls into existing matched slot
-  else maxEfficiency = currentEfficiency // No possible roll
+
+  let maxEfficiency = currentEfficiency
+  const maxRollEff = maxSubstatRollEfficiency[rarity]
+  // Rolls into good empty slots, assuming max-level artifacts have no empty slots
+  maxEfficiency += maxRollEff * Math.min(emptySlotCount, unusedFilterCount)
+  // Rolls into an existing good slot
+  if (matchedSlotCount || (emptySlotCount && unusedFilterCount))
+    maxEfficiency += maxRollEff * (rollsRemaining - emptySlotCount)
 
   return { currentEfficiency, maxEfficiency }
 }


### PR DESCRIPTION
## Describe your changes

This updates a max-RV calculation, and fix a minor bug that overestimate max RV in certain scenarios.

## Issue or discord link

- https://discord.com/channels/785153694478893126/785176548428087306/1181204144900546613

## Testing/validation

Current
<img width="477" alt="current" src="https://github.com/frzyc/genshin-optimizer/assets/16190491/e6ff01c2-7bc7-438e-a2b5-ed824f7b6e55">

Corrected
<img width="480" alt="corrected" src="https://github.com/frzyc/genshin-optimizer/assets/16190491/35d65a6c-4e53-45b9-ba46-9601d5c6cb35">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [X] I have commented my code, in hard-to understand areas.
- [X] I have made corresponding changes to README or wiki.
- [X] For front-end changes, I have updated the corresponding English translations.
- [X] Ran `yarn run mini-ci` locally to validate format + lint.
- [X] If there were format issues, I ran `nx format write` to resolve them automatically.
