### PR TITLE
Add indicator for current build/equipped in generated builds

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -49,7 +49,6 @@ export function BuildEquipped({ active = false }: { active: boolean }) {
     <CardThemed
       bgt="light"
       sx={{
-        undefined,
         boxShadow: active ? '0px 0px 0px 2px green inset' : undefined,
       }}
     >

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetBadges.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ArtifactSetBadges.tsx
@@ -13,25 +13,23 @@ import { getArtSheet } from '../../../../../Data/Artifacts'
 
 type ArtifactSetBadgesProps = {
   artifacts: ICachedArtifact[]
-  currentlyEquipped?: boolean
 }
-export function ArtifactSetBadges({
-  artifacts,
-  currentlyEquipped = false,
-}: ArtifactSetBadgesProps) {
-  const setToSlots: Partial<Record<ArtifactSetKey, ArtifactSlotKey[]>> =
-    useMemo(
-      () =>
-        artifacts
-          .filter((arti) => arti)
-          .reduce((acc, curr) => {
-            acc[curr.setKey]
-              ? acc[curr.setKey].push(curr.slotKey)
-              : (acc[curr.setKey] = [curr.slotKey])
-            return acc
-          }, {}),
-      [artifacts]
-    )
+export function ArtifactSetBadges({ artifacts }: ArtifactSetBadgesProps) {
+  const setToSlots = useMemo(() => {
+    const setToSlots: Partial<Record<ArtifactSetKey, ArtifactSlotKey[]>> =
+      artifacts
+        .filter((arti) => arti)
+        .reduce((acc, curr) => {
+          acc[curr.setKey]
+            ? acc[curr.setKey].push(curr.slotKey)
+            : (acc[curr.setKey] = [curr.slotKey])
+          return acc
+        }, {})
+    Object.keys(setToSlots).forEach((setKey) => {
+      if (setToSlots[setKey]?.length === 1) delete setToSlots[setKey]
+    })
+    return setToSlots
+  }, [artifacts])
   return (
     <>
       {Object.entries(setToSlots)
@@ -40,23 +38,16 @@ export function ArtifactSetBadges({
             slotarr2.length - slotarr1.length
         )
         .map(([key, slotarr]) => (
-          <ArtifactSetBadge
-            key={key}
-            setKey={key}
-            currentlyEquipped={currentlyEquipped}
-            slotarr={slotarr}
-          />
+          <ArtifactSetBadge key={key} setKey={key} slotarr={slotarr} />
         ))}
     </>
   )
 }
 function ArtifactSetBadge({
   setKey,
-  currentlyEquipped = false,
   slotarr,
 }: {
   setKey: ArtifactSetKey
-  currentlyEquipped: boolean
   slotarr: ArtifactSlotKey[]
 }) {
   const artifactSheet = getArtSheet(setKey)
@@ -67,10 +58,7 @@ function ArtifactSetBadge({
   return (
     <Box>
       <ArtifactSetTooltip artifactSheet={artifactSheet} numInSet={numInSet}>
-        <SqBadge
-          sx={{ height: '100%' }}
-          color={currentlyEquipped ? 'success' : 'primary'}
-        >
+        <SqBadge sx={{ height: '100%' }} color={'primary'}>
           <Typography>
             {slotarr.map((slotKey) => (
               <SlotIcon

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -302,7 +302,7 @@ export default function BuildDisplayItem({
               disabled={disabled || isActiveBuild}
               startIcon={<Checkroom />}
             >
-              Equip Build
+              Equip to Current Build
             </Button>
             {extraButtonsRight}
           </Box>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -299,7 +299,7 @@ export default function BuildDisplayItem({
               size="small"
               color="success"
               onClick={equipBuild}
-              disabled={disabled || currentlyEquipped}
+              disabled={disabled || isActiveBuild}
               startIcon={<Checkroom />}
             >
               Equip Build

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/CustomTooltip.tsx
@@ -22,6 +22,7 @@ import CardDark from '../../../../../../Components/Card/CardDark'
 import CloseButton from '../../../../../../Components/CloseButton'
 import SqBadge from '../../../../../../Components/SqBadge'
 import WeaponCardPico from '../../../../../../Components/Weapon/WeaponCardPico'
+import { CharacterContext } from '../../../../../../Context/CharacterContext'
 import { DataContext } from '../../../../../../Context/DataContext'
 import { input } from '../../../../../../Formula'
 import { ArtifactSetBadges } from '../ArtifactSetBadges'
@@ -49,7 +50,9 @@ export default function CustomTooltip({
   const database = useDatabase()
   const { data } = useContext(DataContext)
   const { t } = useTranslation('page_character_optimize')
-
+  const {
+    character: { equippedArtifacts, equippedWeapon },
+  } = useContext(CharacterContext)
   const artifactsBySlot: Record<ArtifactSlotKey, ICachedArtifact | undefined> =
     useMemo(
       () =>
@@ -72,6 +75,12 @@ export default function CustomTooltip({
   )
 
   const currentlyEquipped =
+    equippedWeapon === selectedPoint?.build?.weaponId &&
+    allArtifactSlotKeys.every(
+      (slotKey) => artifactsBySlot[slotKey]?.id === equippedArtifacts[slotKey]
+    )
+
+  const activeBuild =
     data.get(input.weapon.id).value?.toString() ===
       selectedPoint?.build?.weaponId &&
     artifactsBySlot &&
@@ -117,12 +126,17 @@ export default function CustomTooltip({
                     <strong>{t('currentlyEquippedBuild')}</strong>
                   </SqBadge>
                 )}
+                {activeBuild && (
+                  <SqBadge color="success">
+                    {/* TODO: Translation */}
+                    <strong>Active Build</strong>
+                  </SqBadge>
+                )}
                 {generLabel && <SqBadge color="info">{generLabel}</SqBadge>}
                 {graphLabel && <SqBadge color="info">{graphLabel}</SqBadge>}
                 <Suspense fallback={<Skeleton width={300} height={50} />}>
                   <ArtifactSetBadges
                     artifacts={Object.values(artifactsBySlot)}
-                    currentlyEquipped={currentlyEquipped}
                   />
                 </Suspense>
               </Stack>


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Show whether a generated build is equipped (and if its a saved build)
<img width="940" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/550742d1-0a64-457e-8e0b-4642b80d9058">

Show whether a generated build is the "current build" (and if multiple builds match)
<img width="949" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/5a37b78b-4edd-4d46-825d-c07199dad18d">


Update Opt Graph
<img width="396" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/7ab9b741-42df-4485-aa82-9b79b15eb5c8">

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1592

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
