### PR TITLE
Restrict PR deployments to main repo branches only

### DIFF
--- a/.github/workflows/clean-pr.yml
+++ b/.github/workflows/clean-pr.yml
@@ -41,8 +41,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm -r ./${{ steps.build-info.outputs.deploy_path }}
           git commit -m "clean ${{ steps.build-info.outputs.deploy_path }}"
-          git push origin gh-pages
         working-directory: gh-pages
+      - name: Push commit
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 4
+          timeout_minutes: 4
+          command: |
+            cd gh-pages
+            git pull origin gh-pages
+            git push origin gh-pages
       - name: Output date
         id: output-date
         run: echo "date=$(date -u)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -76,11 +76,14 @@ jobs:
       - name: Output date
         id: output-date
         run: echo "date=$(date -u)" >> $GITHUB_OUTPUT
+      - name: Output ref
+        id: output-ref
+        run: echo "ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Maintain comment
         uses: actions-cool/maintain-one-comment@v3
         with:
           body: |
-            [${{ inputs.frontend_name }}] [${{ steps.output-date.outputs.date }}] - Building version $(git rev-parse HEAD)
+            [${{ inputs.frontend_name }}] [${{ steps.output-date.outputs.date }}] - Building version ${{ steps.output-ref.outputs.ref }}
           body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
           update-mode: 'append'
       - name: Build genshin-optimizer (Webpack)
@@ -128,6 +131,7 @@ jobs:
             git push origin gh-pages
       - name: Export url
         id: export-url
+        # First line splits the full repo name (frzyc/genshin-optimizer) into $account (frzyc) and $repo (genshin-optimizer)
         run: |
           IFS=/ read -r account repo <<< ${{ inputs.pr_repo }}
           echo "url=Deployed $(git rev-parse HEAD) to https://$account.github.io/$repo/${{ inputs.deployment_name }}/${{ inputs.frontend_name }} (Takes 3-5 minutes after this completes to be available)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions-cool/maintain-one-comment@v3
         with:
           body: |
-            [${{ inputs.frontend_name }}] [${{ steps.output-date.outputs.date }}] - Building version ${{ inputs.ref }}
+            [${{ inputs.frontend_name }}] [${{ steps.output-date.outputs.date }}] - Building version $(git rev-parse HEAD)
           body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
           update-mode: 'append'
       - name: Build genshin-optimizer (Webpack)

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,6 +2,30 @@ name: Deploy Frontend
 run-name: Deploy frontend of ${{ inputs.frontend_name }} for ${{ inputs.deployment_name }} - ${{ github.event.inputs.ref }}
 
 on:
+  workflow_dispatch:
+    inputs:
+      frontend_name:
+        description: 'Frontend type to build. Can be `frontend`, `gi-frontend` or `sr-frontend`'
+        type: string
+      repo_full_name:
+        description: 'Full repository name to build from.'
+        type: string
+        default: 'frzyc/genshin-optimizer'
+      ref:
+        description: 'Ref to build from. Can be a commit hash.'
+        type: string
+        default: 'master'
+      deployment_name:
+        description: 'Name for the deployment. This will determine the URL. If you choose a name that is already deployed, it will overwrite that deployment.'
+        type: string
+        default: 'master'
+      pr_repo:
+        description: 'Name of the repo to create the deployment on'
+        type: string
+      show_dev_components:
+        description: 'Flag to show components typically only shown in development mode, for experimental or in-progress features.'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       frontend_name:

--- a/.github/workflows/deploy-go-pando-pr.yml
+++ b/.github/workflows/deploy-go-pando-pr.yml
@@ -8,9 +8,7 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  pull_request:
     paths-ignore:
       - 'apps/frontend/**'
       - 'apps/frontend-e2e/**'
@@ -28,6 +26,8 @@ on:
 jobs:
   call-deploy-frontend:
     uses: ./.github/workflows/deploy-frontend.yml
+    # Forks don't have permission to deploy
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       frontend_name: 'gi-frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/deploy-go-pando-pr.yml
+++ b/.github/workflows/deploy-go-pando-pr.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       frontend_name: 'gi-frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-      ref: ${{ github.event.pull_request.merge_commit_sha }}
+      ref: ''
       deployment_name: ${{ github.event.number }}
       pr_repo: ${{ vars.PR_REPO }}
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/deploy-go-wr-pr.yml
+++ b/.github/workflows/deploy-go-wr-pr.yml
@@ -8,9 +8,7 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  pull_request:
     paths-ignore:
       - 'apps/gi-frontend/**'
       - 'apps/gi-frontend-e2e/**'
@@ -30,6 +28,8 @@ on:
 jobs:
   call-deploy-frontend:
     uses: ./.github/workflows/deploy-frontend.yml
+    # Forks don't have permission to deploy
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       frontend_name: 'frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/deploy-go-wr-pr.yml
+++ b/.github/workflows/deploy-go-wr-pr.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       frontend_name: 'frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-      ref: ${{ github.event.pull_request.merge_commit_sha }}
+      ref: ''
       deployment_name: ${{ github.event.number }}
       pr_repo: ${{ vars.PR_REPO }}
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/deploy-sro-pr.yml
+++ b/.github/workflows/deploy-sro-pr.yml
@@ -39,7 +39,7 @@ jobs:
     with:
       frontend_name: 'sr-frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-      ref: ${{ github.event.pull_request.merge_commit_sha }}
+      ref: ''
       deployment_name: ${{ github.event.number }}
       pr_repo: ${{ vars.PR_REPO }}
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/deploy-sro-pr.yml
+++ b/.github/workflows/deploy-sro-pr.yml
@@ -8,9 +8,7 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  pull_request:
     paths-ignore:
       - 'apps/gi-frontend/**'
       - 'apps/gi-frontend-e2e/**'
@@ -36,6 +34,8 @@ on:
 jobs:
   call-deploy-frontend:
     uses: ./.github/workflows/deploy-frontend.yml
+    # Forks don't have permission to deploy
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       frontend_name: 'sr-frontend'
       repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
* Fix #1327 

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->


## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/5bcff35d-50e4-4ddb-a50e-022d4039cfb8)
This PR is getting both the old method of deployment (red) and the new method I just added (pink). This highlights the bug we are fixing.

The old method (red) is deploying an old merge commit because it is not waiting for the newest merge commit to be ready. The new method (pink) is waiting and deploying the correct merge commit, so we don't need to trigger a double deployment.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code, in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] Ran `yarn run mini-ci` locally to validate format + lint.
- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
