### PR TITLE
Remove disableSlot in favor of fixedSlotKey in ArtifactEditor props

### DIFF
--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
@@ -142,7 +142,7 @@ export default function ArtifactEditor({
   allowUpload = false,
   allowEmpty = false,
   disableSet = false,
-  fixedSlotKey = undefined,
+  fixedSlotKey,
 }: ArtifactEditorProps) {
   const queueRef = useRef(
     new ScanningQueue(textsFromImage, shouldShowDevComponents)

--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
@@ -255,8 +255,7 @@ export default function ArtifactEditor({
         // value (e.g. when creating a new artifact from the artifact swap UI). If neither, then we default to
         // 'flower'.
         newValue.slotKey =
-          artifact?.slotKey ??
-          (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
+          artifact?.slotKey ?? (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
       }
       if (newValue.rarity) newValue.level = artifact?.level ?? 0
       if (newValue.level)
@@ -294,10 +293,7 @@ export default function ArtifactEditor({
   const { rarity = 5, level = 0 } = artifact ?? {}
   // Same as above when assigning newValue.slotKey in update.
   const slotKey = useMemo(() => {
-    return (
-      artifact?.slotKey ??
-      (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
-    )
+    return artifact?.slotKey ?? (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
   }, [fixedSlotKey, artifact])
   const { currentEfficiency = 0, maxEfficiency = 0 } = cArtifact
     ? Artifact.getArtifactEfficiency(cArtifact, allSubstatFilter)

--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
@@ -134,7 +134,6 @@ export type ArtifactEditorProps = {
   allowUpload?: boolean
   allowEmpty?: boolean
   disableSet?: boolean
-  disableSlot?: boolean
   fixedSlotKey?: ArtifactSlotKey | ''
 }
 export default function ArtifactEditor({
@@ -143,7 +142,6 @@ export default function ArtifactEditor({
   allowUpload = false,
   allowEmpty = false,
   disableSet = false,
-  disableSlot = false,
   fixedSlotKey = '',
 }: ArtifactEditorProps) {
   const queueRef = useRef(
@@ -178,7 +176,7 @@ export default function ArtifactEditor({
   const queueTotal = processedNum + outstandingNum + scanningNum
   const disableEditSlot =
     (!['new', ''].includes(artifactIdToEdit) && !!artifact?.location) ||
-    disableSlot
+    fixedSlotKey !== ''
 
   const uploadFiles = useCallback(
     (files?: FileList | null) => {
@@ -258,7 +256,7 @@ export default function ArtifactEditor({
         // 'flower'.
         newValue.slotKey =
           artifact?.slotKey ??
-          (disableSlot && fixedSlotKey !== '' ? fixedSlotKey : 'flower')
+          (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
       }
       if (newValue.rarity) newValue.level = artifact?.level ?? 0
       if (newValue.level)
@@ -282,7 +280,7 @@ export default function ArtifactEditor({
       }
       artifactDispatch({ type: 'update', artifact: newValue })
     },
-    [artifact, sheet, artifactDispatch, disableSlot, fixedSlotKey]
+    [artifact, sheet, artifactDispatch, fixedSlotKey]
   )
   const setSubstat = useCallback(
     (index: number, substat: ISubstat) => {
@@ -298,9 +296,9 @@ export default function ArtifactEditor({
   const slotKey = useMemo(() => {
     return (
       artifact?.slotKey ??
-      (disableSlot && fixedSlotKey !== '' ? fixedSlotKey : 'flower')
+      (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
     )
-  }, [disableSlot, fixedSlotKey, artifact])
+  }, [fixedSlotKey, artifact])
   const { currentEfficiency = 0, maxEfficiency = 0 } = cArtifact
     ? Artifact.getArtifactEfficiency(cArtifact, allSubstatFilter)
     : {}

--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
@@ -134,7 +134,7 @@ export type ArtifactEditorProps = {
   allowUpload?: boolean
   allowEmpty?: boolean
   disableSet?: boolean
-  fixedSlotKey?: ArtifactSlotKey | ''
+  fixedSlotKey?: ArtifactSlotKey
 }
 export default function ArtifactEditor({
   artifactIdToEdit = '',
@@ -142,7 +142,7 @@ export default function ArtifactEditor({
   allowUpload = false,
   allowEmpty = false,
   disableSet = false,
-  fixedSlotKey = '',
+  fixedSlotKey = undefined,
 }: ArtifactEditorProps) {
   const queueRef = useRef(
     new ScanningQueue(textsFromImage, shouldShowDevComponents)
@@ -176,7 +176,7 @@ export default function ArtifactEditor({
   const queueTotal = processedNum + outstandingNum + scanningNum
   const disableEditSlot =
     (!['new', ''].includes(artifactIdToEdit) && !!artifact?.location) ||
-    fixedSlotKey !== ''
+    !!fixedSlotKey
 
   const uploadFiles = useCallback(
     (files?: FileList | null) => {
@@ -254,8 +254,7 @@ export default function ArtifactEditor({
         // Otherwise, if slot selection is disabled but a key has been provided in fixedSlotKey, we assign that
         // value (e.g. when creating a new artifact from the artifact swap UI). If neither, then we default to
         // 'flower'.
-        newValue.slotKey =
-          artifact?.slotKey ?? (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
+        newValue.slotKey = artifact?.slotKey ?? fixedSlotKey ?? 'flower'
       }
       if (newValue.rarity) newValue.level = artifact?.level ?? 0
       if (newValue.level)
@@ -293,7 +292,7 @@ export default function ArtifactEditor({
   const { rarity = 5, level = 0 } = artifact ?? {}
   // Same as above when assigning newValue.slotKey in update.
   const slotKey = useMemo(() => {
-    return artifact?.slotKey ?? (fixedSlotKey !== '' ? fixedSlotKey : 'flower')
+    return artifact?.slotKey ?? fixedSlotKey ?? 'flower'
   }, [fixedSlotKey, artifact])
   const { currentEfficiency = 0, maxEfficiency = 0 } = cArtifact
     ? Artifact.getArtifactEfficiency(cArtifact, allSubstatFilter)

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -296,7 +296,7 @@ function CompareArtifactModal({
               canEquip
               editorProps={{
                 disableSet: true,
-                fixedSlotKey: newArtifact?.slotKey ?? '',
+                fixedSlotKey: newArtifact?.slotKey,
               }}
             />
             {newArtifact && <ArtInclusionButton id={newId} />}

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -242,6 +242,7 @@ function CompareArtifactModal({
   }, [newId, database, characterKey, onClose])
   const newLoc = database.arts.get(newId)?.location ?? ''
   const newArtifact = useArtifact(newId)
+  const oldArtifact = useArtifact(oldId)
 
   const deleteArtifact = useCallback(
     (id: string) => database.arts.remove(id),
@@ -270,7 +271,7 @@ function CompareArtifactModal({
                 onDelete={deleteArtifact}
                 mainStatAssumptionLevel={mainStatAssumptionLevel}
                 canEquip
-                editorProps={{ disableSet: true, disableSlot: true }}
+                editorProps={{ disableSet: true, fixedSlotKey: oldArtifact.slotKey }}
               />
               <ArtInclusionButton id={oldId} />
             </Box>
@@ -290,7 +291,7 @@ function CompareArtifactModal({
               onDelete={deleteArtifact}
               mainStatAssumptionLevel={mainStatAssumptionLevel}
               canEquip
-              editorProps={{ disableSet: true, disableSlot: true }}
+              editorProps={{ disableSet: true, fixedSlotKey: newArtifact?.slotKey ?? '' }}
             />
             {newArtifact && <ArtInclusionButton id={newId} />}
             {newLoc &&

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -271,7 +271,10 @@ function CompareArtifactModal({
                 onDelete={deleteArtifact}
                 mainStatAssumptionLevel={mainStatAssumptionLevel}
                 canEquip
-                editorProps={{ disableSet: true, fixedSlotKey: oldArtifact.slotKey }}
+                editorProps={{
+                  disableSet: true,
+                  fixedSlotKey: oldArtifact.slotKey,
+                }}
               />
               <ArtInclusionButton id={oldId} />
             </Box>
@@ -291,7 +294,10 @@ function CompareArtifactModal({
               onDelete={deleteArtifact}
               mainStatAssumptionLevel={mainStatAssumptionLevel}
               canEquip
-              editorProps={{ disableSet: true, fixedSlotKey: newArtifact?.slotKey ?? '' }}
+              editorProps={{
+                disableSet: true,
+                fixedSlotKey: newArtifact?.slotKey ?? '',
+              }}
             />
             {newArtifact && <ArtInclusionButton id={newId} />}
             {newLoc &&

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOverview/ArtifactSwapModal.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOverview/ArtifactSwapModal.tsx
@@ -158,7 +158,6 @@ export default function ArtifactSwapModal({
             cancelEdit={onHideEditor}
             allowUpload
             allowEmpty
-            disableSlot
             fixedSlotKey={filterOption.slotKeys[0]}
           />
         </Suspense>


### PR DESCRIPTION
## Describe your changes
- Removed `disableSlot` from `ArtifactEditor` props in favor of using `fixedSlotKey`
- Updated all locations where `disableSlot` was set to `true` to pass in the specific slot to lock the selector to
<!--- Provide a general summary of your changes -->

## Issue or discord link

- Follow-up to #1501<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
I've manually checked the artifact editor UI where present and confirmed the artifact slot is locked correctly when either editing an existing artifact or creating a new artifact from the artifact swap UI and that the slot can be freely selected otherwise.
<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
