### PR TITLE
fix talents order in gcsim button

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTheorycraft/GcsimButton.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabTheorycraft/GcsimButton.tsx
@@ -55,7 +55,7 @@ export default function GcsimButton({ disabled }: { disabled: boolean }) {
       level,
       ascension,
       constellation,
-      talent: { auto, burst, skill },
+      talent: { auto, skill, burst },
     },
   } = useContext(CharacterContext)
   const {
@@ -103,7 +103,7 @@ export default function GcsimButton({ disabled }: { disabled: boolean }) {
 # Character
 ${charKeyLow} char lvl=${level}/${
     ascensionMaxLevel[ascension]
-  } cons=${constellation} talent=${auto},${burst},${skill};
+  } cons=${constellation} talent=${auto},${skill},${burst};
 
 # Weapon
 ${charKeyLow} add weapon="${weaponKey.toLowerCase()}" refine=${wRefinement} lvl=${wLevel}/${


### PR DESCRIPTION
## Describe your changes

- Rearranges talents order when exporting to gcsim in order to match gcsim's ordering

## Issue or discord link

- Resolves #1480

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
