### PR TITLE
Fix : 1 star weapons show NaN as a secondary stat 

### DIFF
--- a/apps/frontend/src/app/Components/Weapon/WeaponFullCard.tsx
+++ b/apps/frontend/src/app/Components/Weapon/WeaponFullCard.tsx
@@ -68,7 +68,7 @@ export default function WeaponFullCard({ weaponId }: { weaponId: string }) {
   )
 }
 function WeaponStat({ node }: { node: NodeDisplay }) {
-  return (
+  return Number.isNaN(node.value) ? null : (
     <SqBadge color="secondary">
       {node.info.icon} {nodeVStr(node)}
     </SqBadge>

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -265,7 +265,7 @@ export default function ChartCard({
           )}
         </Grid>
       </CardContent>
-      {displayData && displayData.length && <Divider />}
+      {displayData && !!displayData.length && <Divider />}
       {chartData && displayData && !!displayData.length && (
         <CardContent>
           <Collapse in={!!downloadData && showDownload}>


### PR DESCRIPTION
## Describe your changes

1. Fix 1 star weapons showing NaN as a secondary stat 
2. Fix Graph shows single '0' if you there are no builds 

## Issue or discord link

Resolves https://github.com/frzyc/genshin-optimizer/issues/1441
https://discord.com/channels/785153694478893126/1145686734990999593

## Testing/validation

Tested locally

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code, in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] Ran `yarn run mini-ci` locally to validate format + lint.
- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
