### PR TITLE
Fix the optimization graph disappearing

### DIFF
--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -88,7 +88,7 @@ export default function ChartCard({
     (_e: unknown, value: number | number[]) => {
       if (typeof value === 'number') throw new TypeError()
       const [l, h] = value
-      if (l >= h) return
+      if (l == h) return
       setSliderLow(l)
       setSliderHigh(h)
     },
@@ -270,8 +270,8 @@ export default function ChartCard({
           )}
         </Grid>
       </CardContent>
-      {displayData && !!displayData.length && <Divider />}
-      {chartData && displayData && !!displayData.length && (
+      {chartData && !!chartData.data.length && <Divider />}
+      {chartData && !!chartData.data.length && displayData && (
         <CardContent>
           <Collapse in={!!downloadData && showDownload}>
             <CardDark sx={{ mb: 2 }}>
@@ -293,7 +293,7 @@ export default function ChartCard({
             valueNode={chartData.valueNode}
             showMin={showMin}
           />
-          {displayData.length > 1 && (
+          {chartData.data.length > 1 && (
             <Slider
               marks
               value={[sliderLow, sliderHigh]}

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -88,6 +88,7 @@ export default function ChartCard({
     (_e: unknown, value: number | number[]) => {
       if (typeof value === 'number') throw new TypeError()
       const [l, h] = value
+      if (l >= h) return
       setSliderLow(l)
       setSliderHigh(h)
     },

--- a/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/apps/frontend/src/app/PageCharacter/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -88,7 +88,7 @@ export default function ChartCard({
     (_e: unknown, value: number | number[]) => {
       if (typeof value === 'number') throw new TypeError()
       const [l, h] = value
-      if (l == h) return
+      if (l === h) return
       setSliderLow(l)
       setSliderHigh(h)
     },


### PR DESCRIPTION
## Describe your changes

Fixes a bug where the graph and/or the slider would disappear when the two slider ends would meet.

This was caused by the graph and slider not being drawn when there was no filtered display data, even though they should only be hidden when there is no data at all, or, in the case of the slider when there are less than 2 data points.

## Issue or discord link

[Discord thread](https://discord.com/channels/785153694478893126/1207766463671312384)

## Testing/validation

### Before:
https://github.com/frzyc/genshin-optimizer/assets/20338170/60b32d41-0bb8-4257-bf50-ce9d4fdabf63

https://github.com/frzyc/genshin-optimizer/assets/20338170/7980a2ac-4f64-4ba9-b967-73b38b0cb9e7
### After:
https://github.com/frzyc/genshin-optimizer/assets/20338170/c9af2a9f-8e5b-47bc-8b59-cca4414f46c3

https://github.com/frzyc/genshin-optimizer/assets/20338170/16815ded-0878-476c-be02-45a21c00a367

The correct behavior of hiding the graph when there are no data points is also kept:
![firefox_iPDqUEDAWK](https://github.com/frzyc/genshin-optimizer/assets/20338170/c18ca380-6e20-4b4f-83d0-37ed8b5ae3f4)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
