### PR TITLE
show loadout + build name on teamcard hover

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterCard/CharacterCardEquipmentRow.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterCard/CharacterCardEquipmentRow.tsx
@@ -1,13 +1,13 @@
 import type { ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
 import { allArtifactSlotKeys } from '@genshin-optimizer/gi/consts'
-import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
+import type { ICachedArtifact, ICachedWeapon } from '@genshin-optimizer/gi/db'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
-import { Box, Grid } from '@mui/material'
+import { Box, Card, Grid, Typography } from '@mui/material'
 import { useContext } from 'react'
 import { DataContext } from '../../../Context/DataContext'
 import { input } from '../../../Formula'
 import ArtifactCardPico from '../../Artifact/ArtifactCardPico'
-import WeaponCardPico from '../../Weapon/WeaponCardPico'
+import WeaponCardPico, { WeaponCardPicoObj } from '../../Weapon/WeaponCardPico'
 
 export function CharacterCardEquipmentRow({
   hideWeapon = false,
@@ -49,5 +49,36 @@ function Artifacts() {
         )
       )}
     </>
+  )
+}
+export function CharacterCardEquipmentRowTC({
+  weapon,
+}: {
+  weapon: ICachedWeapon
+}) {
+  return (
+    <Box>
+      <Grid container columns={weapon ? 6 : 5} spacing={0.5} sx={{}}>
+        {weapon && (
+          <Grid item xs={1} height="100%">
+            <WeaponCardPicoObj weapon={weapon} />
+          </Grid>
+        )}
+        <Grid item xs={5}>
+          <Card
+            sx={{
+              backgroundColor: 'info.main',
+              height: '44px',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            {/* TODO: Translation */}
+            <Typography>TC Build</Typography>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
   )
 }

--- a/apps/frontend/src/app/Components/Character/CharacterCardPico.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterCardPico.tsx
@@ -1,3 +1,8 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
+import {
+  BootstrapTooltip,
+  ConditionalWrapper,
+} from '@genshin-optimizer/common/ui'
 import { imgAssets } from '@genshin-optimizer/gi/assets'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import {
@@ -9,32 +14,26 @@ import { SillyContext } from '@genshin-optimizer/gi/ui'
 import { ascensionMaxLevel } from '@genshin-optimizer/gi/util'
 import FavoriteIcon from '@mui/icons-material/Favorite'
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
-import { Box, CardActionArea, Skeleton, Typography } from '@mui/material'
+import { Box, CardActionArea, Typography } from '@mui/material'
 import type { MouseEvent, ReactNode } from 'react'
-import { Suspense, useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext } from 'react'
 import { getCharSheet } from '../../Data/Characters'
-import { ElementIcon } from '../../KeyMap/StatIcon'
 import { iconAsset } from '../../Util/AssetUtil'
-import BootstrapTooltip from '../BootstrapTooltip'
 import CardDark from '../Card/CardDark'
-import ConditionalWrapper from '../ConditionalWrapper'
 import SqBadge from '../SqBadge'
-import CharacterCard from './CharacterCard'
 
 export default function CharacterCardPico({
   characterKey,
   onClick,
   onMouseDown,
   onMouseEnter,
-  simpleTooltip = false,
-  disableTooltip = false,
+  hoverChild,
 }: {
   characterKey: CharacterKey
   onClick?: (characterKey: CharacterKey) => void
   onMouseDown?: (e: MouseEvent) => void
   onMouseEnter?: (e: MouseEvent) => void
-  simpleTooltip?: boolean
-  disableTooltip?: boolean
+  hoverChild?: React.ReactNode
 }) {
   const character = useCharacter(characterKey)
   const { favorite } = useCharMeta(characterKey)
@@ -57,81 +56,17 @@ export default function CharacterCardPico({
     ),
     [onClickHandler, onMouseDown, onMouseEnter]
   )
-  const [open, setOpen] = useState(false)
-  const onTooltipOpen = useCallback(
-    () => !disableTooltip && setOpen(true),
-    [disableTooltip]
-  )
-  const onTooltipClose = useCallback(() => setOpen(false), [])
-  useEffect(() => {
-    disableTooltip && setOpen(false)
-  }, [disableTooltip])
-
-  const simpleTooltipWrapperFunc = useCallback(
-    (children: ReactNode) => (
-      <BootstrapTooltip
-        placement="top"
-        open={open && !disableTooltip}
-        onClose={onTooltipClose}
-        onOpen={onTooltipOpen}
-        title={
-          <Suspense fallback={<Skeleton width={300} height={400} />}>
-            <Typography>
-              {characterSheet.elementKey && (
-                <ElementIcon
-                  ele={characterSheet.elementKey}
-                  iconProps={{
-                    fontSize: 'inherit',
-                    sx: {
-                      verticalAlign: '-10%',
-                      color: `${characterSheet.elementKey}.main`,
-                    },
-                  }}
-                />
-              )}{' '}
-              {characterSheet.name}
-            </Typography>
-          </Suspense>
-        }
-      >
-        {children as JSX.Element}
-      </BootstrapTooltip>
-    ),
-    [
-      characterSheet.elementKey,
-      characterSheet.name,
-      disableTooltip,
-      onTooltipClose,
-      onTooltipOpen,
-      open,
-    ]
-  )
-  const charCardTooltipWrapperFunc = useCallback(
-    (children: ReactNode) => (
-      <BootstrapTooltip
-        enterNextDelay={500}
-        enterTouchDelay={500}
-        placement="top"
-        open={open && !disableTooltip}
-        onClose={onTooltipClose}
-        onOpen={onTooltipOpen}
-        title={
-          <Box sx={{ width: 300, m: -1 }}>
-            <CharacterCard hideStats characterKey={characterKey} />
-          </Box>
-        }
-      >
-        {children as JSX.Element}
-      </BootstrapTooltip>
-    ),
-    [characterKey, disableTooltip, onTooltipClose, onTooltipOpen, open]
-  )
+  const [open, onTooltipOpen, onTooltipClose] = useBoolState()
 
   return (
-    <ConditionalWrapper
-      condition={simpleTooltip}
-      wrapper={simpleTooltipWrapperFunc}
-      falseWrapper={charCardTooltipWrapperFunc}
+    <BootstrapTooltip
+      enterNextDelay={500}
+      enterTouchDelay={500}
+      placement="top"
+      open={!!hoverChild && open}
+      onClose={onTooltipClose}
+      onOpen={onTooltipOpen}
+      title={hoverChild}
     >
       <CardDark
         sx={{
@@ -198,7 +133,7 @@ export default function CharacterCardPico({
           )}
         </ConditionalWrapper>
       </CardDark>
-    </ConditionalWrapper>
+    </BootstrapTooltip>
   )
 }
 

--- a/apps/frontend/src/app/Components/Weapon/WeaponCardPico.tsx
+++ b/apps/frontend/src/app/Components/Weapon/WeaponCardPico.tsx
@@ -1,4 +1,5 @@
 import { weaponAsset } from '@genshin-optimizer/gi/assets'
+import type { ICachedWeapon } from '@genshin-optimizer/gi/db'
 import { useWeapon } from '@genshin-optimizer/gi/db-ui'
 import { Box, Typography } from '@mui/material'
 import { useMemo } from 'react'
@@ -14,6 +15,11 @@ import WeaponNameTooltip from './WeaponNameTooltip'
 
 export default function WeaponCardPico({ weaponId }: { weaponId: string }) {
   const weapon = useWeapon(weaponId)
+  if (!weapon) return null
+  return <WeaponCardPicoObj weapon={weapon} />
+}
+
+export function WeaponCardPicoObj({ weapon }: { weapon: ICachedWeapon }) {
   const weaponSheet = weapon?.key && getWeaponSheet(weapon.key)
   const UIData = useMemo(
     () =>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEditorBtn.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEditorBtn.tsx
@@ -13,7 +13,7 @@ import {
   Divider,
   Typography,
 } from '@mui/material'
-import { Suspense, useContext, useMemo } from 'react'
+import { Suspense, useContext } from 'react'
 import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'
 import { Build } from './Build'
 import { BuildEquipped } from './BuildEquipped'
@@ -35,16 +35,8 @@ export default function BuildEditorBtn() {
     },
   } = useContext(TeamCharacterContext)
   const weaponTypeKey = getCharData(characterKey).weaponType
-  const name = useMemo(() => {
-    switch (buildType) {
-      case 'equipped':
-        return 'Equipped Build'
-      case 'real':
-        return database.builds.get(buildId)?.name ?? ''
-      case 'tc':
-        return database.buildTcs.get(buildTcId)?.name ?? ''
-    }
-  }, [database, buildType, buildId, buildTcId])
+  // TODO: Translate for the `equippedName` variable
+  const name = database.teamChars.getActiveBuildName(teamCharId)
   return (
     <>
       <Button

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/AllowChar.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/AllowChar.tsx
@@ -563,7 +563,6 @@ function SelectItem({
     setCharListMode(mode)
     setCharList(new Set([...charList]).add(locKey))
   }, [selected, setCharListMode, setCharList, charList, locKey])
-  const disableTooltip = useMemo(() => charList.size !== 0, [charList.size])
   const allowed =
     // Character is already allowed, and not selected to be excluded
     (selected &&
@@ -607,7 +606,6 @@ function SelectItem({
         characterKey={database.chars.LocationToCharacterKey(locKey)}
         onMouseDown={onMouseDown}
         onMouseEnter={onMouseEnter}
-        disableTooltip={disableTooltip}
       />
       {content}
     </CardLight>

--- a/apps/frontend/src/app/PageTeams/TeamCard.tsx
+++ b/apps/frontend/src/app/PageTeams/TeamCard.tsx
@@ -1,23 +1,53 @@
-import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
+import {
+  BootstrapTooltip,
+  CardThemed,
+  SqBadge,
+} from '@genshin-optimizer/common/ui'
 import { hexToColor, range } from '@genshin-optimizer/common/util'
 import type { CharacterKey, ElementKey } from '@genshin-optimizer/gi/consts'
-import { useDatabase, useTeam } from '@genshin-optimizer/gi/db-ui'
+import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
+import {
+  useCharacter,
+  useDBMeta,
+  useDatabase,
+  useTeam,
+  useTeamChar,
+} from '@genshin-optimizer/gi/db-ui'
+import CheckroomIcon from '@mui/icons-material/Checkroom'
 import InfoIcon from '@mui/icons-material/Info'
-import { Box, CardActionArea, Grid, Typography } from '@mui/material'
+import PersonIcon from '@mui/icons-material/Person'
+import { Box, CardActionArea, Grid, Skeleton, Typography } from '@mui/material'
+import { Suspense, useMemo } from 'react'
+import {
+  CharacterCardHeader,
+  CharacterCardHeaderContent,
+} from '../Components/Character/CharacterCard/CharacterCardHeader'
 import CharacterCardPico, {
   BlankCharacterCardPico,
 } from '../Components/Character/CharacterCardPico'
+import type { CharacterContextObj } from '../Context/CharacterContext'
+import { CharacterContext } from '../Context/CharacterContext'
+import type { dataContextObj } from '../Context/DataContext'
+import { DataContext } from '../Context/DataContext'
 import { getCharSheet } from '../Data/Characters'
+import { getArtifactData } from '../PageTeam/CharacterDisplay/Tabs/TabTheorycraft/optimizeTc'
+import useCharData from '../ReactHooks/useCharData'
+import {
+  CharacterCardEquipmentRow,
+  CharacterCardEquipmentRowTC,
+} from '../Components/Character/CharacterCard/CharacterCardEquipmentRow'
 
 // TODO: Translation
 
 export default function TeamCard({
   teamId,
   onClick,
+  hoverCard = false,
   bgt,
 }: {
   teamId: string
   bgt?: 'light' | 'dark'
+  hoverCard?: boolean
   onClick: (cid?: CharacterKey) => void
 }) {
   const team = useTeam(teamId)!
@@ -70,28 +100,145 @@ export default function TeamCard({
 
         <Box sx={{ p: 1 }}>
           <Grid container columns={4} spacing={1}>
-            {range(0, 3).map((i) => (
-              <Grid key={i} item xs={1} height="100%">
-                {teamCharIds[i] ? (
-                  <CardActionArea
-                    onClick={() =>
-                      onClick(database.teamChars.get(teamCharIds[i])?.key)
-                    }
-                  >
-                    <CharacterCardPico
-                      characterKey={database.teamChars.get(teamCharIds[i])!.key}
-                    />
-                  </CardActionArea>
-                ) : (
-                  <CardActionArea onClick={() => onClick()}>
-                    <BlankCharacterCardPico index={i} />
-                  </CardActionArea>
-                )}
-              </Grid>
-            ))}
+            {range(0, 3).map((i) => {
+              const teamCharId = teamCharIds[i]
+              const characterKey =
+                teamCharId && database.teamChars.get(teamCharId)?.key
+              return (
+                <Grid key={i} item xs={1} height="100%">
+                  {characterKey ? (
+                    <CardActionArea onClick={() => onClick(characterKey)}>
+                      <CharacterCardPico
+                        characterKey={characterKey}
+                        hoverChild={
+                          hoverCard && (
+                            <HoverCard
+                              characterKey={characterKey}
+                              teamCharId={teamCharId}
+                            />
+                          )
+                        }
+                      />
+                    </CardActionArea>
+                  ) : (
+                    <CardActionArea onClick={() => onClick()}>
+                      <BlankCharacterCardPico index={i} />
+                    </CardActionArea>
+                  )}
+                </Grid>
+              )
+            })}
           </Grid>
         </Box>
       </Box>
     </CardThemed>
+  )
+}
+function HoverCard({
+  characterKey,
+  teamCharId,
+}: {
+  characterKey: CharacterKey
+  teamCharId: string
+}) {
+  const database = useDatabase()
+  const character = useCharacter(characterKey)
+  const { gender } = useDBMeta()
+  const characterSheet = getCharSheet(characterKey, gender)
+
+  const { name, buildType, buildTcId, buildIds, buildTcIds } =
+    useTeamChar(teamCharId)!
+  const buildname = database.teamChars.getActiveBuildName(teamCharId)
+  const weapon = (() => {
+    return database.teamChars.getLoadoutWeapon(teamCharId)
+  })()
+  const arts = (() => {
+    if (buildType === 'tc' && buildTcId)
+      return getArtifactData(database.buildTcs.get(buildTcId)!)
+    return Object.values(
+      database.teamChars.getLoadoutArtifacts(teamCharId)
+    ).filter((a) => a) as ICachedArtifact[]
+  })()
+
+  const teamData = useCharData(characterKey, undefined, arts, weapon)
+  const data = teamData?.[characterKey]?.target
+
+  const characterContextObj: CharacterContextObj | undefined = useMemo(
+    () =>
+      character &&
+      characterSheet && {
+        character,
+        characterSheet,
+        characterDispatch: () => {},
+      },
+    [character, characterSheet]
+  )
+  const dataContextObj: dataContextObj | undefined = useMemo(
+    () =>
+      data &&
+      teamData && {
+        data,
+        teamData,
+      },
+    [data, teamData]
+  )
+  if (!characterContextObj || !dataContextObj) return null
+  return (
+    <CharacterContext.Provider value={characterContextObj}>
+      <DataContext.Provider value={dataContextObj}>
+        <Box sx={{ width: 300, m: -1 }}>
+          <Suspense
+            fallback={
+              <Skeleton variant="rectangular" width="100%" height={300} />
+            }
+          >
+            <CardThemed>
+              <CharacterCardHeader characterKey={characterKey}>
+                <CharacterCardHeaderContent characterKey={characterKey} />
+              </CharacterCardHeader>
+              <Box
+                sx={{ p: 1, display: 'flex', flexDirection: 'column', gap: 1 }}
+              >
+                <Typography>
+                  <SqBadge
+                    sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
+                  >
+                    <PersonIcon />
+                    <span>{name}</span>
+                  </SqBadge>
+                </Typography>
+                <Typography sx={{ display: 'flex', gap: 1 }}>
+                  <SqBadge
+                    color={buildIds.length ? 'success' : 'secondary'}
+                    sx={{ flexGrow: 1 }}
+                  >
+                    {buildIds.length} Builds
+                  </SqBadge>
+                  <SqBadge
+                    color={buildTcIds.length ? 'success' : 'secondary'}
+                    sx={{ flexGrow: 1 }}
+                  >
+                    {buildTcIds.length} TC Builds
+                  </SqBadge>
+                </Typography>
+                <Typography>
+                  <SqBadge
+                    sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
+                  >
+                    <CheckroomIcon />
+                    <span>{buildname}</span>
+                  </SqBadge>
+                </Typography>
+                {buildType === 'tc' && buildTcId ? (
+                  <CharacterCardEquipmentRowTC weapon={weapon} />
+                ) : (
+                  <CharacterCardEquipmentRow />
+                )}
+              </Box>
+            </CardThemed>
+          </Suspense>
+        </Box>
+      </DataContext.Provider>
+    </CharacterContext.Provider>
   )
 }

--- a/apps/frontend/src/app/PageTeams/index.tsx
+++ b/apps/frontend/src/app/PageTeams/index.tsx
@@ -238,6 +238,7 @@ export default function PageTeams() {
                 teamId={tid}
                 bgt="light"
                 onClick={(cid) => navigate(`${tid}${cid ? `/${cid}` : ''}`)}
+                hoverCard
               />
             </Grid>
           ))}

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -514,4 +514,17 @@ export class TeamCharacterDataManager extends DataManager<
       return this.database.buildTcs.follow(teamChar.compareBuildTcId, callback)
     return () => {}
   }
+  getActiveBuildName(teamCharId: string, equippedName = 'Equipped Build') {
+    const teamChar = this.database.teamChars.get(teamCharId)
+    if (!teamChar) return
+    const { buildType, buildId, buildTcId } = teamChar
+    switch (buildType) {
+      case 'equipped':
+        return equippedName
+      case 'real':
+        return this.database.builds.get(buildId)?.name ?? ''
+      case 'tc':
+        return this.database.buildTcs.get(buildTcId)?.name ?? ''
+    }
+  }
 }


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Old behaviour: shows character with currently equipped build, not the build used in the loadout
Update the loadout + build information to the hover information
<img width="385" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/55ecb820-d123-4bc9-beaa-e0efcd5d5d09">
<img width="362" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/f438b79c-267b-4d6f-9214-924220eca5d6">

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1649

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
