### PR TITLE
store weapons in generated builds

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
@@ -1,5 +1,6 @@
 import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
+import type { GeneratedBuild } from '@genshin-optimizer/gi/db'
 import { useCharacter, useDBMeta } from '@genshin-optimizer/gi/db-ui'
 import { CardContent, Skeleton } from '@mui/material'
 import { Suspense, useEffect, useMemo, useState } from 'react'
@@ -72,8 +73,8 @@ function CharacterEditorContent({
     }
   }, [character, characterSheet, characterDispatch])
 
-  const [chartData, setChartData] = useState(undefined as ChartData | undefined)
-  const [graphBuilds, setGraphBuilds] = useState<string[][]>()
+  const [chartData, setChartData] = useState<ChartData | undefined>()
+  const [graphBuilds, setGraphBuilds] = useState<GeneratedBuild[] | undefined>()
   const graphContextValue: GraphContextObj | undefined = useMemo(() => {
     return {
       chartData,

--- a/apps/frontend/src/app/Context/GraphContext.tsx
+++ b/apps/frontend/src/app/Context/GraphContext.tsx
@@ -1,16 +1,21 @@
+import type { GeneratedBuild } from '@genshin-optimizer/gi/db'
 import { createContext } from 'react'
 import type { NumNode } from '../Formula/type'
-import type { Build } from '../Solver/common'
+
+type Data = GeneratedBuild & {
+  value: number
+  plot?: number
+}
 
 export type ChartData = {
   valueNode: NumNode
   plotNode: NumNode
-  data: Build[]
+  data: Data[]
 }
 export type GraphContextObj = {
   chartData?: ChartData
   setChartData: (data: ChartData | undefined) => void
-  graphBuilds: string[][] | undefined
-  setGraphBuilds: (builds: string[][] | undefined) => void
+  graphBuilds: GeneratedBuild[] | undefined
+  setGraphBuilds: (builds: GeneratedBuild[] | undefined) => void
 }
 export const GraphContext = createContext({} as GraphContextObj)

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -51,8 +51,7 @@ export default function CustomTooltip({
 
   const artifactsBySlot: { [slot: string]: ICachedArtifact } = useMemo(
     () =>
-      selectedPoint &&
-      selectedPoint.build.artifactIds &&
+      selectedPoint?.build?.artifactIds &&
       objMap(selectedPoint.build.artifactIds, (id) => database.arts.get(id)),
     [database.arts, selectedPoint]
   )
@@ -72,7 +71,7 @@ export default function CustomTooltip({
 
   const currentlyEquipped =
     data.get(input.weapon.id).value?.toString() ===
-      selectedPoint.build?.weaponId &&
+      selectedPoint?.build?.weaponId &&
     artifactsBySlot &&
     allArtifactSlotKeys.every(
       (slotKey) =>
@@ -100,95 +99,90 @@ export default function CustomTooltip({
     [selectedPoint, t]
   )
 
-  if (tooltipProps.active && selectedPoint) {
-    return (
-      <ClickAwayListener onClickAway={clickAwayHandler}>
-        <CardDark
-          sx={{ minWidth: '400px', maxWidth: '400px', p: 1 }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Box>
-            <Stack gap={1}>
-              <Stack direction="row" alignItems="start" gap={1}>
-                <Stack spacing={0.5} flexGrow={99}>
-                  {currentlyEquipped && (
-                    <SqBadge color="info">
-                      <strong>{t('currentlyEquippedBuild')}</strong>
-                    </SqBadge>
-                  )}
-                  {generLabel && <SqBadge color="info">{generLabel}</SqBadge>}
-                  {graphLabel && <SqBadge color="info">{graphLabel}</SqBadge>}
-                  <Suspense fallback={<Skeleton width={300} height={50} />}>
-                    <ArtifactSetBadges
-                      artifacts={Object.values(artifactsBySlot)}
-                      currentlyEquipped={currentlyEquipped}
+  if (!tooltipProps.active || !selectedPoint) return null
+  return (
+    <ClickAwayListener onClickAway={clickAwayHandler}>
+      <CardDark
+        sx={{ minWidth: '400px', maxWidth: '400px', p: 1 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Box>
+          <Stack gap={1}>
+            <Stack direction="row" alignItems="start" gap={1}>
+              <Stack spacing={0.5} flexGrow={99}>
+                {currentlyEquipped && (
+                  <SqBadge color="info">
+                    <strong>{t('currentlyEquippedBuild')}</strong>
+                  </SqBadge>
+                )}
+                {generLabel && <SqBadge color="info">{generLabel}</SqBadge>}
+                {graphLabel && <SqBadge color="info">{graphLabel}</SqBadge>}
+                <Suspense fallback={<Skeleton width={300} height={50} />}>
+                  <ArtifactSetBadges
+                    artifacts={Object.values(artifactsBySlot)}
+                    currentlyEquipped={currentlyEquipped}
+                  />
+                </Suspense>
+              </Stack>
+              <Grid item flexGrow={1} />
+              <CloseButton onClick={() => setSelectedPoint(undefined)} />
+            </Stack>
+            <Grid container direction="row" spacing={0.75} columns={6}>
+              {selectedPoint.build?.weaponId && (
+                <Grid item xs={1}>
+                  <Suspense fallback={<Skeleton width={75} height={75} />}>
+                    <WeaponCardPico weaponId={selectedPoint.build.weaponId} />
+                  </Suspense>
+                </Grid>
+              )}
+              {allArtifactSlotKeys.map((key) => (
+                <Grid item key={key} xs={1}>
+                  <Suspense fallback={<Skeleton width={75} height={75} />}>
+                    <ArtifactCardPico
+                      artifactObj={artifactsBySlot[key]}
+                      slotKey={key}
                     />
                   </Suspense>
-                </Stack>
-                <Grid item flexGrow={1} />
-                <CloseButton onClick={() => setSelectedPoint(undefined)} />
-              </Stack>
-              <Grid container direction="row" spacing={0.75} columns={6}>
-                {selectedPoint.build?.weaponId && (
-                  <Grid item xs={1}>
-                    <Suspense fallback={<Skeleton width={75} height={75} />}>
-                      <WeaponCardPico weaponId={selectedPoint.build.weaponId} />
-                    </Suspense>
-                  </Grid>
-                )}
-                {allArtifactSlotKeys.map((key) => (
-                  <Grid item key={key} xs={1}>
-                    <Suspense fallback={<Skeleton width={75} height={75} />}>
-                      <ArtifactCardPico
-                        artifactObj={artifactsBySlot[key]}
-                        slotKey={key}
-                      />
-                    </Suspense>
-                  </Grid>
-                ))}
-              </Grid>
-              <Typography>
-                <strong>{xLabel}</strong>:{' '}
-                {valueString(
-                  xUnit === '%' ? selectedPoint.x / 100 : selectedPoint.x,
-                  xUnit
-                )}
-              </Typography>
-              <Typography>
-                <strong>{yLabel}</strong>:{' '}
-                {valueString(
-                  yUnit === '%' ? selectedPoint.y / 100 : selectedPoint.y,
-                  yUnit
-                )}
-              </Typography>
-              <BootstrapTooltip
-                title={
-                  selectedPoint.highlighted
-                    ? t('tcGraph.buildAlreadyInList')
-                    : ''
-                }
-                placement="top"
-              >
-                <span>
-                  <Button
-                    sx={{ width: '100%' }}
-                    disabled={selectedPoint?.graphBuildNumber !== undefined}
-                    color="info"
-                    onClick={() =>
-                      selectedPoint.build &&
-                      addBuildToList(structuredClone(selectedPoint.build))
-                    }
-                  >
-                    {t('addBuildToList')}
-                  </Button>
-                </span>
-              </BootstrapTooltip>
-            </Stack>
-          </Box>
-        </CardDark>
-      </ClickAwayListener>
-    )
-  }
-
-  return null
+                </Grid>
+              ))}
+            </Grid>
+            <Typography>
+              <strong>{xLabel}</strong>:{' '}
+              {valueString(
+                xUnit === '%' ? selectedPoint.x / 100 : selectedPoint.x,
+                xUnit
+              )}
+            </Typography>
+            <Typography>
+              <strong>{yLabel}</strong>:{' '}
+              {valueString(
+                yUnit === '%' ? selectedPoint.y / 100 : selectedPoint.y,
+                yUnit
+              )}
+            </Typography>
+            <BootstrapTooltip
+              title={
+                selectedPoint.highlighted ? t('tcGraph.buildAlreadyInList') : ''
+              }
+              placement="top"
+            >
+              <span>
+                <Button
+                  sx={{ width: '100%' }}
+                  disabled={selectedPoint?.graphBuildNumber !== undefined}
+                  color="info"
+                  onClick={() =>
+                    selectedPoint.build &&
+                    addBuildToList(structuredClone(selectedPoint.build))
+                  }
+                >
+                  {t('addBuildToList')}
+                </Button>
+              </span>
+            </BootstrapTooltip>
+          </Stack>
+        </Box>
+      </CardDark>
+    </ClickAwayListener>
+  )
 }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/EnhancedPoint.ts
@@ -1,17 +1,19 @@
+import type { GeneratedBuild } from '@genshin-optimizer/gi/db'
+
 export default class EnhancedPoint {
   public x: number
   public trueY?: number
-  public artifactIds: string[]
+  public build: GeneratedBuild
   public min?: number
   public current?: number
   public highlighted?: number
   public generBuildNumber?: number
   public graphBuildNumber?: number
 
-  public constructor(x: number, y: number, artifactIds: string[]) {
+  public constructor(x: number, y: number, build: GeneratedBuild) {
     this.x = x
     this.trueY = y
-    this.artifactIds = artifactIds
+    this.build = build
   }
 
   public get y(): number {

--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -1,7 +1,11 @@
 import { CardThemed } from '@genshin-optimizer/common/ui'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import { charKeyToLocGenderedCharKey } from '@genshin-optimizer/gi/consts'
-import type { Team, TeamCharacter } from '@genshin-optimizer/gi/db'
+import type {
+  GeneratedBuild,
+  Team,
+  TeamCharacter,
+} from '@genshin-optimizer/gi/db'
 import {
   useCharacter,
   useDBMeta,
@@ -178,7 +182,7 @@ function Page({ teamId, onClose }: { teamId: string; onClose?: () => void }) {
 }
 // Stored per teamCharId
 const chartDataAll: Record<string, ChartData> = {}
-const graphBuildAll: Record<string, string[][]> = {}
+const graphBuildAll: Record<string, GeneratedBuild[]> = {}
 function PageContent({
   characterKey,
   teamCharId,
@@ -221,9 +225,9 @@ function PageContent({
   const [chartData, setChartDataState] = useState<ChartData | undefined>(
     chartDataAll[teamCharId]
   )
-  const [graphBuilds, setGraphBuildState] = useState<string[][] | undefined>(
-    graphBuildAll[teamCharId]
-  )
+  const [graphBuilds, setGraphBuildState] = useState<
+    GeneratedBuild[] | undefined
+  >(graphBuildAll[teamCharId])
   useEffect(() => {
     setChartDataState(chartDataAll[teamCharId])
     setGraphBuildState(graphBuildAll[teamCharId])

--- a/apps/frontend/src/app/Solver/GOSolver/ComputeWorker.ts
+++ b/apps/frontend/src/app/Solver/GOSolver/ComputeWorker.ts
@@ -4,14 +4,14 @@ import { optimize, precompute } from '../../Formula/optimization'
 import type {
   ArtifactBuildData,
   ArtifactsBySlot,
-  Build,
+  SolverBuild,
   PlotData,
   RequestFilter,
 } from '../common'
 import { countBuilds, filterArts, mergePlot, pruneAll } from '../common'
 
 export class ComputeWorker {
-  builds: Build[] = []
+  builds: SolverBuild[] = []
   buildValues: number[] | undefined = undefined
   plotData: PlotData | undefined
   threshold = -Infinity
@@ -84,7 +84,7 @@ export class ComputeWorker {
         if (min.every((m, i) => m <= result[i])) {
           const value = result[min.length],
             { builds, plotData } = this
-          let build: Build | undefined
+          let build: SolverBuild | undefined
           if (value >= this.threshold) {
             build = {
               value,

--- a/apps/frontend/src/app/Solver/common.ts
+++ b/apps/frontend/src/app/Solver/common.ts
@@ -533,7 +533,10 @@ export function filterArts(
   }
 }
 
-export function mergeBuilds(builds: Build[][], maxNum: number): Build[] {
+export function mergeBuilds(
+  builds: SolverBuild[][],
+  maxNum: number
+): SolverBuild[] {
   return builds
     .flatMap((x) => x)
     .sort((a, b) => b.value - a.value)
@@ -812,8 +815,8 @@ export type ArtifactsBySlot = {
   values: StrictDict<ArtifactSlotKey, ArtifactBuildData[]>
 }
 
-export type PlotData = Dict<number, Build>
-export interface Build {
+export type PlotData = Dict<number, SolverBuild>
+export interface SolverBuild {
   value: number
   plot?: number
   artifactIds: string[]

--- a/apps/frontend/src/app/Solver/index.d.ts
+++ b/apps/frontend/src/app/Solver/index.d.ts
@@ -1,6 +1,11 @@
 import type { ArtSetExclusion } from '@genshin-optimizer/gi/db'
 import type { OptNode } from '../Formula/optimization'
-import type { ArtifactsBySlot, Build, PlotData, RequestFilter } from './common'
+import type {
+  ArtifactsBySlot,
+  SolverBuild,
+  PlotData,
+  RequestFilter,
+} from './common'
 
 export type OptProblemInput = {
   arts: ArtifactsBySlot
@@ -65,7 +70,7 @@ export interface CountResult {
 }
 export interface FinalizeResult {
   resultType: 'finalize'
-  builds: Build[]
+  builds: SolverBuild[]
   plotData?: PlotData
 }
 export interface Interim {

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -12,6 +12,7 @@ import type {
   AllowLocationsState,
   ArtSetExclusion,
   ArtSetExclusionKey,
+  GeneratedBuild,
   StatFilterSetting,
   StatFilters,
 } from './OptConfigDataManager'
@@ -51,6 +52,7 @@ export type {
   AllowLocationsState,
   ArtSetExclusion,
   ArtSetExclusionKey,
+  GeneratedBuild,
   MinTotalStatKey,
   StatFilterSetting,
   StatFilters,


### PR DESCRIPTION
## Describe your changes

Add weaponId to generated builds in optimize tab. This also changes the format for stored builds in opt graph.

## Issue or discord link

- Resolves #1565 

## Testing/validation

<!--- Add screenshots if possible -->
<img width="545" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/50b076ea-0b7d-4125-a2e0-73435a6751d4">

Generated builds retain their original generated weapon after changing to a different Build with a different weapon 

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
