### PR TITLE
Implement character-specific navigation for teamcard

### DIFF
--- a/apps/frontend/src/app/PageTeams/TeamCard.tsx
+++ b/apps/frontend/src/app/PageTeams/TeamCard.tsx
@@ -29,7 +29,7 @@ export default function TeamCard({
 }: {
   teamId: string
   bgt?: 'light' | 'dark'
-  onClick: (cid: CharacterKey) => void
+  onClick: (cid?: CharacterKey) => void
   disableButtons?: boolean
 }) {
   const team = useTeam(teamId)
@@ -94,7 +94,9 @@ export default function TeamCard({
                     />
                   </CardActionArea>
                 ) : (
-                  <BlankCharacterCardPico index={i} />
+                  <CardActionArea onClick={() => onClick()}>
+                    <BlankCharacterCardPico index={i} />
+                  </CardActionArea>
                 )}
               </Grid>
             ))}

--- a/apps/frontend/src/app/PageTeams/TeamCard.tsx
+++ b/apps/frontend/src/app/PageTeams/TeamCard.tsx
@@ -1,5 +1,6 @@
 import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
 import { range } from '@genshin-optimizer/common/util'
+import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import { useDatabase, useTeam } from '@genshin-optimizer/gi/db-ui'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
@@ -28,7 +29,7 @@ export default function TeamCard({
 }: {
   teamId: string
   bgt?: 'light' | 'dark'
-  onClick: () => void
+  onClick: (cid: CharacterKey) => void
   disableButtons?: boolean
 }) {
   const team = useTeam(teamId)
@@ -62,49 +63,44 @@ export default function TeamCard({
         flexDirection: 'column',
       }}
     >
-      <CardActionArea
-        onClick={onClick}
+      <Box
         sx={{
+          height: '100%',
+          p: 1,
           display: 'flex',
           flexDirection: 'column',
           gap: 1,
-          alignItems: 'stretch',
-          flexGrow: 1,
         }}
       >
-        <Box
-          sx={{
-            height: '100%',
-            p: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 1,
-          }}
-        >
-          <Typography sx={{ display: 'flex', gap: 1 }}>
-            <span>{name}</span>{' '}
-            <BootstrapTooltip title={<Typography>{description}</Typography>}>
-              <InfoIcon />
-            </BootstrapTooltip>
-          </Typography>
+        <Typography sx={{ display: 'flex', gap: 1 }}>
+          <span>{name}</span>{' '}
+          <BootstrapTooltip title={<Typography>{description}</Typography>}>
+            <InfoIcon />
+          </BootstrapTooltip>
+        </Typography>
 
-          <Box sx={{ marginTop: 'auto' }}>
-            <Grid container columns={4} spacing={1}>
-              {range(0, 3).map((i) => (
-                <Grid key={i} item xs={1} height="100%">
-                  {teamCharIds[i] ? (
+        <Box sx={{ marginTop: 'auto' }}>
+          <Grid container columns={4} spacing={1}>
+            {range(0, 3).map((i) => (
+              <Grid key={i} item xs={1} height="100%">
+                {teamCharIds[i] ? (
+                  <CardActionArea
+                    onClick={() =>
+                      onClick(database.teamChars.get(teamCharIds[i]).key)
+                    }
+                  >
                     <CharacterCardPico
                       characterKey={database.teamChars.get(teamCharIds[i]).key}
                     />
-                  ) : (
-                    <BlankCharacterCardPico index={i} />
-                  )}
-                </Grid>
-              ))}
-            </Grid>
-          </Box>
+                  </CardActionArea>
+                ) : (
+                  <BlankCharacterCardPico index={i} />
+                )}
+              </Grid>
+            ))}
+          </Grid>
         </Box>
-      </CardActionArea>
+      </Box>
       {!disableButtons && (
         <Box sx={{ display: 'flex', gap: 1, marginTop: 'auto', p: 1 }}>
           <Button

--- a/apps/frontend/src/app/PageTeams/index.tsx
+++ b/apps/frontend/src/app/PageTeams/index.tsx
@@ -112,7 +112,7 @@ export default function PageTeams() {
               <TeamCard
                 teamId={tid}
                 bgt="light"
-                onClick={(cid) => navigate(`${tid}/${cid}`)}
+                onClick={(cid) => navigate(`${tid}${cid ? `/${cid}` : ''}`)}
               />
             </Grid>
           ))}

--- a/apps/frontend/src/app/PageTeams/index.tsx
+++ b/apps/frontend/src/app/PageTeams/index.tsx
@@ -112,7 +112,7 @@ export default function PageTeams() {
               <TeamCard
                 teamId={tid}
                 bgt="light"
-                onClick={() => navigate(`${tid}`)}
+                onClick={(cid) => navigate(`${tid}/${cid}`)}
               />
             </Grid>
           ))}


### PR DESCRIPTION
## Describe your changes

Moved `CardActionArea` from covering the whole box to covering each character individually.
Update `TeamCard` onClick to navigate to `{team_id}/{character_id}` directly.

## Issue or discord link

- resolves #1527

## Testing/validation

![_1500x759@40](https://github.com/frzyc/genshin-optimizer/assets/44922829/4eb3c085-3346-47b3-bc90-bd9de16f41cf)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
