### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,7 @@
 
 ## Issue or discord link
 
-<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->
-
--
+- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->
 
 ## Testing/validation
 
@@ -14,9 +12,8 @@
 
 ## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)
 
-- [ ] I have commented my code, in hard-to understand areas.
+- [ ] I have commented my code in hard-to understand areas.
 - [ ] I have made corresponding changes to README or wiki.
 - [ ] For front-end changes, I have updated the corresponding English translations.
-- [ ] Ran `yarn run mini-ci` locally to validate format + lint.
-- [ ] If there were format issues, I ran `nx format write` to resolve them automatically.
+- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
 - [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


### PR DESCRIPTION
## Describe your changes

This removes `format write` from PR template checklist. The command `yarn run mini-ci` already runs `format write` as well as fixing any formatting issues. So it is entirely unneceassary.

## Issue or discord link

- https://discord.com/channels/785153694478893126/819643218446254100/1197645013350350928

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [X] I have commented my code in hard-to understand areas.
- [X] I have made corresponding changes to README or wiki.
- [X] For front-end changes, I have updated the corresponding English translations.
- [X] I have run `yarn run mini-ci` locally to validate format and lint.
- [X] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
