### PR TITLE
Fix Faruzan A4 CD being rounded

### DIFF
--- a/apps/frontend/src/app/Data/Characters/Faruzan/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/Faruzan/index.tsx
@@ -350,6 +350,7 @@ const sheet: ICharacterSheet = {
                 text: stg('cd'),
                 value: datamine.passive2.cd,
                 unit: 's',
+                fixed: 1,
               },
             ],
           },


### PR DESCRIPTION
## Describe your changes

* Fix Faruzan A4 to show 0.8s instead of 1s

## Issue or discord link

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

-

## Testing/validation

<!--- Add screenshots if possible -->
<img width="192" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/36019388/7fd400a3-3685-4bdd-a2aa-063526f78957">


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code, in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] Ran `yarn run mini-ci` locally to validate format + lint.
- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
