### PR TITLE
Reduce columns for stat display

### DIFF
--- a/apps/frontend/src/app/Components/Character/StatDisplayComponent.tsx
+++ b/apps/frontend/src/app/Components/Character/StatDisplayComponent.tsx
@@ -1,5 +1,6 @@
 import { objMap } from '@genshin-optimizer/common/util'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import type { MasonryProps } from '@mui/lab'
 import { Masonry } from '@mui/lab'
 import { Box, Divider, ListItem } from '@mui/material'
 import { useContext, useMemo } from 'react'
@@ -15,7 +16,11 @@ import { FieldDisplayList, NodeFieldDisplay } from '../FieldDisplay'
 import ImgIcon from '../Image/ImgIcon'
 import SqBadge from '../SqBadge'
 
-export default function StatDisplayComponent() {
+export default function StatDisplayComponent({
+  columns = { xs: 1, sm: 2, md: 3, xl: 4 },
+}: {
+  columns?: MasonryProps['columns']
+}) {
   const { data } = useContext(DataContext)
   const sections = useMemo(
     () =>
@@ -26,7 +31,7 @@ export default function StatDisplayComponent() {
   )
   return (
     <Box sx={{ mr: -1, mb: -1 }}>
-      <Masonry columns={{ xs: 1, sm: 2, md: 3, xl: 4 }} spacing={1}>
+      <Masonry columns={columns} spacing={1}>
         {sections.map(([key, Nodes]) => (
           <Section key={key} displayNs={Nodes} sectionKey={key} />
         ))}

--- a/apps/frontend/src/app/Components/FieldDisplay.tsx
+++ b/apps/frontend/src/app/Components/FieldDisplay.tsx
@@ -14,7 +14,15 @@ import {
   Typography,
   styled,
 } from '@mui/material'
-import React, { Suspense, useCallback, useContext, useMemo } from 'react'
+import type {
+  ReactNode
+} from 'react'
+import React, {
+  Suspense,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react'
 import { DataContext } from '../Context/DataContext'
 import { FormulaDataContext } from '../Context/FormulaDataContext'
 import type { NodeDisplay } from '../Formula/api'
@@ -121,26 +129,29 @@ export function NodeFieldDisplay({
   const { multi } = node.info
 
   const multiDisplay = multi && <span>{multi}&#215;</span>
-  let fieldVal = '' as Displayable
+  let fieldVal = false as ReactNode
   if (oldValue !== undefined) {
     const diff = node.value - oldValue
     const pctDiff = valueString(Math.abs(diff / oldValue), '%', node.info.fixed)
     fieldVal = (
-      <span>
-        {valueString(oldValue, node.info.unit, node.info.fixed)}
-        {diff > 0.0001 || diff < -0.0001 ? (
-          <ColorText color={diff > 0 ? 'success' : 'error'}>
-            {' '}
-            {diff > 0 ? '+' : ''}
-            {valueString(diff, node.info.unit, node.info.fixed)}
-            {node.info.unit !== '%' && oldValue !== 0 ? ` (${pctDiff})` : ''}
-          </ColorText>
-        ) : (
-          ''
+      <>
+        <span>{valueString(oldValue, node.info.unit, node.info.fixed)}</span>
+        {Math.abs(diff) > 0.0001 && (
+          <>
+            <ColorText color={diff > 0 ? 'success' : 'error'}>
+              {diff > 0 ? '+' : ''}
+              {valueString(diff, node.info.unit, node.info.fixed)}
+            </ColorText>
+            {node.info.unit !== '%' && oldValue !== 0 && (
+              <ColorText color={diff > 0 ? 'success' : 'error'}>
+                ({pctDiff})
+              </ColorText>
+            )}
+          </>
         )}
-      </span>
+      </>
     )
-  } else fieldVal = nodeVStr(node)
+  } else fieldVal = <span>{nodeVStr(node)}</span>
 
   return (
     <Box
@@ -154,51 +165,57 @@ export function NodeFieldDisplay({
       component={component}
     >
       <NodeFieldDisplayText node={node} />
-      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-        <Typography noWrap>
-          {multiDisplay}
-          {fieldVal}
-        </Typography>
-        {!!node.formula && (
-          <BootstrapTooltip
-            placement="top"
-            title={
-              <Typography>
-                <Suspense
-                  fallback={
-                    <Skeleton variant="rectangular" width={300} height={30} />
-                  }
-                >
-                  {allAmpReactionKeys.includes(node.info.variant as any) && (
-                    <Box sx={{ display: 'inline-flex', gap: 1, mr: 1 }}>
-                      <Box>
-                        <AmpReactionModeText
-                          reaction={node.info.variant as AmpReactionKey}
-                          trigger={
-                            node.info.subVariant as
-                              | 'cryo'
-                              | 'pyro'
-                              | 'hydro'
-                              | undefined
-                          }
-                        />
-                      </Box>
-                      <Divider orientation="vertical" flexItem />
+      <Typography
+        sx={{
+          display: 'flex',
+          gap: 0.5,
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          flexWrap: 'wrap',
+        }}
+      >
+        {multiDisplay}
+        {fieldVal}
+      </Typography>
+      {!!node.formula && (
+        <BootstrapTooltip
+          placement="top"
+          title={
+            <Typography>
+              <Suspense
+                fallback={
+                  <Skeleton variant="rectangular" width={300} height={30} />
+                }
+              >
+                {allAmpReactionKeys.includes(node.info.variant as any) && (
+                  <Box sx={{ display: 'inline-flex', gap: 1, mr: 1 }}>
+                    <Box>
+                      <AmpReactionModeText
+                        reaction={node.info.variant as AmpReactionKey}
+                        trigger={
+                          node.info.subVariant as
+                            | 'cryo'
+                            | 'pyro'
+                            | 'hydro'
+                            | undefined
+                        }
+                      />
                     </Box>
-                  )}
-                  <span>{node.formula}</span>
-                </Suspense>
-              </Typography>
-            }
-          >
-            <HelpIcon
-              onClick={onClick}
-              fontSize="inherit"
-              sx={{ cursor: 'help' }}
-            />
-          </BootstrapTooltip>
-        )}
-      </Box>
+                    <Divider orientation="vertical" flexItem />
+                  </Box>
+                )}
+                <span>{node.formula}</span>
+              </Suspense>
+            </Typography>
+          }
+        >
+          <HelpIcon
+            onClick={onClick}
+            fontSize="inherit"
+            sx={{ cursor: 'help' }}
+          />
+        </BootstrapTooltip>
+      )}
     </Box>
   )
 }
@@ -208,7 +225,12 @@ export function NodeFieldDisplayText({ node }: { node: NodeDisplay }) {
   return (
     <Typography
       component="div"
-      sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
+      sx={{
+        display: 'flex',
+        gap: 1,
+        alignItems: 'center',
+        marginRight: 'auto',
+      }}
     >
       {!!node.info.isTeamBuff && <Groups />}
       {node.info.icon}

--- a/apps/frontend/src/app/Components/FieldDisplay.tsx
+++ b/apps/frontend/src/app/Components/FieldDisplay.tsx
@@ -14,15 +14,8 @@ import {
   Typography,
   styled,
 } from '@mui/material'
-import type {
-  ReactNode
-} from 'react'
-import React, {
-  Suspense,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react'
+import type { ReactNode } from 'react'
+import React, { Suspense, useCallback, useContext, useMemo } from 'react'
 import { DataContext } from '../Context/DataContext'
 import { FormulaDataContext } from '../Context/FormulaDataContext'
 import type { NodeDisplay } from '../Formula/api'

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
@@ -54,7 +54,9 @@ export default function TabOverview() {
               }}
             >
               <DataContext.Provider value={dataContextObj}>
-                <StatDisplayComponent />
+                <StatDisplayComponent
+                  columns={{ xs: 1, sm: 1, md: 1, lg: 2, xl: 3 }}
+                />
               </DataContext.Provider>
               <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                 <CompareBtn />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
@@ -32,14 +32,14 @@ export default function TabOverview() {
     <Stack spacing={1}>
       <Box>
         <Grid container spacing={1} sx={{ justifyContent: 'center' }}>
-          <Grid item xs={8} sm={8} md={4} lg={2.3}>
+          <Grid item xs={8} sm={8} md={3} lg={2.3}>
             <CharacterProfileCard />
           </Grid>
           <Grid
             item
             xs={12}
             sm={12}
-            md={8}
+            md={9}
             lg={9.7}
             sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
           >
@@ -55,7 +55,7 @@ export default function TabOverview() {
             >
               <DataContext.Provider value={dataContextObj}>
                 <StatDisplayComponent
-                  columns={{ xs: 1, sm: 1, md: 1, lg: 2, xl: 3 }}
+                  columns={{ xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }}
                 />
               </DataContext.Provider>
               <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
@@ -32,13 +32,13 @@ export default function TabOverview() {
     <Stack spacing={1}>
       <Box>
         <Grid container spacing={1} sx={{ justifyContent: 'center' }}>
-          <Grid item xs={8} sm={5} md={4} lg={2.3}>
+          <Grid item xs={8} sm={8} md={4} lg={2.3}>
             <CharacterProfileCard />
           </Grid>
           <Grid
             item
             xs={12}
-            sm={7}
+            sm={12}
             md={8}
             lg={9.7}
             sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -253,13 +253,13 @@ export default function TabTheorycraft() {
       <Stack spacing={1}>
         <Box>
           <Grid container spacing={1} sx={{ justifyContent: 'center' }}>
-            <Grid item xs={8} sm={5} md={4} lg={2.3}>
+            <Grid item xs={8} sm={8} md={4} lg={2.3}>
               <CharacterProfileCard />
             </Grid>
             <Grid
               item
               xs={12}
-              sm={7}
+              sm={12}
               md={8}
               lg={9.7}
               sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
@@ -268,7 +268,9 @@ export default function TabTheorycraft() {
                 <OptimizationTargetContext.Provider value={optimizationTarget}>
                   {dataContextValueWithOld ? (
                     <DataContext.Provider value={dataContextValueWithOld}>
-                      <StatDisplayComponent />
+                      <StatDisplayComponent
+                        columns={{ xs: 1, sm: 1, md: 1, lg: 2, xl: 3 }}
+                      />
                     </DataContext.Provider>
                   ) : (
                     <Skeleton variant="rectangular" width="100%" height={500} />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -253,14 +253,14 @@ export default function TabTheorycraft() {
       <Stack spacing={1}>
         <Box>
           <Grid container spacing={1} sx={{ justifyContent: 'center' }}>
-            <Grid item xs={8} sm={8} md={4} lg={2.3}>
+            <Grid item xs={8} sm={8} md={3} lg={2.3}>
               <CharacterProfileCard />
             </Grid>
             <Grid
               item
               xs={12}
               sm={12}
-              md={8}
+              md={9}
               lg={9.7}
               sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
             >
@@ -269,7 +269,7 @@ export default function TabTheorycraft() {
                   {dataContextValueWithOld ? (
                     <DataContext.Provider value={dataContextValueWithOld}>
                       <StatDisplayComponent
-                        columns={{ xs: 1, sm: 1, md: 1, lg: 2, xl: 3 }}
+                        columns={{ xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }}
                       />
                     </DataContext.Provider>
                   ) : (


### PR DESCRIPTION
## Describe your changes

Since the comparison UI were still scaled before we had % comparison, the increase in content due to comparison is pushing content off the grid.

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1683

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
