### PR TITLE
Fix active character usage and tc opt

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -11,7 +11,11 @@ import {
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
 import type { GeneratedBuild, ICachedArtifact } from '@genshin-optimizer/gi/db'
-import { defThreads, getActiveTeamCharId, maxBuildsToShowList } from '@genshin-optimizer/gi/db'
+import {
+  defThreads,
+  getActiveTeamCharId,
+  maxBuildsToShowList,
+} from '@genshin-optimizer/gi/db'
 import {
   useDBMeta,
   useDatabase,
@@ -109,7 +113,7 @@ export default function TabBuild() {
     teamCharId,
     teamChar: { optConfigId, key: characterKey },
     teamId,
-    team
+    team,
   } = useContext(TeamCharacterContext)
   const { characterSheet } = useContext(CharacterContext)
   const database = useDatabase()

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -13,8 +13,7 @@ import {
 import type { GeneratedBuild, ICachedArtifact } from '@genshin-optimizer/gi/db'
 import {
   defThreads,
-  getActiveTeamCharId,
-  maxBuildsToShowList,
+  maxBuildsToShowList
 } from '@genshin-optimizer/gi/db'
 import {
   useDBMeta,
@@ -113,15 +112,13 @@ export default function TabBuild() {
     teamCharId,
     teamChar: { optConfigId, key: characterKey },
     teamId,
-    team,
   } = useContext(TeamCharacterContext)
   const { characterSheet } = useContext(CharacterContext)
   const database = useDatabase()
   const { setChartData, graphBuilds, setGraphBuilds } = useContext(GraphContext)
   const { gender } = useDBMeta()
 
-  const activeTeamCharId = getActiveTeamCharId(team)
-  const activeCharKey = database.teamChars.get(activeTeamCharId).key
+  const activeCharKey = database.teams.getActiveTeamChar(teamId).key
 
   const [notification, setnotification] = useState(false)
   const notificationRef = useRef(false)

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -11,10 +11,7 @@ import {
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
 import type { GeneratedBuild, ICachedArtifact } from '@genshin-optimizer/gi/db'
-import {
-  defThreads,
-  maxBuildsToShowList
-} from '@genshin-optimizer/gi/db'
+import { defThreads, maxBuildsToShowList } from '@genshin-optimizer/gi/db'
 import {
   useDBMeta,
   useDatabase,

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -11,7 +11,7 @@ import {
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
 import type { GeneratedBuild, ICachedArtifact } from '@genshin-optimizer/gi/db'
-import { defThreads, maxBuildsToShowList } from '@genshin-optimizer/gi/db'
+import { defThreads, getActiveTeamCharId, maxBuildsToShowList } from '@genshin-optimizer/gi/db'
 import {
   useDBMeta,
   useDatabase,
@@ -109,11 +109,15 @@ export default function TabBuild() {
     teamCharId,
     teamChar: { optConfigId, key: characterKey },
     teamId,
+    team
   } = useContext(TeamCharacterContext)
   const { characterSheet } = useContext(CharacterContext)
   const database = useDatabase()
   const { setChartData, graphBuilds, setGraphBuilds } = useContext(GraphContext)
   const { gender } = useDBMeta()
+
+  const activeTeamCharId = getActiveTeamCharId(team)
+  const activeCharKey = database.teamChars.get(activeTeamCharId).key
 
   const [notification, setnotification] = useState(false)
   const notificationRef = useRef(false)
@@ -319,7 +323,7 @@ export default function TabBuild() {
       []
     )
     if (!teamData) return
-    const workerData = uiDataForTeam(teamData.teamData, gender, characterKey)[
+    const workerData = uiDataForTeam(teamData.teamData, gender, activeCharKey)[
       characterKey
     ]?.target.data![0]
     if (!workerData) return
@@ -480,13 +484,14 @@ export default function TabBuild() {
       })
     }
   }, [
-    teamCharId,
-    teamId,
     buildSetting,
     characterKey,
     filteredArts,
     database,
+    teamId,
+    teamCharId,
     gender,
+    activeCharKey,
     setChartData,
     maxWorkers,
     optConfigId,

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -23,7 +23,7 @@ import type { dataContextObj } from '../../../../Context/DataContext'
 import { DataContext } from '../../../../Context/DataContext'
 import { OptimizationTargetContext } from '../../../../Context/OptimizationTargetContext'
 import { TeamCharacterContext } from '../../../../Context/TeamCharacterContext'
-import { getTeamDataCalc } from '../../../../ReactHooks/useCharData'
+import { getTeamDataCalc } from '../../../../ReactHooks/useTeamData'
 import { isDev } from '../../../../Util/Util'
 import CharacterProfileCard from '../../../CharProfileCard'
 import useOldData from '../../../useOldData'
@@ -50,6 +50,8 @@ export default function TabTheorycraft() {
   const database = useDatabase()
   const { gender } = useDBMeta()
   const {
+    teamId,
+    teamCharId,
     teamChar: { key: characterKey, buildTcId },
   } = useContext(TeamCharacterContext)
   const buildTc = useBuildTc(buildTcId)
@@ -146,9 +148,10 @@ export default function TabTheorycraft() {
      */
     const tempTeamData = getTeamDataCalc(
       database,
-      characterKey,
-      0,
+      teamId,
       gender,
+      teamCharId,
+      0,
       getArtifactData(buildTc),
       getWeaponData(buildTc)
     )

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -33,10 +33,7 @@ import {
   allArtifactSlotKeys,
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
-import {
-  getActiveTeamCharId,
-  type ICachedArtifact,
-} from '@genshin-optimizer/gi/db'
+import { type ICachedArtifact } from '@genshin-optimizer/gi/db'
 import {
   Suspense,
   useCallback,
@@ -79,13 +76,11 @@ export default function TabUpopt() {
     teamId,
     teamCharId,
     teamChar: { optConfigId, key: characterKey },
-    team,
   } = useContext(TeamCharacterContext)
   const database = useDatabase()
   const { gender } = useDBMeta()
 
-  const activeTeamCharId = getActiveTeamCharId(team)
-  const activeCharKey = database.teamChars.get(activeTeamCharId).key
+  const activeCharKey = database.teams.getActiveTeamChar(teamId).key
 
   const noArtifact = useMemo(() => !database.arts.values.length, [database])
 

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -33,7 +33,10 @@ import {
   allArtifactSlotKeys,
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
-import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
+import {
+  getActiveTeamCharId,
+  type ICachedArtifact,
+} from '@genshin-optimizer/gi/db'
 import {
   Suspense,
   useCallback,
@@ -76,9 +79,13 @@ export default function TabUpopt() {
     teamId,
     teamCharId,
     teamChar: { optConfigId, key: characterKey },
+    team,
   } = useContext(TeamCharacterContext)
   const database = useDatabase()
   const { gender } = useDBMeta()
+
+  const activeTeamCharId = getActiveTeamCharId(team)
+  const activeCharKey = database.teamChars.get(activeTeamCharId).key
 
   const noArtifact = useMemo(() => !database.arts.values.length, [database])
 
@@ -210,7 +217,7 @@ export default function TabUpopt() {
     if (!characterKey || !optimizationTarget) return
     const teamData = getTeamData(database, teamId, teamCharId, 0, [])
     if (!teamData) return
-    const workerData = uiDataForTeam(teamData.teamData, gender, characterKey)[
+    const workerData = uiDataForTeam(teamData.teamData, gender, activeCharKey)[
       characterKey
     ]?.target.data![0]
     if (!workerData) return
@@ -331,15 +338,16 @@ export default function TabUpopt() {
     upoptCalc.calcSlowToIndex(5)
     setUpOptCalc(upoptCalc)
   }, [
-    teamCharId,
-    teamId,
     buildSetting,
     characterKey,
     database,
+    teamId,
+    teamCharId,
     gender,
+    activeCharKey,
+    check4th,
     show20,
     useFilters,
-    check4th,
   ])
 
   const dataContext: dataContextObj | undefined = useMemo(() => {

--- a/apps/frontend/src/app/ReactHooks/useCharData.tsx
+++ b/apps/frontend/src/app/ReactHooks/useCharData.tsx
@@ -104,7 +104,7 @@ const getCache = (database: ArtCharDatabase) => {
   return cache
 }
 
-export function getTeamDataCalc(
+function getTeamDataCalc(
   database: ArtCharDatabase,
   characterKey: CharacterKey | '',
   mainStatAssumptionLevel = 0,

--- a/apps/frontend/src/app/ReactHooks/useTeamData.tsx
+++ b/apps/frontend/src/app/ReactHooks/useTeamData.tsx
@@ -2,7 +2,6 @@ import { useForceUpdate } from '@genshin-optimizer/common/react-util'
 import { objMap } from '@genshin-optimizer/common/util'
 import type { CharacterKey, GenderKey } from '@genshin-optimizer/gi/consts'
 import {
-  getActiveTeamCharId,
   type ArtCharDatabase,
   type ICachedArtifact,
   type ICachedCharacter,
@@ -111,9 +110,7 @@ export function getTeamDataCalc(
   overrideWeapon?: ICachedWeapon
 ): TeamData | undefined {
   if (!teamId) return undefined
-  const team = database.teams.get(teamId)
-  if (!team) return undefined
-  const activeChar = database.teamChars.get(getActiveTeamCharId(team))
+  const activeChar = database.teams.getActiveTeamChar(teamId)
   if (!activeChar) return undefined
 
   const { teamData, teamBundle } =

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -6,9 +6,9 @@ import { DBMetaEntry } from './DataEntries/DBMetaEntry'
 import { DisplayArtifactEntry } from './DataEntries/DisplayArtifactEntry'
 import { DisplayCharacterEntry } from './DataEntries/DisplayCharacterEntry'
 import { DisplayOptimizeEntry } from './DataEntries/DisplayOptimizeEntry'
+import { DisplayTeamEntry } from './DataEntries/DisplayTeamEntry'
 import { DisplayToolEntry } from './DataEntries/DisplayTool'
 import { DisplayWeaponEntry } from './DataEntries/DisplayWeaponEntry'
-import { DisplayTeamEntry } from './DataEntries/DisplayTeamEntry'
 import { ArtifactDataManager } from './DataManagers/ArtifactDataManager'
 import { BuildDataManager } from './DataManagers/BuildDataManager'
 import { BuildTcDataManager } from './DataManagers/BuildTcDataManager'
@@ -169,10 +169,10 @@ export class ArtCharDatabase extends Database {
         if (ind < 0) arr.push(value)
         else arr[ind] = value
       }),
-      this.arts.followAny((key, reason, value) =>
+      this.arts.followAny((_key, reason, value) =>
         result.artifacts[reason].push(value)
       ),
-      this.weapons.followAny((key, reason, value) =>
+      this.weapons.followAny((_key, reason, value) =>
         result.weapons[reason].push(value)
       ),
     ]

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -87,12 +87,9 @@ export class TeamDataManager extends DataManager<
     return id
   }
 
-  getActiveTeamCharId(teamId: string) {
-    const team = this.database.teams.get(teamId)
-    return team?.teamCharIds[0]
-  }
   getActiveTeamChar(teamId: string) {
-    const teamCharId = this.getActiveTeamCharId(teamId)
+    const team = this.database.teams.get(teamId)
+    const teamCharId = team?.teamCharIds[0]
     return this.database.teamChars.get(teamCharId)
   }
 }

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -119,3 +119,7 @@ function validateTeam(
     lastEdit,
   }
 }
+
+export function getActiveTeamCharId(team: Team) {
+  return team.teamCharIds[0]
+}

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -86,6 +86,15 @@ export class TeamDataManager extends DataManager<
       return ''
     return id
   }
+
+  getActiveTeamCharId(teamId: string) {
+    const team = this.database.teams.get(teamId)
+    return team?.teamCharIds[0]
+  }
+  getActiveTeamChar(teamId: string) {
+    const teamCharId = this.getActiveTeamCharId(teamId)
+    return this.database.teamChars.get(teamCharId)
+  }
 }
 
 function validateTeam(
@@ -118,8 +127,4 @@ function validateTeam(
     teamCharIds,
     lastEdit,
   }
-}
-
-export function getActiveTeamCharId(team: Team) {
-  return team.teamCharIds[0]
 }

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -24,7 +24,6 @@ import {
 } from './OptConfigDataManager'
 import type { TeamCharacter } from './TeamCharacterDataManager'
 import type { Team } from './TeamDataManager'
-import { getActiveTeamCharId } from './TeamDataManager'
 import {
   defaultInitialWeapon,
   defaultInitialWeaponKey,
@@ -38,7 +37,6 @@ export {
   cachedArtifact,
   defaultInitialWeapon,
   defaultInitialWeaponKey,
-  getActiveTeamCharId,
   handleArtSetExclusion,
   initCharTC,
   initCustomMultiTarget,

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -24,6 +24,7 @@ import {
 } from './OptConfigDataManager'
 import type { TeamCharacter } from './TeamCharacterDataManager'
 import type { Team } from './TeamDataManager'
+import { getActiveTeamCharId } from './TeamDataManager'
 import {
   defaultInitialWeapon,
   defaultInitialWeaponKey,
@@ -37,6 +38,7 @@ export {
   cachedArtifact,
   defaultInitialWeapon,
   defaultInitialWeaponKey,
+  getActiveTeamCharId,
   handleArtSetExclusion,
   initCharTC,
   initCustomMultiTarget,


### PR DESCRIPTION
## Describe your changes

* Add util function to get the active character index in a team (in case this changes later or we need to refactor for multiple active)
* Adjust which character is marked as active when optimizing (tc + upopt + regular)
* Fix tc opt to look at the actual teams data, not just the singular character

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

On current master, I did a TC solve for Ganyu with:
* Rosaria providing 15 CR
* Hunters Path
* ATK/Cryo/CD mainstats
* Blizz 4p on Frozen
* KQMS
And the solver still tried to give me 12 CR rolls for 145 total CR. So seems like it was ignoring all the conditional CR.

On this branch, I did the same thing and got a 103 CR build, with only the 2 base rolls of CR. Which mathematically makes more sense.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
