### PR TITLE
fix artifact editor disabling slot on new artifact

### DIFF
--- a/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
+++ b/apps/frontend/src/app/PageArtifact/ArtifactEditor.tsx
@@ -175,9 +175,10 @@ export default function ArtifactEditor({
 
   const queueTotal = processedNum + outstandingNum + scanningNum
   const disableEditSlot =
-    (!['new', ''].includes(artifactIdToEdit) && !!artifact?.location) ||
-    !!fixedSlotKey ||
-    !!artifactIdToEdit // Disable editing slot of existing artifacts
+    (!['new', ''].includes(artifactIdToEdit) && !!artifact?.location) || // Disable slot for equipped artifact
+    !!fixedSlotKey || // Disable slot if its fixed
+    // Disable editing slot of existing artifacts // TODO: disable slot only for artifacts that are in a build?
+    (!!artifactIdToEdit && artifactIdToEdit !== 'new')
 
   const uploadFiles = useCallback(
     (files?: FileList | null) => {


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Fix an issue where the artifact editor is disabling the slotkey dropdown on during new artifact creation.

## Issue or discord link

- [<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->](https://discord.com/channels/785153694478893126/1200154094476734556/1212328921870114887)

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
