### PR TITLE
Fixed "Add Team" button not displaying if no teams exist yet

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/Content.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/Content.tsx
@@ -174,7 +174,6 @@ function InTeam() {
       ),
     [characterKey, database]
   )
-  if (!teamIds.length) return null
 
   const onAddTeam = () => {
     const teamId = database.teams.new()


### PR DESCRIPTION
## Describe your changes

Fixed "Add Team" button not displaying on Character Editor if no teams exist for the character yet

## Issue or discord link

- Resolves #1579 

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/37397745/9950b5e9-2a41-45d5-8ef2-ea20a161d74b)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
