### PR TITLE
Add popup text for icon buttons

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/Build.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/Build.tsx
@@ -30,6 +30,7 @@ import {
   Divider,
   Grid,
   TextField,
+  Tooltip,
   Typography,
   styled,
 } from '@mui/material'
@@ -161,26 +162,56 @@ export function Build({
                 </Box>
               </CardActionArea>
             </CardThemed>
-            <Button color="info" size="small" onClick={onOpen}>
-              <EditIcon />
-            </Button>
-            <Button color="info" size="small" onClick={copyToTc}>
-              <ScienceIcon />
-            </Button>
-            <Button color="info" size="small" onClick={onDupe}>
-              <ContentCopyIcon />
-            </Button>
-            <Button
-              color="success"
-              size="small"
-              disabled={!weaponId} // disabling equip of outfit with invalid weaponId
-              onClick={onEquip}
+            <Tooltip
+              title={<Typography>Edit Build Settings</Typography>}
+              placement="top"
+              arrow
             >
-              <CheckroomIcon />
-            </Button>
-            <Button color="error" size="small" onClick={onRemove}>
-              <DeleteForeverIcon />
-            </Button>
+              <Button color="info" size="small" onClick={onOpen}>
+                <EditIcon />
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title={<Typography>Copy to TC Builds</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="info" size="small" onClick={copyToTc}>
+                <ScienceIcon />
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title={<Typography>Duplicate Build</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="info" size="small" onClick={onDupe}>
+                <ContentCopyIcon />
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title={<Typography>Equip Build</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button
+                color="success"
+                size="small"
+                disabled={!weaponId} // disabling equip of outfit with invalid weaponId
+                onClick={onEquip}
+              >
+                <CheckroomIcon />
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title={<Typography>Delete Build</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="error" size="small" onClick={onRemove}>
+                <DeleteForeverIcon />
+              </Button>
+            </Tooltip>
           </Box>
 
           <Grid

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   CardActionArea,
   CardContent,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import { useContext } from 'react'
@@ -58,15 +59,33 @@ export function BuildEquipped({ active = false }: { active: boolean }) {
               <Typography variant="h6">Equipped</Typography>
             </CardActionArea>
           </CardThemed>
-          <Button disabled color="info" size="small">
-            <EditIcon />
-          </Button>
-          <Button color="info" size="small" onClick={copyToTc}>
-            <ScienceIcon />
-          </Button>
-          <Button color="info" size="small" onClick={onDupe}>
-            <ContentCopyIcon />
-          </Button>
+          <Tooltip
+            title={<Typography>Edit Build Settings</Typography>}
+            placement="top"
+            arrow
+          >
+            <Button disabled color="info" size="small">
+              <EditIcon />
+            </Button>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Copy to TC Builds</Typography>}
+            placement="top"
+            arrow
+          >
+            <Button color="info" size="small" onClick={copyToTc}>
+              <ScienceIcon />
+            </Button>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Duplicate Build</Typography>}
+            placement="top"
+            arrow
+          >
+            <Button color="info" size="small" onClick={onDupe}>
+              <ContentCopyIcon />
+            </Button>
+          </Tooltip>
         </Box>
 
         <BuildEquip weaponId={equippedWeapon} artifactIds={equippedArtifacts} />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
@@ -24,6 +24,7 @@ import {
   Divider,
   Grid,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import { useContext, useDeferredValue, useEffect, useState } from 'react'
@@ -86,12 +87,24 @@ export default function BuildTc({
                 </Box>
               </CardActionArea>
             </CardThemed>
-            <Button color="info" size="small" onClick={onOpen}>
-              <EditIcon />
-            </Button>
-            <Button color="error" size="small" onClick={onRemove}>
-              <DeleteForeverIcon />
-            </Button>
+            <Tooltip
+              title={<Typography>Edit Build Settings</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="info" size="small" onClick={onOpen}>
+                <EditIcon />
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title={<Typography>Delete Build</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="error" size="small" onClick={onRemove}>
+                <DeleteForeverIcon />
+              </Button>
+            </Tooltip>
           </Box>
 
           <TcEquip buildTcId={buildTcId} />


### PR DESCRIPTION
## Describe your changes

Add popup text for icon buttons on Build Management.

## Issue or discord link

- Resolves #1530

## Testing/validation

https://github.com/frzyc/genshin-optimizer/assets/37397745/1682bca0-efbb-4a18-822b-e855dc4cda85

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
