### PR TITLE
scanner fix for other rarities

### DIFF
--- a/libs/gi-art-scanner/src/lib/consts.ts
+++ b/libs/gi-art-scanner/src/lib/consts.ts
@@ -16,6 +16,38 @@ export const goldenTitleLighterColor: Color = {
   b: 50,
 }
 
+/**
+ * "purple" title
+ * light: a056e0 rgb(160, 86, 224)
+ * dark: 7943a7 rgb(121, 67, 167)
+ */
+export const purpleTitleDarkerColor: Color = {
+  r: 121,
+  g: 67,
+  b: 167,
+}
+export const purpleTitleLighterColor: Color = {
+  r: 160,
+  g: 86,
+  b: 224,
+}
+
+/**
+ * "blue" title
+ * light: 517fcc rgb(81, 127, 204)
+ * dark: 3e6095 rgb(62, 96, 149)
+ */
+export const blueTitleDarkerColor: Color = {
+  r: 62,
+  g: 96,
+  b: 149,
+}
+export const blueTitleLighterColor: Color = {
+  r: 81,
+  g: 127,
+  b: 204,
+}
+
 // The "baige" background of artifact card, ebe4d8  rgb(235, 228, 216)
 export const cardWhite: Color = {
   r: 235,

--- a/libs/gi-art-scanner/src/lib/processImg.ts
+++ b/libs/gi-art-scanner/src/lib/processImg.ts
@@ -115,7 +115,7 @@ export async function processEntry(
    */
   // const goldenTitleCropped = cropHorizontal(
   //   artifactCardCanvas,
-  //   artifactCardImageData,
+  //   titleTop,
   //   titleBot
   // )
 

--- a/libs/gi-art-scanner/src/lib/processImg.ts
+++ b/libs/gi-art-scanner/src/lib/processImg.ts
@@ -2,8 +2,8 @@ import type { IArtifact } from '@genshin-optimizer/gi-good'
 import { clamp } from '@genshin-optimizer/util'
 import type { ReactNode } from 'react'
 
+import type { Color } from '@genshin-optimizer/img-util'
 import {
-  Color,
   bandPass,
   cropHorizontal,
   cropImageData,
@@ -392,6 +392,7 @@ function findTitle(artifactCardImageData: ImageData) {
     [purpleTitleDarkerColor, purpleTitleLighterColor],
     [blueTitleDarkerColor, blueTitleLighterColor],
   ] as const
+  // Return first detected title color
   return titleColors.reduce(
     (a, curr) => (a ? a : findTitleColored(curr[0], curr[1])),
     null as null | number[]

--- a/libs/gi-art-scanner/src/lib/processImg.ts
+++ b/libs/gi-art-scanner/src/lib/processImg.ts
@@ -3,6 +3,7 @@ import { clamp } from '@genshin-optimizer/util'
 import type { ReactNode } from 'react'
 
 import {
+  Color,
   bandPass,
   cropHorizontal,
   cropImageData,
@@ -18,12 +19,16 @@ import {
   urlToImageData,
 } from '@genshin-optimizer/img-util'
 import {
+  blueTitleDarkerColor,
+  blueTitleLighterColor,
   cardWhite,
   equipColor,
   goldenTitleDarkerColor,
   goldenTitleLighterColor,
   greenTextColor,
   lockColor,
+  purpleTitleDarkerColor,
+  purpleTitleLighterColor,
   starColor,
   textColorDark,
   textColorLight,
@@ -67,14 +72,10 @@ export async function processEntry(
   const artifactCardImageData = verticallyCropArtifactCard(imageData, debugImgs)
   const artifactCardCanvas = imageDataToCanvas(artifactCardImageData)
 
-  const goldTitleHistogram = histogramContAnalysis(
-    artifactCardImageData,
-    darkerColor(goldenTitleDarkerColor, 20),
-    lighterColor(goldenTitleLighterColor, 20),
-    false,
-    [0, 0.3]
-  )
-  const [goldTitleTop, goldTitleBot] = findHistogramRange(goldTitleHistogram)
+  const titleHistogram = findTitle(artifactCardImageData)
+  const [titleTop, titleBot] = titleHistogram
+    ? findHistogramRange(titleHistogram)
+    : [0, 0]
 
   const whiteCardHistogram = histogramContAnalysis(
     artifactCardImageData,
@@ -102,7 +103,7 @@ export async function processEntry(
 
   const artifactCardCropped = cropHorizontal(
     artifactCardCanvas,
-    goldTitleTop,
+    titleTop,
     hasEquip ? equipBot : whiteCardBot
   )
 
@@ -114,8 +115,8 @@ export async function processEntry(
    */
   // const goldenTitleCropped = cropHorizontal(
   //   artifactCardCanvas,
-  //   goldTitleTop,
-  //   goldTitleBot
+  //   artifactCardImageData,
+  //   titleBot
   // )
 
   // if (debug)
@@ -124,23 +125,24 @@ export async function processEntry(
 
   const headerCropped = cropHorizontal(
     artifactCardCanvas,
-    goldTitleBot,
+    titleBot,
     whiteCardTop
   )
 
   if (debugImgs) {
     const canvas = imageDataToCanvas(artifactCardImageData)
-    drawHistogram(
-      canvas,
-      goldTitleHistogram,
-      {
-        r: 0,
-        g: 150,
-        b: 150,
-        a: 100,
-      },
-      false
-    )
+    titleHistogram &&
+      drawHistogram(
+        canvas,
+        titleHistogram,
+        {
+          r: 0,
+          g: 150,
+          b: 150,
+          a: 100,
+        },
+        false
+      )
 
     drawHistogram(
       canvas,
@@ -150,7 +152,7 @@ export async function processEntry(
     )
     drawHistogram(canvas, equipHistogram, { r: 0, g: 0, b: 100, a: 100 }, false)
 
-    drawline(canvas, goldTitleTop, { r: 0, g: 255, b: 0, a: 200 }, false)
+    drawline(canvas, titleTop, { r: 0, g: 255, b: 0, a: 200 }, false)
     drawline(
       canvas,
       hasEquip ? equipBot : whiteCardBot,
@@ -368,4 +370,30 @@ function parseRarity(
     }
   }
   return clamp(count, 1, 5)
+}
+
+function findTitle(artifactCardImageData: ImageData) {
+  const width = artifactCardImageData.width
+  const widthThreshold = width * 0.7
+
+  function findTitleColored(darkerTitleColor: Color, LighterTitleColor: Color) {
+    const hist = histogramContAnalysis(
+      artifactCardImageData,
+      darkerColor(darkerTitleColor, 20),
+      lighterColor(LighterTitleColor, 20),
+      false,
+      [0, 0.3] // only scan the top 30% of the img
+    )
+    if (hist.find((v) => v > widthThreshold)) return hist
+    return null
+  }
+  const titleColors = [
+    [goldenTitleDarkerColor, goldenTitleLighterColor],
+    [purpleTitleDarkerColor, purpleTitleLighterColor],
+    [blueTitleDarkerColor, blueTitleLighterColor],
+  ] as const
+  return titleColors.reduce(
+    (a, curr) => (a ? a : findTitleColored(curr[0], curr[1])),
+    null as null | number[]
+  )
 }


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Scanner doesn't detect other rarity(4*,3*) colors(purple, blue). Add those colors in the pipeline

## Issue or discord link

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

- https://discord.com/channels/785153694478893126/1184588581843513344

## Testing/validation

<!--- Add screenshots if possible -->

Example of a 3* artifact, detecting the header.
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/2338a828-c21a-46f7-988f-b8e133a1b039)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
