### PR TITLE
make equipped build title button-like

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -44,6 +44,14 @@ export function BuildEquipped({ active = false }: { active: boolean }) {
       description: 'Copied from Equipped Build',
     })
   }
+
+  const canActivate = !active
+  const titleElement = (
+    <Typography sx={{ p: 1 }} variant="h6">
+      Equipped Build
+    </Typography>
+  )
+
   return (
     <CardThemed
       bgt="light"
@@ -54,11 +62,22 @@ export function BuildEquipped({ active = false }: { active: boolean }) {
     >
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <Box sx={{ display: 'flex', gap: 1 }}>
-          <CardThemed sx={{ flexGrow: 1 }}>
-            <CardActionArea disabled={active} onClick={onActive} sx={{ p: 1 }}>
-              <Typography variant="h6">Equipped Build</Typography>
-            </CardActionArea>
-          </CardThemed>
+          {canActivate ? (
+            <Button
+              onClick={onActive}
+              color="info"
+              sx={{
+                flexGrow: 1,
+                p: 0,
+                textAlign: 'left',
+                justifyContent: 'flex-start',
+              }}
+            >
+              {titleElement}
+            </Button>
+          ) : (
+            <CardThemed sx={{ flexGrow: 1 }}>{titleElement}</CardThemed>
+          )}
           <Tooltip
             title={<Typography>Copy to TC Builds</Typography>}
             placement="top"

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -3,14 +3,7 @@ import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ScienceIcon from '@mui/icons-material/Science'
-import {
-  Box,
-  Button,
-  CardActionArea,
-  CardContent,
-  Tooltip,
-  Typography,
-} from '@mui/material'
+import { Box, Button, CardContent, Tooltip, Typography } from '@mui/material'
 import { useContext } from 'react'
 import { CharacterContext } from '../../../Context/CharacterContext'
 import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
@@ -18,7 +18,6 @@ import InfoIcon from '@mui/icons-material/Info'
 import {
   Box,
   Button,
-  CardActionArea,
   CardContent,
   CardHeader,
   Divider,
@@ -57,7 +56,15 @@ export default function BuildTc({
     // trigger validation
     database.teamChars.set(teamCharId, {})
   }
-
+  const canActivate = !active
+  const titleElement = (
+    <Box sx={{ p: 1, display: 'flex', gap: 1, alignItems: 'center' }}>
+      <Typography variant="h6">{name}</Typography>
+      <BootstrapTooltip title={<Typography>{description}</Typography>}>
+        <InfoIcon />
+      </BootstrapTooltip>
+    </Box>
+  )
   return (
     <>
       <ModalWrapper open={open} onClose={onClose}>
@@ -72,21 +79,22 @@ export default function BuildTc({
       >
         <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
           <Box sx={{ display: 'flex', gap: 1 }}>
-            <CardThemed sx={{ flexGrow: 1 }}>
-              <CardActionArea disabled={active} onClick={onActive}>
-                <Box
-                  component="span"
-                  sx={{ p: 1, display: 'flex', gap: 1, alignItems: 'center' }}
-                >
-                  <Typography variant="h6">{name}</Typography>
-                  <BootstrapTooltip
-                    title={<Typography>{description}</Typography>}
-                  >
-                    <InfoIcon />
-                  </BootstrapTooltip>
-                </Box>
-              </CardActionArea>
-            </CardThemed>
+            {canActivate ? (
+              <Button
+                onClick={onActive}
+                color="info"
+                sx={{
+                  flexGrow: 1,
+                  p: 0,
+                  textAlign: 'left',
+                  justifyContent: 'flex-start',
+                }}
+              >
+                {titleElement}
+              </Button>
+            ) : (
+              <CardThemed sx={{ flexGrow: 1 }}>{titleElement}</CardThemed>
+            )}
             <Tooltip
               title={<Typography>Edit Build Settings</Typography>}
               placement="top"


### PR DESCRIPTION
## Describe your changes
Make the equipped build interaction title more button-like
## Testing/validation
<img width="840" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/2c9b7ad8-6101-4ce0-83fa-0db002c80737">
<img width="822" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/5bbf4e11-9151-4bca-8c27-d2ea0b278c0b">



## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
