### PR TITLE
Add modal to compare weapons in generated builds in the optimize tab and disable individual swapping/locations

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -329,30 +329,6 @@ function CompareWeaponModal({
   } = useContext(TeamCharacterContext)
   const buildEquip = buildId && buildType === 'real'
 
-  const {
-    character: { key: characterKey },
-  } = useContext(CharacterContext)
-  const onEquip = useCallback(() => {
-    const confirmMsg = buildEquip
-      ? 'Do you want to equip this weapon to this build?'
-      : 'Do you want to equip this weapon to this character?'
-    if (!window.confirm(confirmMsg)) return
-    if (buildEquip) {
-      const weap = database.weapons.get(newId)
-      database.weapons.set(newId, {
-        location: charKeyToLocCharKey(characterKey),
-      })
-      if (weap)
-        database.builds.set(buildId, (build) => {
-          build.weaponId = newId
-        })
-    } else
-      database.weapons.set(newId, {
-        location: charKeyToLocCharKey(characterKey),
-      })
-    onClose()
-  }, [newId, buildEquip, buildId, database, characterKey, onClose])
-
   const deleteWeapon = useCallback(
     (id: string) => database.weapons.remove(id),
     [database]
@@ -396,13 +372,7 @@ function CompareWeaponModal({
           {oldId && <Box display="flex" flexGrow={1} />}
           {oldId && (
             <Box display="flex" alignItems="center" justifyContent="center">
-              <Button
-                onClick={onEquip}
-                sx={{ display: 'flex' }}
-                disabled={oldId === 'tc'}
-              >
-                <ChevronRight sx={{ fontSize: 40 }} />
-              </Button>
+              <ChevronRight sx={{ fontSize: 40 }} />
             </Box>
           )}
           {oldId && <Box display="flex" flexGrow={1} />}
@@ -443,22 +413,7 @@ function CompareArtifactModal({
   const {
     character: { key: characterKey },
   } = useContext(CharacterContext)
-  const onEquip = useCallback(() => {
-    const confirmMsg = buildEquip
-      ? 'Do you want to equip this artifact to this build?'
-      : 'Do you want to equip this artifact to this character?'
-    if (!window.confirm(confirmMsg)) return
-    if (buildEquip) {
-      const art = database.arts.get(newId)
-      if (!art) return
-      if (art.slotKey)
-        database.builds.set(buildId, (build) => {
-          build.artifactIds[art.slotKey] = newId
-        })
-    } else
-      database.arts.set(newId, { location: charKeyToLocCharKey(characterKey) })
-    onClose()
-  }, [newId, buildEquip, buildId, database, characterKey, onClose])
+
   const newLoc = database.arts.get(newId)?.location ?? ''
   const newArtifact = useArtifact(newId)
   const oldArtifact = useArtifact(oldId)
@@ -513,13 +468,7 @@ function CompareArtifactModal({
           {oldId && <Box display="flex" flexGrow={1} />}
           {oldId && (
             <Box display="flex" alignItems="center" justifyContent="center">
-              <Button
-                onClick={onEquip}
-                sx={{ display: 'flex' }}
-                disabled={oldId === 'tc'}
-              >
-                <ChevronRight sx={{ fontSize: 40 }} />
-              </Button>
+              <ChevronRight sx={{ fontSize: 40 }} />
             </Box>
           )}
           {oldId && <Box display="flex" flexGrow={1} />}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -354,8 +354,6 @@ function CompareWeaponModal({
     onClose()
   }, [newId, buildEquip, buildId, database, characterKey, onClose])
 
-  const oldWeapon = useWeapon(oldId)
-
   const deleteWeapon = useCallback(
     (id: string) => database.weapons.remove(id),
     [database]
@@ -376,7 +374,7 @@ function CompareWeaponModal({
             gap: 2,
           }}
         >
-          {oldWeapon && (
+          {oldId && (
             <Box minWidth={320} display="flex" flexDirection="column" gap={1}>
               <CardThemed bgt="light" sx={{ p: 1 }}>
                 <Typography variant="h6" textAlign="center">
@@ -396,8 +394,8 @@ function CompareWeaponModal({
               )}
             </Box>
           )}
-          {oldWeapon && <Box display="flex" flexGrow={1} />}
-          {oldWeapon && (
+          {oldId && <Box display="flex" flexGrow={1} />}
+          {oldId && (
             <Box display="flex" alignItems="center" justifyContent="center">
               <Button
                 onClick={onEquip}
@@ -408,7 +406,7 @@ function CompareWeaponModal({
               </Button>
             </Box>
           )}
-          {oldWeapon && <Box display="flex" flexGrow={1} />}
+          {oldId && <Box display="flex" flexGrow={1} />}
           <Box minWidth={320} display="flex" flexDirection="column" gap={1}>
             <CardThemed bgt="light" sx={{ p: 1 }}>
               <Typography variant="h6" textAlign="center">

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -190,7 +190,7 @@ export default function BuildDisplayItem({
     if (compareType === 'tc') return 'tc'
     if (compareType === 'equipped') return equippedWeapon
     if (compareType === 'real')
-      return database.builds.get(compareBuildId).weaponId
+      return database.builds.get(compareBuildId)!.weaponId ?? ''
     // default
     return ''
   }, [

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -18,7 +18,6 @@ import {
   useArtifact,
   useDatabase,
   useOptConfig,
-  useWeapon,
 } from '@genshin-optimizer/gi/db-ui'
 import { Checkroom, ChevronRight } from '@mui/icons-material'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
@@ -47,9 +46,9 @@ import { TeamCharacterContext } from '../../../../../Context/TeamCharacterContex
 import { getCharSheet } from '../../../../../Data/Characters'
 import { uiInput as input } from '../../../../../Formula'
 import ArtifactCard from '../../../../../PageArtifact/ArtifactCard'
+import WeaponCard from '../../../../../PageWeapon/WeaponCard'
 import { ArtifactSetBadges } from './ArtifactSetBadges'
 import SetInclusionButton from './SetInclusionButton'
-import WeaponCard from '../../../../../PageWeapon/WeaponCard'
 
 type NewOld = {
   newId: string
@@ -190,7 +189,8 @@ export default function BuildDisplayItem({
     if (!compare) return buildEquippedWeaponId
     if (compareType === 'tc') return 'tc'
     if (compareType === 'equipped') return equippedWeapon
-    if (compareType === 'real') return database.builds.get(compareBuildId).weaponId
+    if (compareType === 'real')
+      return database.builds.get(compareBuildId).weaponId
     // default
     return ''
   }, [
@@ -202,26 +202,21 @@ export default function BuildDisplayItem({
     buildEquippedWeaponId,
   ])
 
-  const weapNano = useMemo(
-    () => {
-      return (
-        <Grid item xs={1}>
-          <WeaponCardNano
-            showLocation
-            weaponId={data.get(input.weapon.id).value!}
-            onClick={() => {
-              const oldId = compareEquippedWeaponId
-              const newId = data.get(input.weapon.id).value!
-              setWeapNewOld({ oldId: oldId !== newId ? oldId : undefined, newId })
-            }}
-          />
-        </Grid>
-      )}, [
-      data,
-      setWeapNewOld,
-      compareEquippedWeaponId,
-    ]
-  )
+  const weapNano = useMemo(() => {
+    return (
+      <Grid item xs={1}>
+        <WeaponCardNano
+          showLocation
+          weaponId={data.get(input.weapon.id).value!}
+          onClick={() => {
+            const oldId = compareEquippedWeaponId
+            const newId = data.get(input.weapon.id).value!
+            setWeapNewOld({ oldId: oldId !== newId ? oldId : undefined, newId })
+          }}
+        />
+      </Grid>
+    )
+  }, [data, setWeapNewOld, compareEquippedWeaponId])
 
   // Memoize Arts because of its dynamic onClick
   const artNanos = useMemo(
@@ -236,7 +231,10 @@ export default function BuildDisplayItem({
             onClick={() => {
               const oldId = compareEquippedArtifactIds[slotKey]
               const newId = artifactIdsBySlot[slotKey]!
-              setArtNewOld({ oldId: oldId !== newId ? oldId : undefined, newId })
+              setArtNewOld({
+                oldId: oldId !== newId ? oldId : undefined,
+                newId,
+              })
             }}
           />
         </Grid>
@@ -261,10 +259,7 @@ export default function BuildDisplayItem({
         fallback={<Skeleton variant="rectangular" width="100%" height={600} />}
       >
         {weapNewOld && (
-          <CompareWeaponModal
-            newOld={weapNewOld}
-            onClose={closeWeap}
-          />
+          <CompareWeaponModal newOld={weapNewOld} onClose={closeWeap} />
         )}
         {artNewOld && (
           <CompareArtifactModal
@@ -322,7 +317,7 @@ export default function BuildDisplayItem({
 }
 
 function CompareWeaponModal({
-  newOld: {newId, oldId},
+  newOld: { newId, oldId },
   onClose,
 }: {
   newOld: NewOld
@@ -344,13 +339,17 @@ function CompareWeaponModal({
     if (!window.confirm(confirmMsg)) return
     if (buildEquip) {
       const weap = database.weapons.get(newId)
-      database.weapons.set(newId, { location: charKeyToLocCharKey(characterKey) })
+      database.weapons.set(newId, {
+        location: charKeyToLocCharKey(characterKey),
+      })
       if (weap)
         database.builds.set(buildId, (build) => {
           build.weaponId = newId
         })
     } else
-      database.weapons.set(newId, { location: charKeyToLocCharKey(characterKey) })
+      database.weapons.set(newId, {
+        location: charKeyToLocCharKey(characterKey),
+      })
     onClose()
   }, [newId, buildEquip, buildId, database, characterKey, onClose])
 

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -324,10 +324,6 @@ function CompareWeaponModal({
   onClose: () => void
 }) {
   const database = useDatabase()
-  const {
-    teamChar: { buildType, buildId },
-  } = useContext(TeamCharacterContext)
-  const buildEquip = buildId && buildType === 'real'
 
   const deleteWeapon = useCallback(
     (id: string) => database.weapons.remove(id),
@@ -361,11 +357,7 @@ function CompareWeaponModal({
                   <SqBadge>TC Weapon</SqBadge>
                 </Typography>
               ) : (
-                <WeaponCard
-                  weaponId={oldId}
-                  onDelete={deleteWeapon}
-                  canEquip={!buildEquip}
-                />
+                <WeaponCard weaponId={oldId} onDelete={deleteWeapon} />
               )}
             </Box>
           )}
@@ -382,11 +374,7 @@ function CompareWeaponModal({
                 New Weapon
               </Typography>
             </CardThemed>
-            <WeaponCard
-              weaponId={newId}
-              onDelete={deleteWeapon}
-              canEquip={!buildEquip}
-            />
+            <WeaponCard weaponId={newId} onDelete={deleteWeapon} />
           </Box>
         </CardContent>
       </CardDark>
@@ -406,10 +394,6 @@ function CompareArtifactModal({
   allowLocationsState: AllowLocationsState
 }) {
   const database = useDatabase()
-  const {
-    teamChar: { buildType, buildId },
-  } = useContext(TeamCharacterContext)
-  const buildEquip = buildId && buildType === 'real'
   const {
     character: { key: characterKey },
   } = useContext(CharacterContext)
@@ -454,7 +438,6 @@ function CompareArtifactModal({
                   artifactId={oldId}
                   onDelete={deleteArtifact}
                   mainStatAssumptionLevel={mainStatAssumptionLevel}
-                  canEquip={!buildEquip}
                   editorProps={{
                     disableSet: true,
                     fixedSlotKey: oldArtifact?.slotKey,
@@ -482,7 +465,6 @@ function CompareArtifactModal({
               artifactId={newId}
               onDelete={deleteArtifact}
               mainStatAssumptionLevel={mainStatAssumptionLevel}
-              canEquip={!buildEquip}
               editorProps={{
                 disableSet: true,
                 fixedSlotKey: newArtifact?.slotKey,


### PR DESCRIPTION
## Describe your changes
- Added `CompareWeaponModal` to `BuildDisplayItem.tsx` that functions identically to the existing `CompareArtifactModal`
- Removed the ability to swap artifacts from `CompareArtifactModal`
- Disabled the location dropdowns for both comparison modals
- Fixed a bug where the old weapon/artifact shown in the comparison modal does not reflect any changes made to the comparison build despite calcs updating in real-time
<!--- Provide a general summary of your changes -->

## Issue or discord link
- Resolves #1591 
- Resolves #1616
- https://discord.com/channels/785153694478893126/1200154094476734556/1214119792999403591<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
Comparison weapon matches optimized weapon
![image](https://github.com/frzyc/genshin-optimizer/assets/47800040/d97658c7-c535-4930-a4e2-fe1353113fc8)

Comparison weapon does not match optimized weapon
![image](https://github.com/frzyc/genshin-optimizer/assets/47800040/b4117ab4-6e04-4c84-a91a-1077fa45a07e)

Modified artifact comparison
![image](https://github.com/frzyc/genshin-optimizer/assets/47800040/38a7d327-3c9b-4855-b4f1-d71d022099db)

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
