### PR TITLE
Fix stat calculation stage and listing

### DIFF
--- a/libs/gi-formula/src/data/char/util.ts
+++ b/libs/gi-formula/src/data/char/util.ts
@@ -15,6 +15,7 @@ import {
   allStatics,
   customDmg,
   customShield,
+  listingItem,
   percent,
   readStat,
   self,
@@ -128,13 +129,15 @@ export function fixedShield(
 const baseStats = new Set(['atk', 'def', 'hp'])
 
 export function entriesForChar(
-  { ele, weaponType, region }: CharInfo,
+  { key, ele, weaponType, region }: CharInfo,
   { lvlCurves, ascensionBonus }: CharacterDataGen
 ): TagMapNodeEntries {
-  const specials = new Set(Object.keys(ascensionBonus))
-  specials.delete('atk')
-  specials.delete('def')
-  specials.delete('hp')
+  const specialized = new Set(
+    Object.keys(ascensionBonus) as (keyof typeof ascensionBonus)[]
+  )
+  specialized.delete('atk')
+  specialized.delete('def')
+  specialized.delete('hp')
 
   const { ascension } = self.char
   return [
@@ -156,5 +159,25 @@ export function entriesForChar(
     // Counters
     selfBuff.common.count[ele].add(1),
     ...(region !== '' ? [selfBuff.common.count[region].add(1)] : []),
+
+    // Listing (formulas)
+    selfBuff.listing.formulas.add(listingItem(self.final.hp)),
+    selfBuff.listing.formulas.add(listingItem(self.final.atk)),
+    selfBuff.listing.formulas.add(listingItem(self.final.def)),
+    selfBuff.listing.formulas.add(listingItem(self.final.eleMas)),
+    selfBuff.listing.formulas.add(listingItem(self.final.enerRech_)),
+    selfBuff.listing.formulas.add(listingItem(self.common.cappedCritRate_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.critDMG_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.heal_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.dmg_[ele])),
+    selfBuff.listing.formulas.add(listingItem(self.final.dmg_.physical)),
+
+    // Listing (specialized)
+    ...[...specialized].map((stat) =>
+      selfBuff.listing.specialized.add(
+        // Sheet-specific data (i.e., `src:<key>`)
+        listingItem(readStat(self.premod, stat).src(key))
+      )
+    ),
   ]
 }

--- a/libs/gi-formula/src/data/common/index.ts
+++ b/libs/gi-formula/src/data/common/index.ts
@@ -15,13 +15,16 @@ const data: TagMapNodeEntries = [
   reader.withTag({ src: 'iso', et: 'self' }).reread(reader.src('custom')),
   reader.withTag({ src: 'agg', et: 'self' }).reread(reader.src('custom')),
 
-  // Final <= Premod <= Base
+  // Final <= Premod <= Base + WeaponRefinement
   reader
     .withTag({ src: 'agg', et: 'self', qt: 'final' })
     .add(reader.with('qt', 'premod').sum),
   reader
     .withTag({ src: 'agg', et: 'self', qt: 'premod' })
     .add(reader.with('qt', 'base').sum),
+  reader
+    .withTag({ src: 'agg', et: 'self', qt: 'premod' })
+    .add(reader.with('qt', 'weaponRefinement').sum),
 
   // premod X += base X * premod X%
   ...(['atk', 'def', 'hp'] as const).map((s) =>

--- a/libs/gi-formula/src/data/common/prep.ts
+++ b/libs/gi-formula/src/data/common/prep.ts
@@ -15,10 +15,10 @@ const data: TagMapNodeEntries = [
     })
   ),
   selfBuff.formula.shield.add(
-    prod(self.formula.base, sum(percent(1), self.base.shield_))
+    prod(self.formula.base, sum(percent(1), self.premod.shield_))
   ),
   selfBuff.formula.heal.add(
-    prod(self.formula.base, sum(percent(1), self.base.heal_))
+    prod(self.formula.base, sum(percent(1), self.premod.heal_))
   ),
 
   // Transformative reactions

--- a/libs/gi-formula/src/data/common/reaction.ts
+++ b/libs/gi-formula/src/data/common/reaction.ts
@@ -364,7 +364,7 @@ const data: TagMapNodeEntries = [
     return variants.flatMap((ele) => {
       const name = trans === 'swirl' ? `swirl_${ele}` : trans
       return [
-        selfBuff.formula.listing.add(
+        selfBuff.listing.formulas.add(
           tag(cond, { trans, q, ele, src: 'static', name })
         ),
         selfBuff.prep.ele.name(name).add(ele),

--- a/libs/gi-formula/src/data/util/sheet.ts
+++ b/libs/gi-formula/src/data/util/sheet.ts
@@ -105,11 +105,15 @@ function registerFormula(
   ...extra: TagMapNodeEntries
 ): TagMapNodeEntries {
   reader.name(name) // register name:<name>
-  const buff = team ? teamBuff : selfBuff
+  const listing = (team ? teamBuff : selfBuff).listing.formulas
   return [
-    buff.formula.listing.add(tag(cond, { name, q })),
+    listing.add(listingItem(reader.withTag({ name, qt: 'formula', q }), cond)),
     ...extra.map(({ tag, value }) => ({ tag: { ...tag, name }, value })),
   ]
+}
+
+export function listingItem(t: Read, cond?: string | StrNode) {
+  return tag(cond ?? t.ex ?? 'unique', t.tag)
 }
 
 export function readStat(

--- a/libs/gi-formula/src/data/util/sheet.ts
+++ b/libs/gi-formula/src/data/util/sheet.ts
@@ -7,9 +7,11 @@ import type {
 import type { NumNode, StrNode } from '@genshin-optimizer/pando'
 import { prod } from '@genshin-optimizer/pando'
 import type { Source, Stat } from './listing'
+import type { Read } from './read'
 import { reader, tag } from './read'
 import { self, selfBuff, teamBuff } from './tag'
 import type { TagMapNodeEntries, TagMapNodeEntry } from './tagMapType'
+import type { StatKey } from '@genshin-optimizer/dm'
 
 // Use `registerArt` for artifacts
 export function register(
@@ -23,24 +25,6 @@ export function register(
   return data.flatMap((data) =>
     Array.isArray(data) ? data.map(internal) : internal(data)
   )
-}
-
-export function addStatCurve(key: string, value: NumNode): TagMapNodeEntry {
-  return (
-    key.endsWith('_dmg_')
-      ? selfBuff.premod['dmg_'][key.slice(0, -5) as ElementWithPhyKey]
-      : selfBuff.base[key as Stat]
-  ).add(value)
-}
-export function registerStatListing(key: string): TagMapNodeEntry {
-  const tags = key.endsWith('_dmg_')
-    ? {
-        qt: 'premod',
-        q: 'dmg_',
-        ele: key.slice(0, -5) as ElementWithPhyKey,
-      }
-    : { qt: 'base', q: key }
-  return selfBuff.formula.listing.add(tag('sum', tags))
 }
 
 export type FormulaArg = {
@@ -126,4 +110,13 @@ function registerFormula(
     buff.formula.listing.add(tag(cond, { name, q })),
     ...extra.map(({ tag, value }) => ({ tag: { ...tag, name }, value })),
   ]
+}
+
+export function readStat(
+  list: Record<Stat | 'shield_', Read>,
+  key: StatKey
+): Read {
+  return key.endsWith('_dmg_')
+    ? list['dmg_'][key.slice(0, -5) as ElementWithPhyKey]
+    : list[key as Stat]
 }

--- a/libs/gi-formula/src/data/util/tag.ts
+++ b/libs/gi-formula/src/data/util/tag.ts
@@ -133,13 +133,16 @@ export const selfTag = {
   prep: { ele: prep, move: prep, amp: prep, cata: prep, trans: prep },
   formula: {
     base: agg,
-    listing: aggStr,
     dmg: prep,
     shield: prep,
     heal: prep,
     trans: prep,
     transCrit: prep,
     swirl: prep,
+  },
+  listing: {
+    formulas: aggStr,
+    specialized: aggStr,
   },
 } as const
 export const enemyTag = {

--- a/libs/gi-formula/src/data/util/tag.ts
+++ b/libs/gi-formula/src/data/util/tag.ts
@@ -88,6 +88,7 @@ const stats: Record<Stat, Desc> = {
 } as const
 export const selfTag = {
   base: { atk: agg, def: agg, hp: agg },
+  weaponRefinement: { ...stats, shield_: agg },
   premod: { ...stats, shield_: agg },
   final: stats,
   char: {

--- a/libs/gi-formula/src/data/util/tag.ts
+++ b/libs/gi-formula/src/data/util/tag.ts
@@ -87,8 +87,8 @@ const stats: Record<Stat, Desc> = {
   heal_: agg,
 } as const
 export const selfTag = {
-  base: { ...stats, shield_: agg },
-  premod: stats,
+  base: { atk: agg, def: agg, hp: agg },
+  premod: { ...stats, shield_: agg },
   final: stats,
   char: {
     lvl: iso,
@@ -159,7 +159,7 @@ export function convert<V extends Record<string, Record<string, Desc>>>(
 ): { [j in keyof V]: { [k in keyof V[j]]: Read } } {
   return reader.withTag(tag).withAll('qt', Object.keys(v), (r, qt) =>
     r.withAll('q', Object.keys(v[qt]), (r, q) => {
-      if (!v[qt][q]) console.log(v, qt, q)
+      if (!v[qt][q]) console.error(`Invalid { qt:${qt} q:${q} }`)
       const { src, accu } = v[qt][q]
       // `tag.src` overrides `Desc`
       if (src && !tag.src) r = r.src(src)

--- a/libs/gi-formula/src/data/weapon/util.ts
+++ b/libs/gi-formula/src/data/weapon/util.ts
@@ -2,25 +2,29 @@ import { type WeaponKey } from '@genshin-optimizer/consts'
 import { allStats } from '@genshin-optimizer/gi-stats'
 import { prod, subscript } from '@genshin-optimizer/pando'
 import type { TagMapNodeEntries } from '../util'
-import { addStatCurve, allStatics, registerStatListing, self } from '../util'
+import { allStatics, readStat, self, selfBuff } from '../util'
 
 export function entriesForWeapon(key: WeaponKey): TagMapNodeEntries {
   const gen = allStats.weapon.data[key]
   const { refinement, ascension } = self.weapon
-  const specials = new Set(Object.keys(gen.ascensionBonus))
 
   return [
     // Stats
     ...gen.lvlCurves.map(({ key, base, curve }) =>
-      addStatCurve(key, prod(base, allStatics('static')[curve]))
+      (key == 'atk' ? selfBuff.base[key] : readStat(selfBuff.premod, key)).add(
+        prod(base, allStatics('static')[curve])
+      )
     ),
     ...Object.entries(gen.ascensionBonus).map(([key, values]) =>
-      addStatCurve(key, subscript(ascension, values))
+      (key == 'atk'
+        ? selfBuff.base[key]
+        : readStat(selfBuff.premod, key as keyof typeof gen.ascensionBonus)
+      ).add(subscript(ascension, values))
     ),
     ...Object.entries(gen.refinementBonus).map(([key, values]) =>
-      addStatCurve(key, subscript(refinement, values))
+      readStat(selfBuff.premod, key as keyof typeof gen.refinementBonus).add(
+        subscript(refinement, values)
+      )
     ),
-    // Listing
-    ...[...specials].map((key) => registerStatListing(key)),
   ]
 }

--- a/libs/gi-formula/src/data/weapon/util.ts
+++ b/libs/gi-formula/src/data/weapon/util.ts
@@ -22,9 +22,10 @@ export function entriesForWeapon(key: WeaponKey): TagMapNodeEntries {
       ).add(subscript(ascension, values))
     ),
     ...Object.entries(gen.refinementBonus).map(([key, values]) =>
-      readStat(selfBuff.premod, key as keyof typeof gen.refinementBonus).add(
-        subscript(refinement, values)
-      )
+      readStat(
+        selfBuff.weaponRefinement,
+        key as keyof typeof gen.refinementBonus
+      ).add(subscript(refinement, values))
     ),
   ]
 }

--- a/libs/gi-formula/src/debug.ts
+++ b/libs/gi-formula/src/debug.ts
@@ -161,7 +161,7 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
               text: `expand ${tagStr(nTag!, ex)} (${tagStr(tag!)})`,
               deps: args.map(({ meta, entryTag }) => ({
                 ...meta,
-                text: `${entryTag!.map((tag) => tagStr(tag)).join(' <- ')} <= ${
+                text: `${entryTag?.map((tag) => tagStr(tag)).join(' <- ')} <= ${
                   meta.text
                 }`,
               })),

--- a/libs/gi-formula/src/example.test.ts
+++ b/libs/gi-formula/src/example.test.ts
@@ -109,7 +109,7 @@ describe('example', () => {
         calc.compute(member1.final.eleMas).val
     )
   })
-  describe('list final formulas', () => {
+  describe('retrieve formulas in formula listing', () => {
     /**
      * Each entry in listing is a `Tag` in the shape of
      * ```
@@ -123,7 +123,9 @@ describe('example', () => {
      * }
      * ```
      */
-    const listing = calc.listFormulas(member0.formula.listing).map((x) => x.tag)
+    const listing = calc
+      .listFormulas(member0.listing.formulas)
+      .map((x) => x.tag)
 
     // Simple check that all tags are in the correct format
     const names: string[] = []
@@ -158,9 +160,9 @@ describe('example', () => {
     ])
     expect(listing.filter((x) => x.src === 'static').length).toEqual(5)
   })
-  test('calculate final formulas', () => {
+  test('calculate formulas in a listing', () => {
     const read = calc
-      .listFormulas(member0.formula.listing)
+      .listFormulas(member0.listing.formulas)
       .find((x) => x.tag.name === 'normal_0')!
     const tag = read.tag
 
@@ -203,7 +205,7 @@ describe('example', () => {
     // Step 1: Pick formula(s); anything that `calc.compute` can handle will work
     const nodes = [
       calc
-        .listFormulas(member0.formula.listing)
+        .listFormulas(member0.listing.formulas)
         .find((x) => x.tag.name === 'normal_0')!,
       member0.char.auto,
       member0.final.atk,
@@ -247,7 +249,7 @@ describe('example', () => {
   test.skip('debug formula', () => {
     // Pick formula
     const normal0 = calc
-      .listFormulas(member1.formula.listing)
+      .listFormulas(member1.listing.formulas)
       .find((x) => x.tag.name === 'normal_0')!
 
     // Use `DebugCalculator` instead of `Calculator`, same constructor

--- a/libs/gi-formula/src/executors/gen-desc/executor.ts
+++ b/libs/gi-formula/src/executors/gen-desc/executor.ts
@@ -34,8 +34,8 @@ export default async function runExecutor(
       // sheet-specific
       tag['src'] != 'agg' &&
       // formula listing
-      tag['qt'] == 'formula' &&
-      tag['q'] == 'listing' &&
+      tag['qt'] == 'listing' &&
+      tag['q'] == 'formulas' &&
       // pattern from `registerFormula`
       value['op'] == 'tag' &&
       'name' in value.tag &&

--- a/libs/gi-formula/src/util.ts
+++ b/libs/gi-formula/src/util.ts
@@ -44,8 +44,8 @@ export function charData(data: ICharacter): TagMapNodeEntries {
     constellation.add(data.constellation),
 
     // Default char
-    selfBuff.base.critRate_.add(0.05),
-    selfBuff.base.critDMG_.add(0.5),
+    selfBuff.premod.critRate_.add(0.05),
+    selfBuff.premod.critDMG_.add(0.5),
   ]
 }
 

--- a/libs/gi-stats/src/executors/gen-stats/src/weaponData.ts
+++ b/libs/gi-stats/src/executors/gen-stats/src/weaponData.ts
@@ -25,9 +25,9 @@ export type WeaponDataGen = {
   rarity: 1 | 2 | 3 | 4 | 5
   mainStat: WeaponProp
   subStat?: WeaponProp | undefined
-  lvlCurves: { key: string; base: number; curve: WeaponGrowCurveKey }[]
-  refinementBonus: { [key in string]: number[] }
-  ascensionBonus: { [key in string]: number[] }
+  lvlCurves: { key: StatKey; base: number; curve: WeaponGrowCurveKey }[]
+  refinementBonus: { [key in StatKey]?: number[] }
+  ascensionBonus: { [key in StatKey]?: number[] }
 }
 
 export default function weaponData() {
@@ -52,7 +52,7 @@ export default function weaponData() {
           if (!(key in refinementBonus))
             refinementBonus[key] = [...emptyRefinement]
           // Refinement uses 1-based index, hence the +1
-          refinementBonus[key][i + 1] += extrapolateFloat(value)
+          refinementBonus[key]![i + 1] += extrapolateFloat(value)
         }
       })
       const ascensionBonus: WeaponDataGen['ascensionBonus'] = {}
@@ -63,7 +63,7 @@ export default function weaponData() {
           const key = propTypeMap[propType]
           if (!(key in ascensionBonus))
             ascensionBonus[key] = [...emptyAscension]
-          ascensionBonus[key][i] += extrapolateFloat(value)
+          ascensionBonus[key]![i] += extrapolateFloat(value)
         }
       })
 


### PR DESCRIPTION
## Describe your changes

Current stats in `gi-formula` are added to the wrong stage of the calculation. They have been corrected to the following.

Stats for `base` stage includes
- All stats bonus from char lvl
- atk/def/hp from char ascension bonus
- atk from weapon lvl
- atk from weapon ascension

Stats for `premod` stage include
- All stats (except atk/def/hp) from char ascension bonus
- All stats (except atk) from weapon lvl
- All stats (except atk) from weapon ascension
- All stats from weapon refinement
  - These stats are added into a separate stage `weaponRefinement` stage, which is then added to `premod`

I also update the listings from `registerStatListing` to a more general `<listing node>.add(<listing item>)` to be more in line with other `TagMapEntries`.

## Issue or discord link

https://discord.com/channels/785153694478893126/1189329506842984570/1189330901990125658

## Testing/validation

Unit tests

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [X] I have commented my code, in hard-to understand areas.
- [X] I have made corresponding changes to README or wiki.
- [X] For front-end changes, I have updated the corresponding English translations.
- [X] Ran `yarn run mini-ci` locally to validate format + lint.
- [X] If there were format issues, I ran `nx format write` to resolve them automatically.
