### PR TITLE
Fix issue with Raiden A4 + Min constraints

### DIFF
--- a/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
@@ -17,9 +17,9 @@ import {
 } from '../../../Formula/utils'
 import { cond, st, stg } from '../../SheetUtil'
 import CharacterSheet from '../CharacterSheet'
+import type { ICharacterSheet } from '../ICharacterSheet.d'
 import { charTemplates } from '../charTemplates'
 import { customDmgNode, dataObjForCharacterSheet, dmgNode } from '../dataUtil'
-import type { ICharacterSheet } from '../ICharacterSheet.d'
 
 const key: CharacterKey = 'RaidenShogun'
 const data_gen = allStats.char.data[key]
@@ -178,14 +178,20 @@ function burstResolve(mvArr: number[], initial = false) {
   )
 }
 
-const a4EnergyRestore_ = greaterEq(
-  input.asc,
-  4,
-  prod(
-    sum(input.total.enerRech_, percent(-dm.passive2.er)),
-    percent(dm.passive2.energyGen),
-    100
-  )
+const a4EnergyRestore_ = infoMut(
+  greaterEq(
+    input.asc,
+    4,
+    prod(
+      sum(input.total.enerRech_, percent(-dm.passive2.er)),
+      percent(dm.passive2.energyGen),
+      100
+    )
+  ),
+  {
+    name: ct.ch('a4.enerRest'),
+    unit: '%',
+  }
 )
 
 const [condC4Path, condC4] = cond(key, 'c4')
@@ -245,14 +251,7 @@ const dmgFormulas = {
         100
       )
     ),
-    energyRestore: greaterEq(
-      input.asc,
-      4,
-      infoMut(a4EnergyRestore_, {
-        name: ct.ch('a4.enerRest'),
-        unit: '%',
-      })
-    ),
+    energyRestore: a4EnergyRestore_,
   },
 }
 const nodeC3 = greaterEq(input.constellation, 3, 3)


### PR DESCRIPTION
## Describe your changes

Fix issue where Raiden A4 energy restore stat constraint was not being divided by 100 on worker-side. So 1% on UI would translate to 100% minimum when optimizing.

Caused by the info being applied to the inner node. This propagates up on the display side to the top-most node, but does not propagate on the worker-side. Therefore, the display side was showing the % symbol as expected, but the worker side was not able to see this same info at the top level

## Issue or discord link

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

- https://discord.com/channels/785153694478893126/1200775231384584223

## Testing/validation

<!--- Add screenshots if possible -->
Tested by optimizing with 10% min before the change. This returned 0 builds. Then optimized with 10% min after the change, and was able to get builds. Also optimized with 100% min and saw builds with > 100% regen

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code, in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] Ran `yarn run mini-ci` locally to validate format + lint.
- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
