### PR TITLE
Add functionality to sort teams based on "recently edited" or "name"

### DIFF
--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -56,7 +56,7 @@ export default function PageTeam() {
     database.teams.set(teamId, { lastEdit: Date.now() })
   }, [teamId, database.teams, invalidKey])
 
-  if (invalidKey) return <Navigate to="/characters" />
+  if (invalidKey) return <Navigate to="/teams" />
 
   return (
     <Box my={1} display="flex" flexDirection="column" gap={1}>

--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -49,10 +49,14 @@ export default function PageTeam() {
   const onClose = useCallback(() => navigate('/teams'), [navigate])
   const { teamId } = useParams<{ teamId?: string }>()
   const invalidKey = !database.teams.keys.includes(teamId)
-  if (invalidKey) return <Navigate to="/characters" />
 
   // An edit is triggered whenever a team gets opened even if no edits are done
-  database.teams.set(teamId, { lastEdit: Date.now() })
+  useEffect(() => {
+    if (invalidKey) return
+    database.teams.set(teamId, { lastEdit: Date.now() })
+  }, [teamId, database.teams, invalidKey])
+
+  if (invalidKey) return <Navigate to="/characters" />
 
   return (
     <Box my={1} display="flex" flexDirection="column" gap={1}>

--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -51,6 +51,9 @@ export default function PageTeam() {
   const invalidKey = !database.teams.keys.includes(teamId)
   if (invalidKey) return <Navigate to="/characters" />
 
+  // An edit is triggered whenever a team gets opened even if no edits are done
+  database.teams.set(teamId, { lastEdit: Date.now() })
+
   return (
     <Box my={1} display="flex" flexDirection="column" gap={1}>
       <Suspense

--- a/apps/frontend/src/app/PageTeams/TeamSort.ts
+++ b/apps/frontend/src/app/PageTeams/TeamSort.ts
@@ -1,0 +1,14 @@
+import type { SortConfigs } from '@genshin-optimizer/common/util'
+import type { Team, TeamSortKey } from '@genshin-optimizer/gi/db'
+
+export function teamSortConfigs(): SortConfigs<TeamSortKey, Team> {
+  return {
+    name: (team) => team.name ?? '',
+    lastEdit: (team) => team.lastEdit ?? 0,
+  }
+}
+
+export const teamSortMap: Record<TeamSortKey, TeamSortKey[]> = {
+  name: ['name', 'lastEdit'],
+  lastEdit: ['lastEdit'],
+}

--- a/apps/frontend/src/app/PageTeams/index.tsx
+++ b/apps/frontend/src/app/PageTeams/index.tsx
@@ -20,6 +20,7 @@ import {
 import { Suspense, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import TeamCard from './TeamCard'
+import SortByButton from '../Components/SortByButton'
 const columns = { xs: 1, sm: 2, md: 3, lg: 4, xl: 4 }
 
 // TODO: Translation
@@ -56,8 +57,33 @@ export default function PageTeams() {
       return
     }
   }
+
+  const sortByButtonProps = {
+    sortKeys: [],
+    value: 'NA',
+    onChange: (value) => value,
+    ascending: true,
+    onChangeAsc: (value) => value,
+  }
+
   return (
     <Box my={1} display="flex" flexDirection="column" gap={1}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+        }}
+      >
+        {/* May use `PageAndSortOptionSelect` to add multiple pages and filter count later */}
+        <SortByButton
+          sortKeys={sortByButtonProps.sortKeys}
+          value={sortByButtonProps.value}
+          onChange={(value) => sortByButtonProps.onChange(value)}
+          ascending={sortByButtonProps.ascending}
+          onChangeAsc={sortByButtonProps.onChangeAsc}
+        />
+      </Box>
       <Box sx={{ display: 'flex', gap: 1 }}>
         <Button fullWidth onClick={onAdd} color="info" startIcon={<AddIcon />}>
           Add Team

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -8,6 +8,7 @@ import { DisplayCharacterEntry } from './DataEntries/DisplayCharacterEntry'
 import { DisplayOptimizeEntry } from './DataEntries/DisplayOptimizeEntry'
 import { DisplayToolEntry } from './DataEntries/DisplayTool'
 import { DisplayWeaponEntry } from './DataEntries/DisplayWeaponEntry'
+import { DisplayTeamEntry } from './DataEntries/DisplayTeamEntry'
 import { ArtifactDataManager } from './DataManagers/ArtifactDataManager'
 import { BuildDataManager } from './DataManagers/BuildDataManager'
 import { BuildTcDataManager } from './DataManagers/BuildTcDataManager'
@@ -37,6 +38,7 @@ export class ArtCharDatabase extends Database {
   displayOptimize: DisplayOptimizeEntry
   displayCharacter: DisplayCharacterEntry
   displayTool: DisplayToolEntry
+  displayTeam: DisplayTeamEntry
   dbIndex: 1 | 2 | 3 | 4
   dbVer: number
 
@@ -81,7 +83,8 @@ export class ArtCharDatabase extends Database {
     this.displayOptimize = new DisplayOptimizeEntry(this)
     this.displayCharacter = new DisplayCharacterEntry(this)
     this.displayTool = new DisplayToolEntry(this)
-
+    this.displayTeam = new DisplayTeamEntry(this)
+    
     // invalidates character when things change.
     this.chars.followAny(() => {
       this.dbMeta.set({ lastEdit: Date.now() })
@@ -115,6 +118,7 @@ export class ArtCharDatabase extends Database {
       this.displayOptimize,
       this.displayCharacter,
       this.displayTool,
+      this.displayTeam,
     ] as const
   }
 

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -84,7 +84,7 @@ export class ArtCharDatabase extends Database {
     this.displayCharacter = new DisplayCharacterEntry(this)
     this.displayTool = new DisplayToolEntry(this)
     this.displayTeam = new DisplayTeamEntry(this)
-    
+
     // invalidates character when things change.
     this.chars.followAny(() => {
       this.dbMeta.set({ lastEdit: Date.now() })

--- a/libs/gi/db/src/Database/DataEntries/DisplayTeamEntry.ts
+++ b/libs/gi/db/src/Database/DataEntries/DisplayTeamEntry.ts
@@ -1,0 +1,40 @@
+import { DataEntry } from '../DataEntry'
+import type { ArtCharDatabase } from '../ArtCharDatabase'
+
+export const teamSortKeys = ['name', 'lastEdit'] as const
+export type TeamSortKey = (typeof teamSortKeys)[number]
+
+export type IDisplayTeamEntry = {
+  ascending: boolean
+  sortType: TeamSortKey
+}
+
+function initialState(): IDisplayTeamEntry {
+  return {
+    ascending: false,
+    sortType: teamSortKeys[0],
+  }
+}
+
+export class DisplayTeamEntry extends DataEntry<
+  'display_team',
+  'display_team',
+  IDisplayTeamEntry,
+  IDisplayTeamEntry
+> {
+  constructor(database: ArtCharDatabase) {
+    super(database, 'display_team', initialState, 'display_team')
+  }
+  override validate(obj: unknown): IDisplayTeamEntry | undefined {
+    if (typeof obj !== 'object') return undefined
+    let { ascending, sortType } = obj as IDisplayTeamEntry
+
+    if (typeof ascending !== 'boolean') ascending = false
+    if (!teamSortKeys.includes(sortType)) sortType = teamSortKeys[0]
+
+    return {
+      ascending,
+      sortType,
+    } as IDisplayTeamEntry
+  }
+}

--- a/libs/gi/db/src/Database/DataEntries/index.ts
+++ b/libs/gi/db/src/Database/DataEntries/index.ts
@@ -3,6 +3,7 @@ import {
   type CharacterSortKey,
 } from './DisplayCharacterEntry'
 import type { TimeZoneKey } from './DisplayTool'
+import { teamSortKeys, type TeamSortKey } from './DisplayTeamEntry'
 import { RESIN_MAX, timeZones } from './DisplayTool'
-export { RESIN_MAX, characterSortKeys, timeZones }
-export type { CharacterSortKey, TimeZoneKey }
+export { RESIN_MAX, characterSortKeys, timeZones, teamSortKeys }
+export type { CharacterSortKey, TimeZoneKey, TeamSortKey }

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -14,6 +14,7 @@ export interface Team {
   >
 
   teamCharIds: string[]
+  lastEdit: number
 }
 
 export class TeamDataManager extends DataManager<
@@ -91,7 +92,7 @@ function validateTeam(
   obj: unknown = {},
   database: ArtCharDatabase
 ): Team | undefined {
-  let { name, description, enemyOverride, teamCharIds } = obj as Team
+  let { name, description, enemyOverride, teamCharIds, lastEdit } = obj as Team
   if (typeof name !== 'string') name = 'Team Name'
   if (typeof description !== 'string') description = 'Team Description'
 
@@ -102,6 +103,8 @@ function validateTeam(
     enemyOverride = {}
 
   if (!Array.isArray(teamCharIds)) teamCharIds = []
+
+  if (typeof lastEdit !== 'number') lastEdit = Date.now()
   else {
     const charIds = database.teamChars.keys
     teamCharIds = teamCharIds.filter((id) => charIds.includes(id))
@@ -113,5 +116,6 @@ function validateTeam(
     description,
     enemyOverride,
     teamCharIds,
+    lastEdit,
   }
 }

--- a/libs/gi/localization/assets/locales/en/ui.json
+++ b/libs/gi/localization/assets/locales/en/ui.json
@@ -40,7 +40,8 @@
     "artsetkey": "Artifact Set",
     "efficiency": "Current RV",
     "mefficiency": "Maximum RV",
-    "probability": "Roll Probability"
+    "probability": "Roll Probability",
+    "lastEdit": "Recently Edited"
   },
   "delete": "Delete",
   "locked": "Locked",


### PR DESCRIPTION
## Describe your changes

Add functionality to sort teams based on "recently edited" or "name".

### Few Notes
* "recently edited" implementation basically gets triggered whenever team card gets opened even if no real edit happens.
* I added translation for `lastEdit` in english only

## Issue or discord link

* Resolves #1532

## Testing/validation

![_1500X703@24](https://github.com/frzyc/genshin-optimizer/assets/44922829/fe4e3504-4660-40ba-a0aa-f23cf1adee94)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
