### PR TITLE
Fix dev server translations

### DIFF
--- a/apps/frontend/vite.config.mts
+++ b/apps/frontend/vite.config.mts
@@ -53,8 +53,8 @@ export default defineConfig({
           dest: 'assets',
         },
         {
-          src: normalizePath(resolve('apps/frontend/assets')),
-          dest: '',
+          src: normalizePath(resolve('apps/frontend/assets/*')),
+          dest: 'assets',
         },
       ],
       // Force page to reload if we change any of the above files


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Change static copy plugin to copy the contents of the `assets` folder, rather than the folder itself. Seems somehow the static copy would just overwrite the `assets` folder but only on the dev server.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Ran dev server locally and translations loaded as expected<!--- Add screenshots if possible -->


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
