### PR TITLE
fix bad numbers used in build generation

### DIFF
--- a/apps/frontend/src/app/Formula/api.tsx
+++ b/apps/frontend/src/app/Formula/api.tsx
@@ -12,6 +12,7 @@ import {
   layeredAssignment,
   objKeyMap,
   objPathValue,
+  toDecimal,
 } from '@genshin-optimizer/util'
 import type { ICachedArtifact } from '../Types/artifact'
 import type { ICachedCharacter } from '../Types/character'
@@ -74,16 +75,16 @@ function dataObjForArtifact(
   const stats: [ArtifactSetKey | MainStatKey | SubstatKey, number][] = []
   stats.push([art.mainStatKey, mainStatVal])
   art.substats.forEach(
-    ({ key, accurateValue }) => key && stats.push([key, accurateValue])
+    ({ key, accurateValue }) =>
+      key && stats.push([key, toDecimal(accurateValue, key)])
   )
   return {
     art: {
       ...Object.fromEntries(
-        stats.map(([key, value]) =>
-          key.endsWith('_')
-            ? [key, percent(value / 100)]
-            : [key, constant(value)]
-        )
+        stats.map(([key, value]) => [
+          key,
+          key.endsWith('_') ? percent(value) : constant(value),
+        ])
       ),
       [art.slotKey]: {
         id: constant(art.id),

--- a/libs/util/src/lib/number.ts
+++ b/libs/util/src/lib/number.ts
@@ -10,6 +10,10 @@ export function toPercent(number: number, statKey: string) {
   if (statKey.endsWith('_')) return number * 100
   return number
 }
+export function toDecimal(number: number, statKey: string) {
+  if (statKey.endsWith('_')) return number / 100
+  return number
+}
 export function within(val: number, a: number, b: number, inclusive = true) {
   if (inclusive) return val >= a && val <= b
   return val > a && val < b


### PR DESCRIPTION
## Describe your changes
Changes added in https://github.com/frzyc/genshin-optimizer/pull/1395 use decimal numbers, instead of the original percent numbers. This change simplifies so that only decimal numbers are used.
<!--- Provide a general summary of your changes -->

## Issue or discord link

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

- https://discord.com/channels/785153694478893126/1187852254091423875/1190159488129445988

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code, in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] Ran `yarn run mini-ci` locally to validate format + lint.
- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
