### PR TITLE
Fix various teambuffs that relied on specific active character assumptions

### DIFF
--- a/apps/frontend/src/app/Data/Characters/HuTao/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/HuTao/index.tsx
@@ -111,20 +111,18 @@ const atk = equal(
 const infusion = equalStr('on', condAfterlife, elementKey)
 
 const [condA1Path, condA1] = cond(key, 'FlutterBy')
-const critRateTeam_1 = greaterEq(
+const critRateTeam_1Disp = greaterEq(
   input.asc,
   1,
-  equal(
-    'on',
-    condA1,
-    unequal(
-      input.activeCharKey,
-      target.charKey,
-      percent(dm.passive1.critRateInc),
-      { ...KeyMap.info('critRate_'), isTeamBuff: true }
-    )
-  )
+  equal('on', condA1, percent(dm.passive1.critRateInc), {
+    ...KeyMap.info('critRate_'),
+    isTeamBuff: true,
+  })
 )
+const critRateTeam_1 = unequal(key, target.charKey, critRateTeam_1Disp, {
+  ...KeyMap.info('critRate_'),
+  isTeamBuff: true,
+})
 const [condA4Path, condA4] = cond(key, 'SanguineRouge')
 const pyro_dmg_ = greaterEq(
   input.asc,
@@ -133,20 +131,18 @@ const pyro_dmg_ = greaterEq(
 )
 
 const [condC4Path, condC4] = cond(key, 'GardenOfEternalRest')
-const critRateTeam_2 = greaterEq(
+const critRateTeam_2Disp = greaterEq(
   input.constellation,
   4,
-  equal(
-    'on',
-    condC4,
-    unequal(
-      input.activeCharKey,
-      target.charKey,
-      percent(dm.constellation4.critRateInc),
-      { ...KeyMap.info('critRate_'), isTeamBuff: true }
-    )
-  )
+  equal('on', condC4, percent(dm.constellation4.critRateInc), {
+    ...KeyMap.info('critRate_'),
+    isTeamBuff: true,
+  })
 )
+const critRateTeam_2 = unequal(key, target.charKey, critRateTeam_2Disp, {
+  ...KeyMap.info('critRate_'),
+  isTeamBuff: true,
+})
 
 const [condC6Path, condC6] = cond(key, 'ButterflysEmbrace')
 const critRate_ = greaterEq(
@@ -410,7 +406,7 @@ const sheet: ICharacterSheet = {
           on: {
             fields: [
               {
-                node: critRateTeam_1,
+                node: critRateTeam_1Disp,
               },
               {
                 text: stg('duration'),
@@ -449,13 +445,12 @@ const sheet: ICharacterSheet = {
         value: condC4,
         path: condC4Path,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, target.charKey, 1),
         name: ct.ch('constellation4.condName'),
         states: {
           on: {
             fields: [
               {
-                node: critRateTeam_2,
+                node: critRateTeam_2Disp,
               },
               {
                 text: stg('duration'),

--- a/apps/frontend/src/app/Data/Characters/HuTao/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/HuTao/index.tsx
@@ -1,7 +1,7 @@
 import type { CharacterKey, ElementKey } from '@genshin-optimizer/gi/consts'
 import { allElementWithPhyKeys } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
-import { input } from '../../../Formula'
+import { input, target } from '../../../Formula'
 import {
   equal,
   equalStr,
@@ -119,7 +119,7 @@ const critRateTeam_1 = greaterEq(
     condA1,
     unequal(
       input.activeCharKey,
-      input.charKey,
+      target.charKey,
       percent(dm.passive1.critRateInc),
       { ...KeyMap.info('critRate_'), isTeamBuff: true }
     )
@@ -141,7 +141,7 @@ const critRateTeam_2 = greaterEq(
     condC4,
     unequal(
       input.activeCharKey,
-      input.charKey,
+      target.charKey,
       percent(dm.constellation4.critRateInc),
       { ...KeyMap.info('critRate_'), isTeamBuff: true }
     )
@@ -405,7 +405,6 @@ const sheet: ICharacterSheet = {
         value: condA1,
         path: condA1Path,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, input.charKey, 1),
         name: ct.ch('paramita.end'),
         states: {
           on: {
@@ -450,7 +449,7 @@ const sheet: ICharacterSheet = {
         value: condC4,
         path: condC4Path,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, input.charKey, 1),
+        canShow: unequal(input.activeCharKey, target.charKey, 1),
         name: ct.ch('constellation4.condName'),
         states: {
           on: {

--- a/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
@@ -15,6 +15,7 @@ import {
   sum,
   unequal,
 } from '../../../Formula/utils'
+import KeyMap from '../../../KeyMap'
 import { cond, st, stg } from '../../SheetUtil'
 import CharacterSheet from '../CharacterSheet'
 import type { ICharacterSheet } from '../ICharacterSheet.d'
@@ -124,9 +125,7 @@ function skillDmg(atkType: number[]) {
 
 const energyCosts = [40, 50, 60, 70, 80, 90]
 const [condSkillEyeTeamPath, condSkillEyeTeam] = cond(key, 'skillEyeTeam')
-const skillEyeTeamBurstDmgInc = unequal(
-  input.activeCharKey,
-  target.charKey,
+const skillEyeTeamBurstDmgIncDisp = infoMut(
   prod(
     lookup(
       condSkillEyeTeam,
@@ -137,7 +136,13 @@ const skillEyeTeamBurstDmgInc = unequal(
       fixed: 2,
       unit: '%',
     })
-  )
+  ),
+  { ...KeyMap.info('burst_dmg_'), isTeamBuff: true }
+)
+const skillEyeTeamBurstDmgInc = unequal(
+  key,
+  target.charKey,
+  skillEyeTeamBurstDmgIncDisp
 )
 
 const resolveStacks = [10, 20, 30, 40, 50, 60]
@@ -387,7 +392,6 @@ const sheet: ICharacterSheet = {
         value: condSkillEyeTeam,
         path: condSkillEyeTeamPath,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, target.charKey, 1),
         name: ct.ch('skill.partyCost'),
         states: Object.fromEntries(
           energyCosts.map((c) => [
@@ -396,7 +400,7 @@ const sheet: ICharacterSheet = {
               name: `${c}`,
               fields: [
                 {
-                  node: skillEyeTeamBurstDmgInc,
+                  node: skillEyeTeamBurstDmgIncDisp,
                 },
               ],
             },

--- a/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
+++ b/apps/frontend/src/app/Data/Characters/RaidenShogun/index.tsx
@@ -1,7 +1,7 @@
 import { objKeyMap } from '@genshin-optimizer/common/util'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
-import { input } from '../../../Formula'
+import { input, target } from '../../../Formula'
 import {
   constant,
   equal,
@@ -126,7 +126,7 @@ const energyCosts = [40, 50, 60, 70, 80, 90]
 const [condSkillEyeTeamPath, condSkillEyeTeam] = cond(key, 'skillEyeTeam')
 const skillEyeTeamBurstDmgInc = unequal(
   input.activeCharKey,
-  input.charKey,
+  target.charKey,
   prod(
     lookup(
       condSkillEyeTeam,
@@ -206,7 +206,7 @@ const c4AtkBonus_ = greaterEq(
   equal(
     'c4',
     condC4,
-    unequal(input.activeCharKey, input.charKey, dm.constellation4.atk_bonus)
+    unequal(input.activeCharKey, target.charKey, dm.constellation4.atk_bonus)
   )
 )
 
@@ -387,7 +387,7 @@ const sheet: ICharacterSheet = {
         value: condSkillEyeTeam,
         path: condSkillEyeTeamPath,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, input.charKey, 1),
+        canShow: unequal(input.activeCharKey, target.charKey, 1),
         name: ct.ch('skill.partyCost'),
         states: Object.fromEntries(
           energyCosts.map((c) => [
@@ -579,7 +579,7 @@ const sheet: ICharacterSheet = {
         value: condC4,
         path: condC4Path,
         teamBuff: true,
-        canShow: unequal(input.activeCharKey, input.charKey, 1),
+        canShow: unequal(input.activeCharKey, target.charKey, 1),
         name: ct.ch('c4.expires'),
         states: {
           c4: {

--- a/apps/frontend/src/app/Data/SheetUtil.tsx
+++ b/apps/frontend/src/app/Data/SheetUtil.tsx
@@ -86,12 +86,12 @@ function NameTrans({
 }
 
 export function activeCharBuff(
-  key: string | StrNode,
+  buffTargetKey: string | StrNode,
   node: NumNode,
   info: Info
 ) {
   return [
     infoMut(node, { ...info, isTeamBuff: true }),
-    equal(input.activeCharKey, key, node),
+    equal(input.activeCharKey, buffTargetKey, node),
   ]
 }

--- a/apps/frontend/src/app/Data/Weapons/Catalyst/AThousandFloatingDreams/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Catalyst/AThousandFloatingDreams/index.tsx
@@ -62,6 +62,7 @@ const team_eleMasDisp = equal(
   subscript(input.weapon.refinement, team_eleMasArr),
   { ...KeyMap.info('eleMas'), isTeamBuff: true }
 )
+// Apply to non-equipped character
 const team_eleMas = unequal(input.charKey, target.charKey, team_eleMasDisp)
 
 export const data = dataObjForWeaponSheet(key, data_gen, {

--- a/apps/frontend/src/app/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Catalyst/ThrillingTalesOfDragonSlayers/index.tsx
@@ -40,7 +40,6 @@ const sheet: IWeaponSheet = {
       value: condPassive,
       path: condPassivePath,
       name: trm('condName'),
-      canShow: unequal(input.activeCharKey, input.charKey, 1),
       teamBuff: true,
       header: headerTemplate(key, st('conditional')),
       states: {

--- a/apps/frontend/src/app/Data/Weapons/Catalyst/WanderingEvenstar/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Catalyst/WanderingEvenstar/index.tsx
@@ -28,6 +28,7 @@ const selfAtk = equal(
   )
 )
 const teamAtkDisp = equal(input.weapon.key, key, prod(percent(0.3), selfAtk))
+// Apply to non-equipped character
 const teamAtk = unequal(input.activeCharKey, input.charKey, teamAtkDisp)
 
 const data = dataObjForWeaponSheet(

--- a/apps/frontend/src/app/Data/Weapons/Claymore/MakhairaAquamarine/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Claymore/MakhairaAquamarine/index.tsx
@@ -28,6 +28,7 @@ const selfAtk = equal(
   )
 )
 const teamAtkDisp = equal(input.weapon.key, key, prod(percent(0.3), selfAtk))
+// Apply to non-equipped character
 const teamAtk = unequal(input.activeCharKey, input.charKey, teamAtkDisp)
 
 const data = dataObjForWeaponSheet(

--- a/apps/frontend/src/app/Data/Weapons/Polearm/CalamityQueller/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Polearm/CalamityQueller/index.tsx
@@ -9,7 +9,6 @@ import {
   lookup,
   prod,
   subscript,
-  unequal,
 } from '../../../../Formula/utils'
 import { cond, st, trans } from '../../../SheetUtil'
 import type { IWeaponSheet } from '../../IWeaponSheet'
@@ -22,7 +21,6 @@ const data_gen = allStats.weapon.data[key]
 const [, trm] = trans('weapon', key)
 
 const [condStackPath, condStack] = cond(key, 'stack')
-const [condOffFieldPath, condOffField] = cond(key, 'offField')
 
 const dmg_ = [-1, 0.12, 0.15, 0.18, 0.21, 0.24]
 const atk_ = [-1, 0.032, 0.04, 0.048, 0.056, 0.064]
@@ -35,10 +33,10 @@ const dmg_Nodes = Object.fromEntries(
 )
 const atkInc = prod(
   compareEq(
-    condOffField,
-    'on',
-    constant(2, { name: trm('inactive') }),
-    constant(1, { name: trm('active') })
+    input.charKey,
+    input.activeCharKey,
+    constant(1, { name: trm('active') }),
+    constant(2, { name: trm('inactive') })
   ),
   lookup(
     condStack,
@@ -79,19 +77,6 @@ const sheet: IWeaponSheet = {
           },
         ])
       ),
-    },
-    {
-      canShow: unequal(condStack, undefined, 1),
-      value: condOffField,
-      path: condOffFieldPath,
-      teamBuff: true,
-      header: headerTemplate(key, st('conditional')),
-      name: st('charOffField'),
-      states: {
-        on: {
-          fields: [],
-        },
-      },
     },
   ],
 }

--- a/apps/frontend/src/app/Data/Weapons/Sword/SwordOfDescension/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Sword/SwordOfDescension/index.tsx
@@ -21,6 +21,7 @@ import { dataObjForWeaponSheet } from '../../util'
 const key: WeaponKey = 'SwordOfDescension'
 const data_gen = allStats.weapon.data[key]
 
+// Check equipped character is Traveler
 const atk = lookup(
   input.charKey,
   objKeyMap(allTravelerKeys, (_) => constant(66)),

--- a/apps/frontend/src/app/Data/Weapons/Sword/XiphosMoonlight/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Sword/XiphosMoonlight/index.tsx
@@ -1,6 +1,6 @@
 import type { WeaponKey } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
-import { input } from '../../../../Formula'
+import { input, target } from '../../../../Formula'
 import {
   equal,
   infoMut,
@@ -37,7 +37,7 @@ const teamEnerRech_disp = equal(
 )
 const teamEnerRech_ = unequal(
   input.activeCharKey,
-  input.charKey,
+  target.charKey,
   teamEnerRech_disp
 )
 

--- a/apps/frontend/src/app/Data/Weapons/Sword/XiphosMoonlight/index.tsx
+++ b/apps/frontend/src/app/Data/Weapons/Sword/XiphosMoonlight/index.tsx
@@ -35,11 +35,8 @@ const teamEnerRech_disp = equal(
   key,
   prod(percent(0.3), selfEnerRech_)
 )
-const teamEnerRech_ = unequal(
-  input.activeCharKey,
-  target.charKey,
-  teamEnerRech_disp
-)
+// Apply to non-equipped character
+const teamEnerRech_ = unequal(input.charKey, target.charKey, teamEnerRech_disp)
 
 const data = dataObjForWeaponSheet(
   key,


### PR DESCRIPTION
## Describe your changes

* Fixed various buffs that had pre-teams assumptions on active character/who could be optimized for
* Fixed display of various teambuffs with assumptions pre-teams
* Updated Calamity Queller to determine off-field state automatically

## Issue or discord link

- Resolves #1634 

## Testing/validation

Tested each change and ensured they were performing as expected

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
