### PR TITLE
Minor gi-formula bug fix

### DIFF
--- a/libs/gi-formula/src/data/common/reaction.ts
+++ b/libs/gi-formula/src/data/common/reaction.ts
@@ -365,7 +365,7 @@ const data: TagMapNodeEntries = [
       const name = trans === 'swirl' ? `swirl_${ele}` : trans
       return [
         selfBuff.listing.formulas.add(
-          tag(cond, { trans, q, ele, src: 'static', name })
+          tag(cond, { trans, qt: 'formula', q, ele, src: 'static', name })
         ),
         selfBuff.prep.ele.name(name).add(ele),
       ]

--- a/libs/gi-formula/src/data/weapon/util.ts
+++ b/libs/gi-formula/src/data/weapon/util.ts
@@ -40,16 +40,14 @@ export function entriesForWeapon(key: WeaponKey): TagMapNodeEntries {
       )
     ),
     ...[...Object.keys(gen.refinementBonus)].map((stat) =>
-      self.listing.specialized
-        .src(key)
-        .add(
-          listingItem(
-            readStat(
-              self.weaponRefinement,
-              stat as keyof typeof gen.refinementBonus
-            )
-          )
+      self.listing.specialized.add(
+        listingItem(
+          readStat(
+            self.weaponRefinement,
+            stat as keyof typeof gen.refinementBonus
+          ).src(key)
         )
+      )
     ),
   ]
 }


### PR DESCRIPTION
## Describe your changes

Fix a minor bug where `calc.compute` will crash on formulas in listings if they contain reaction formulas, and another minor bug that causes refinement bonus not to appear in `specialized` listing.

## Issue or discord link

- https://discord.com/channels/785153694478893126/1189329506842984570/1189699415393452133

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code, in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [x] If there were format issues, I ran `nx format write` to resolve them automatically.
