### PR TITLE
Active build/compare to be stored per team

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/Content.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/Content.tsx
@@ -10,6 +10,7 @@ import {
   charKeyToLocCharKey,
   charKeyToLocGenderedCharKey,
 } from '@genshin-optimizer/gi/consts'
+import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import { useDBMeta, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
 import { CharacterName, SillyContext } from '@genshin-optimizer/gi/ui'
@@ -215,10 +216,13 @@ function InTeam() {
       if (!loadoutTeamMap[teamCharId]) loadoutTeamMap[teamCharId] = []
     })
     database.teams.entries.forEach(([teamId, team]) => {
-      const teamCharIdWithCKey = team.teamCharIds.find(
-        (teamCharId) => database.teamChars.get(teamCharId)?.key === characterKey
+      const teamCharIdWithCKey = team.loadoutData.find(
+        (loadoutDatum) =>
+          loadoutDatum &&
+          database.teamChars.get(loadoutDatum?.teamCharId)?.key === characterKey
       )
-      if (teamCharIdWithCKey) loadoutTeamMap[teamCharIdWithCKey].push(teamId)
+      if (teamCharIdWithCKey)
+        loadoutTeamMap[teamCharIdWithCKey?.teamCharId].push(teamId)
     })
     return dbDirty && loadoutTeamMap
   }, [dbDirty, characterKey, database])
@@ -233,7 +237,7 @@ function InTeam() {
   const onAddTeam = (teamCharId: string) => {
     const teamId = database.teams.new()
     database.teams.set(teamId, (team) => {
-      team.teamCharIds[0] = teamCharId
+      team.loadoutData[0] = { teamCharId } as LoadoutDatum
     })
     navigate(`/teams/${teamId}`, { state: { openSetting: true } })
   }
@@ -241,7 +245,7 @@ function InTeam() {
     const teamId = database.teams.new()
     const teamCharId = database.teamChars.new(characterKey)
     database.teams.set(teamId, (team) => {
-      team.teamCharIds[0] = teamCharId
+      team.loadoutData[0] = { teamCharId } as LoadoutDatum
     })
     navigate(`/teams/${teamId}`, { state: { openSetting: true } })
   }

--- a/apps/frontend/src/app/Components/Character/CharacterMultiAutocomplete.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterMultiAutocomplete.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next'
 import { getCharSheet } from '../../Data/Characters'
 import { bulkCatTotal } from '../../Util/totalUtils'
 import CharIconSide from '../Image/CharIconSide'
+import { notEmpty } from '@genshin-optimizer/common/util'
 
 export function CharacterMultiAutocomplete({
   teamIds,
@@ -62,9 +63,8 @@ export function CharacterMultiAutocomplete({
     } as const
     return bulkCatTotal(catKeys, (ctMap) => {
       database.teams.values.forEach((team) => {
-        const { teamCharIds } = team
-
-        teamCharIds.forEach((teamCharId) => {
+        const { loadoutData } = team
+        loadoutData.filter(notEmpty).forEach(({ teamCharId }) => {
           const teamChar = database.teamChars.get(teamCharId)
           if (!teamChar) return
           const ck = teamChar.key
@@ -74,9 +74,8 @@ export function CharacterMultiAutocomplete({
       teamIds.forEach((teamId) => {
         const team = database.teams.get(teamId)
         if (!team) return
-        const { teamCharIds } = team
-
-        teamCharIds.forEach((teamCharId) => {
+        const { loadoutData } = team
+        loadoutData.filter(notEmpty).forEach(({ teamCharId }) => {
           const teamChar = database.teamChars.get(teamCharId)
           if (!teamChar) return
           const ck = teamChar.key

--- a/apps/frontend/src/app/Components/CompareBuildButton.tsx
+++ b/apps/frontend/src/app/Components/CompareBuildButton.tsx
@@ -69,19 +69,19 @@ function TeamWrapper({ artId, weaponId, onHide }: WrapperProps) {
     character: { key: characterKey },
   } = useContext(CharacterContext)
   const {
-    teamCharId,
+    loadoutDatum,
     teamChar: { optConfigId },
   } = useContext(TeamCharacterContext)
   const { mainStatAssumptionLevel } = useOptConfig(optConfigId)!
   const { data: oldData } = useContext(DataContext)
   const build = useMemo(() => {
     const newArt = database.arts.get(artId ?? '')
-    const equippedArtifacts = database.teamChars.getLoadoutArtifacts(teamCharId)
+    const equippedArtifacts = database.teams.getLoadoutArtifacts(loadoutDatum)
     const artmap = objMap(equippedArtifacts, (art, slot) =>
       slot === newArt?.slotKey ? newArt : art
     )
     return Object.values(artmap).filter((a) => a)
-  }, [database, teamCharId, artId])
+  }, [database, loadoutDatum, artId])
   const teamData = useTeamData(
     mainStatAssumptionLevel,
     build,

--- a/apps/frontend/src/app/Context/TeamCharacterContext.tsx
+++ b/apps/frontend/src/app/Context/TeamCharacterContext.tsx
@@ -1,10 +1,15 @@
-import type { Team, TeamCharacter } from '@genshin-optimizer/gi/db'
+import type {
+  LoadoutDatum,
+  Team,
+  TeamCharacter,
+} from '@genshin-optimizer/gi/db'
 import { createContext } from 'react'
 export type TeamCharacterContextObj = {
   teamId: string
   team: Team
   teamCharId: string
   teamChar: TeamCharacter
+  loadoutDatum: LoadoutDatum
 }
 
 // If using this context without a Provider, then stuff will crash...

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -11,13 +11,15 @@ import { Grid } from '@mui/material'
 import ArtifactCardNano from '../../../Components/Artifact/ArtifactCardNano'
 import WeaponCardNano from '../../../Components/Weapon/WeaponCardNano'
 export function BuildEquipped({ active = false }: { active: boolean }) {
-  const { teamCharId } = useContext(TeamCharacterContext)
+  const { teamId, teamCharId } = useContext(TeamCharacterContext)
   const {
     character: { key: characterKey, equippedArtifacts, equippedWeapon },
   } = useContext(CharacterContext)
   const database = useDatabase()
   const onActive = () =>
-    database.teamChars.set(teamCharId, { buildType: 'equipped' })
+    database.teams.setLoadoutDatum(teamId, teamCharId, {
+      buildType: 'equipped',
+    })
   const onDupe = () =>
     database.teamChars.newBuild(teamCharId, {
       name: 'Duplicate of Equipped',

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
@@ -46,15 +46,19 @@ export default function BuildReal({
 }) {
   const [open, onOpen, onClose] = useBoolState()
   const {
+    teamId,
     teamCharId,
     teamChar: { key: characterKey },
-    team: { teamCharIds },
+    team: { loadoutData },
   } = useContext(TeamCharacterContext)
   const { gender } = useDBMeta()
   const database = useDatabase()
   const { name, description, weaponId, artifactIds } = useBuild(buildId)!
   const onActive = () =>
-    database.teamChars.set(teamCharId, { buildType: 'real', buildId })
+    database.teams.setLoadoutDatum(teamId, teamCharId, {
+      buildType: 'real',
+      buildId,
+    })
   const onEquip = () => {
     // Cannot equip a build without weapon
     if (!weaponId) return
@@ -100,26 +104,26 @@ export default function BuildReal({
       artifactIds: artifactIds,
       weaponId: weaponId,
     })
-  const weaponUsedInTeamCharId = teamCharIds.find(
-    (tcId) =>
-      tcId &&
-      tcId !== teamCharId &&
-      database.teamChars.getLoadoutWeapon(tcId).id === weaponId
+  const weaponUsedInLoadoutDatum = loadoutData.find(
+    (loadoutDatum) =>
+      loadoutDatum &&
+      loadoutDatum.teamCharId !== teamCharId &&
+      database.teams.getLoadoutWeapon(loadoutDatum).id === weaponId
   )
   const weaponUsedInTeamCharKey =
-    weaponUsedInTeamCharId &&
-    database.teamChars.get(weaponUsedInTeamCharId)!.key
+    weaponUsedInLoadoutDatum &&
+    database.teamChars.get(weaponUsedInLoadoutDatum?.teamCharId)!.key
 
   const artUsedInTeamCharKeys = objKeyMap(allArtifactSlotKeys, (slotKey) => {
     const artId = artifactIds[slotKey]
     if (!artId) return undefined
-    const tcId = teamCharIds.find(
-      (tcId) =>
-        tcId &&
-        tcId !== teamCharId &&
-        database.teamChars.getLoadoutArtifacts(tcId)[slotKey]?.id === artId
+    const loadoutDatum = loadoutData.find(
+      (loadoutDatum) =>
+        loadoutDatum &&
+        loadoutDatum.teamCharId !== teamCharId &&
+        database.teams.getLoadoutArtifacts(loadoutDatum)[slotKey]?.id === artId
     )
-    return tcId && database.teamChars.get(tcId)!.key
+    return loadoutDatum && database.teamChars.get(loadoutDatum.teamCharId)!.key
   })
 
   const [showPrompt, onShowPrompt, OnHidePrompt] = useBoolState()

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildTc.tsx
@@ -32,12 +32,12 @@ export default function BuildTc({
   active: boolean
 }) {
   const [open, onOpen, onClose] = useBoolState()
-  const { teamCharId } = useContext(TeamCharacterContext)
+  const { teamId, teamCharId } = useContext(TeamCharacterContext)
   const database = useDatabase()
   const buildTc = useBuildTc(buildTcId)!
   const { name, description } = buildTc
   const onActive = () =>
-    database.teamChars.set(teamCharId, {
+    database.teams.setLoadoutDatum(teamId, teamCharId, {
       buildType: 'tc',
       buildTcId,
     })

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
@@ -15,21 +15,20 @@ import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
 export default function CompareBtn() {
   const database = useDatabase()
   const {
+    teamId,
     teamCharId,
-    teamChar: {
-      buildType,
-      buildId,
-      buildIds,
-      buildTcId,
-      buildTcIds,
-      compare,
-      compareType,
-      compareBuildId,
-      compareBuildTcId,
-      buildId: teamCharBuildId,
-      buildTcId: teamCharBuildTcId,
-    },
+    loadoutDatum,
+    teamChar: { buildIds, buildTcIds },
   } = useContext(TeamCharacterContext)
+  const {
+    buildType,
+    buildId,
+    buildTcId,
+    compare,
+    compareType,
+    compareBuildId,
+    compareBuildTcId,
+  } = loadoutDatum
   const selectedLabel =
     compareType === 'real' ? (
       database.builds.get(compareBuildId)?.name ?? ''
@@ -57,7 +56,9 @@ export default function CompareBtn() {
         startIcon={compare ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
         color={compare ? 'success' : 'secondary'}
         onClick={() =>
-          database.teamChars.set(teamCharId, { compare: !compare })
+          database.teams.setLoadoutDatum(teamId, teamCharId, {
+            compare: !compare,
+          })
         }
       >
         Compare
@@ -77,7 +78,7 @@ export default function CompareBtn() {
       >
         <MenuItem
           onClick={() =>
-            database.teamChars.set(teamCharId, {
+            database.teams.setLoadoutDatum(teamId, teamCharId, {
               compareType: 'equipped',
             })
           }
@@ -89,40 +90,40 @@ export default function CompareBtn() {
             </SqBadge>
           )}
         </MenuItem>
-        {buildIds.map((buildId) => (
+        {buildIds.map((bId) => (
           <MenuItem
-            disabled={!database.builds.get(buildId)?.weaponId}
-            key={buildId}
+            disabled={!database.builds.get(bId)?.weaponId}
+            key={bId}
             onClick={() =>
-              database.teamChars.set(teamCharId, {
+              database.teams.setLoadoutDatum(teamId, teamCharId, {
                 compareType: 'real',
-                compareBuildId: buildId,
+                compareBuildId: bId,
               })
             }
           >
-            {database.builds.get(buildId)!.name}{' '}
-            {buildType === 'real' && buildId === teamCharBuildId && (
+            {database.builds.get(bId)!.name}{' '}
+            {buildType === 'real' && bId === buildId && (
               <SqBadge color="info" sx={{ ml: 1 }}>
                 Current
               </SqBadge>
             )}
           </MenuItem>
         ))}
-        {buildTcIds.map((buildTcId) => (
+        {buildTcIds.map((bTcId) => (
           <MenuItem
-            key={buildTcId}
+            key={bTcId}
             onClick={() =>
-              database.teamChars.set(teamCharId, {
+              database.teams.setLoadoutDatum(teamId, teamCharId, {
                 compareType: 'tc',
-                compareBuildTcId: buildTcId,
+                compareBuildTcId: bTcId,
               })
             }
           >
-            {database.buildTcs.get(buildTcId)?.name ?? ''}{' '}
+            {database.buildTcs.get(bTcId)?.name ?? ''}{' '}
             <SqBadge color="info" sx={{ ml: 1 }}>
               TC
             </SqBadge>
-            {buildType === 'tc' && buildTcId === teamCharBuildTcId && (
+            {buildType === 'tc' && bTcId === buildTcId && (
               <SqBadge color="info" sx={{ ml: 1 }}>
                 Current
               </SqBadge>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
@@ -34,8 +34,12 @@ import TabUpopt from './Tabs/TabUpgradeOpt'
 
 export default function Content({ tab }: { tab: string }) {
   const {
+    loadoutDatum,
     teamChar: { key: characterKey },
   } = useContext(TeamCharacterContext)
+  const isTCBuild = !!(
+    loadoutDatum.buildTcId && loadoutDatum.buildType === 'tc'
+  )
   return (
     <>
       <Box
@@ -68,21 +72,17 @@ export default function Content({ tab }: { tab: string }) {
         <ReactionToggle size="small" />
       </Box>
       <CardLight>
-        <TabNav tab={tab} characterKey={characterKey} />
+        <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
       </CardLight>
-      <CharacterPanel />
+      <CharacterPanel isTCBuild={isTCBuild} />
       <CardLight>
-        <TabNav tab={tab} characterKey={characterKey} />
+        <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
       </CardLight>
     </>
   )
 }
 
-function CharacterPanel() {
-  const {
-    teamChar: { buildType, buildTcId },
-  } = useContext(TeamCharacterContext)
-  const isTCBuild = buildTcId && buildType === 'tc'
+function CharacterPanel({ isTCBuild }: { isTCBuild: boolean }) {
   return (
     <Suspense
       fallback={<Skeleton variant="rectangular" width="100%" height={500} />}
@@ -109,15 +109,14 @@ function CharacterPanel() {
 function TabNav({
   tab,
   characterKey,
+  isTCBuild,
 }: {
   tab: string
   characterKey: CharacterKey
+  isTCBuild: boolean
 }) {
   const { t } = useTranslation('page_character')
-  const {
-    teamChar: { buildType, buildTcId },
-  } = useContext(TeamCharacterContext)
-  const isTCBuild = buildTcId && buildType === 'tc'
+
   return (
     <Tabs
       value={tab}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -4,6 +4,7 @@ import {
   ModalWrapper,
   SqBadge,
 } from '@genshin-optimizer/common/ui'
+import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
 import AddIcon from '@mui/icons-material/Add'
@@ -30,23 +31,16 @@ import BuildTc from './Build/BuildTc'
 // TODO: Translation
 const columns = { xs: 1, sm: 1, md: 2, lg: 2 }
 export default function LoadoutSettingElement() {
+  const database = useDatabase()
   const {
     teamId,
     teamCharId,
-    teamChar: {
-      key: characterKey,
-      buildType,
-      buildId,
-      buildIds,
-      buildTcId,
-      buildTcIds,
-      customMultiTargets,
-    },
+    loadoutDatum,
+    teamChar: { key: characterKey, buildIds, buildTcIds, customMultiTargets },
   } = useContext(TeamCharacterContext)
 
   const weaponTypeKey = getCharData(characterKey).weaponType
 
-  const database = useDatabase()
   const teamChar = database.teamChars.get(teamCharId)!
   const [open, setOpen] = useState(false)
 
@@ -83,10 +77,12 @@ export default function LoadoutSettingElement() {
   const onChangeTeamCharId = (newTeamCharId: string) => {
     const index = database.teams
       .get(teamId)!
-      .teamCharIds.findIndex((id) => id === teamCharId)
+      .loadoutData.findIndex(
+        (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
+      )
     if (index < 0) return
     database.teams.set(teamId, (team) => {
-      team.teamCharIds[index] = newTeamCharId
+      team.loadoutData[index] = { teamCharId: newTeamCharId } as LoadoutDatum
     })
   }
   return (
@@ -111,7 +107,9 @@ export default function LoadoutSettingElement() {
                 sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
               >
                 <CheckroomIcon />
-                <span>{database.teamChars.getActiveBuildName(teamCharId)}</span>
+                <span>
+                  {database.teams.getActiveBuildName(teamId, teamCharId)}
+                </span>
               </SqBadge>
               <SqBadge color={buildIds.length ? 'primary' : 'secondary'}>
                 {buildIds.length} Builds
@@ -192,7 +190,9 @@ export default function LoadoutSettingElement() {
             </Alert>
             <Grid container columns={columns} spacing={2}>
               <Grid item xs={1}>
-                <BuildEquipped active={buildType === 'equipped'} />
+                <BuildEquipped
+                  active={loadoutDatum?.buildType === 'equipped'}
+                />
               </Grid>
             </Grid>
 
@@ -214,7 +214,10 @@ export default function LoadoutSettingElement() {
                   <Grid item xs={1} key={id}>
                     <BuildReal
                       buildId={id}
-                      active={buildType === 'real' && buildId === id}
+                      active={
+                        loadoutDatum?.buildType === 'real' &&
+                        loadoutDatum?.buildId === id
+                      }
                     />
                   </Grid>
                 ))}
@@ -244,7 +247,10 @@ export default function LoadoutSettingElement() {
                   <Grid item xs={1} key={id}>
                     <BuildTc
                       buildTcId={id}
-                      active={buildType === 'tc' && buildTcId === id}
+                      active={
+                        loadoutDatum?.buildType === 'tc' &&
+                        loadoutDatum?.buildTcId === id
+                      }
                     />
                   </Grid>
                 ))}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -83,7 +83,8 @@ export default function BuildDisplayItem({
   disabled,
 }: BuildDisplayItemProps) {
   const {
-    teamChar: { optConfigId, buildType, buildId, buildIds = [] },
+    loadoutDatum: { buildType, buildId },
+    teamChar: { optConfigId, buildIds = [] },
   } = useContext(TeamCharacterContext)
   const {
     character: { key: characterKey, equippedArtifacts, equippedWeapon },

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
@@ -26,16 +26,17 @@ import { dataSetEffects } from '../../../../Data/Artifacts'
 import { uiInput as input } from '../../../../Formula'
 
 export default function EquipmentSection() {
+  const database = useDatabase()
   const {
     character: { key: characterKey },
   } = useContext(CharacterContext)
   const {
-    teamChar: { buildType, buildId },
+    loadoutDatum: { buildType, buildId },
   } = useContext(TeamCharacterContext)
   const loadoutEquip = buildId && buildType === 'real'
   const { teamData, data } = useContext(DataContext)
   const weaponSheet = teamData[characterKey]?.weaponSheet
-  const database = useDatabase()
+
   const theme = useTheme()
   const breakpoint = useMediaQuery(theme.breakpoints.up('lg'))
 
@@ -131,7 +132,7 @@ function ArtifactSectionCard() {
     character: { equippedArtifacts },
   } = useContext(CharacterContext)
   const {
-    teamChar: { buildType, buildId },
+    loadoutDatum: { buildType, buildId },
   } = useContext(TeamCharacterContext)
   const { data } = useContext(DataContext)
   const hasEquipped = !!Object.values(equippedArtifacts).filter((i) => i).length

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -52,14 +52,15 @@ export default function TabTheorycraft() {
   const {
     teamId,
     teamCharId,
-    teamChar: { key: characterKey, buildTcId },
+    loadoutDatum,
+    teamChar: { key: characterKey },
   } = useContext(TeamCharacterContext)
-  const buildTc = useBuildTc(buildTcId)!
+  const buildTc = useBuildTc(loadoutDatum.buildTcId)!
   const setBuildTc = useCallback(
     (data: SetBuildTcAction) => {
-      database.buildTcs.set(buildTcId, data)
+      database.buildTcs.set(loadoutDatum.buildTcId, data)
     },
-    [buildTcId, database]
+    [loadoutDatum, database]
   )
   const buildTCContextObj = useMemo(
     () => ({ buildTc, setBuildTc }),

--- a/apps/frontend/src/app/PageTeam/TeamCharacterSelector.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamCharacterSelector.tsx
@@ -1,4 +1,5 @@
 import { CardThemed } from '@genshin-optimizer/common/ui'
+import { hexToColor } from '@genshin-optimizer/common/util'
 import type { CharacterKey, ElementKey } from '@genshin-optimizer/gi/consts'
 import { useDBMeta, useDatabase, useTeam } from '@genshin-optimizer/gi/db-ui'
 import { CharacterName } from '@genshin-optimizer/gi/ui'
@@ -7,7 +8,6 @@ import { Box, Tab, Tabs } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 import CharIconSide from '../Components/Image/CharIconSide'
 import { getCharSheet } from '../Data/Characters'
-import { hexToColor } from '@genshin-optimizer/common/util'
 export default function TeamCharacterSelector({
   teamId,
   characterKey,
@@ -21,18 +21,20 @@ export default function TeamCharacterSelector({
   const database = useDatabase()
 
   const { gender } = useDBMeta()
-  const { teamCharIds } = useTeam(teamId)!
+  const { loadoutData } = useTeam(teamId)!
 
-  const elementArray: Array<ElementKey | undefined> = teamCharIds.map(
-    (tcid) => {
-      if (!tcid) return
-      const teamChar = database.teamChars.get(tcid)
+  const elementArray: Array<ElementKey | undefined> = loadoutData.map(
+    (loadoutDatum) => {
+      if (!loadoutDatum) return
+      const teamChar = database.teamChars.get(loadoutDatum.teamCharId)
       if (!teamChar) return
       return getCharSheet(teamChar.key).elementKey
     }
   )
-  const selectedIndex = teamCharIds.findIndex(
-    (tcid) => database.teamChars.get(tcid)?.key === characterKey
+  const selectedIndex = loadoutData.findIndex(
+    (loadoutDatum) =>
+      loadoutDatum &&
+      database.teamChars.get(loadoutDatum?.teamCharId)?.key === characterKey
   )
   const selectedEle = elementArray[selectedIndex]
   return (
@@ -71,8 +73,10 @@ export default function TeamCharacterSelector({
             }
           }}
         >
-          {teamCharIds.map((teamCharId, ind) => {
-            const teamCharKey = database.teamChars.get(teamCharId)?.key
+          {loadoutData.map((loadoutDatum, ind) => {
+            const teamCharKey =
+              loadoutDatum &&
+              database.teamChars.get(loadoutDatum?.teamCharId)?.key
             return (
               <Tab
                 icon={
@@ -85,7 +89,7 @@ export default function TeamCharacterSelector({
                 iconPosition="start"
                 value={teamCharKey ?? ind}
                 key={ind}
-                disabled={!teamCharIds[ind]}
+                disabled={!loadoutData[ind]}
                 label={
                   teamCharKey ? (
                     <CharacterName characterKey={teamCharKey} gender={gender} />

--- a/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
@@ -34,6 +34,7 @@ import {
   TeammateDisplay,
 } from './TeamComponents'
 
+import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
@@ -52,7 +53,7 @@ export default function TeamSetting({
   const navigate = useNavigate()
   const database = useDatabase()
   const team = database.teams.get(teamId)!
-  const noChars = team.teamCharIds.every((id) => !id)
+  const noChars = team.loadoutData.every((id) => !id)
 
   const location = useLocation()
 
@@ -170,7 +171,7 @@ export default function TeamSetting({
                 color="info"
                 sx={{ flexGrow: 1 }}
                 startIcon={<ContentPasteIcon />}
-                disabled={team.teamCharIds.every((id) => !id)}
+                disabled={noChars}
                 onClick={onExport}
               >
                 Export Team
@@ -178,7 +179,7 @@ export default function TeamSetting({
               <Button
                 color="info"
                 sx={{ flexGrow: 1 }}
-                disabled={team.teamCharIds.every((id) => !id)}
+                disabled={noChars}
                 onClick={onDup}
                 startIcon={<ContentCopyIcon />}
               >
@@ -212,7 +213,7 @@ function TeamCharacterSelector({
 }) {
   const database = useDatabase()
   const team = database.teams.get(teamId)!
-  const { teamCharIds } = team
+  const { loadoutData } = team
   const [charSelectIndex, setCharSelectIndex] = useState(
     undefined as number | undefined
   )
@@ -222,8 +223,10 @@ function TeamCharacterSelector({
     // Make sure character exists
     database.chars.getWithInitWeapon(cKey)
 
-    const existingIndex = teamCharIds.findIndex(
-      (teamCharId) => database.teamChars.get(teamCharId)?.key === cKey
+    const existingIndex = loadoutData.findIndex(
+      (loadoutDatum) =>
+        loadoutDatum &&
+        database.teamChars.get(loadoutDatum.teamCharId)?.key === cKey
     )
     if (existingIndex < 0) {
       //find the first available teamchar
@@ -233,23 +236,24 @@ function TeamCharacterSelector({
       // if there is no teamchar, create one.
       if (!teamCharId) teamCharId = database.teamChars.new(cKey)
       database.teams.set(teamId, (team) => {
-        team.teamCharIds[charSelectIndex] = teamCharId
+        if (!teamCharId) return
+        team.loadoutData[charSelectIndex] = { teamCharId } as LoadoutDatum
       })
     } else {
       if (charSelectIndex === existingIndex) return
-      if (teamCharIds[charSelectIndex]) {
+      if (loadoutData[charSelectIndex]) {
         // Already have a teamChar at destination, move to existing Index
-        const existingTeamCharId = teamCharIds[existingIndex]
-        const destinationTeamCharId = teamCharIds[charSelectIndex]
+        const existingLoadoutDatum = loadoutData[existingIndex]
+        const destinationLoadoutDatum = loadoutData[charSelectIndex]
         database.teams.set(teamId, (team) => {
-          team.teamCharIds[charSelectIndex] = existingTeamCharId
-          team.teamCharIds[existingIndex] = destinationTeamCharId
+          team.loadoutData[charSelectIndex] = existingLoadoutDatum
+          team.loadoutData[existingIndex] = destinationLoadoutDatum
         })
       }
     }
   }
   const charKeyAtIndex = database.teamChars.get(
-    teamCharIds[charSelectIndex as number]
+    loadoutData[charSelectIndex as number]?.teamCharId
   )?.key
 
   // This context is only used by the ResonanceDisplay, which needs to attach conditional values to team data.
@@ -258,10 +262,10 @@ function TeamCharacterSelector({
       ({
         teamId,
         team,
-        teamCharId: teamCharIds[0],
+        teamCharId: '', // can be left blank since its only modifying team conditional
         teamChar: {},
       } as TeamCharacterContextObj),
-    [team, teamId, teamCharIds]
+    [team, teamId]
   )
   return (
     <>
@@ -288,14 +292,14 @@ function TeamCharacterSelector({
             </DataContext.Provider>
           )}
         </Grid>
-        {teamCharIds.map((teamCharId, ind) => (
-          <Grid item xs={1} key={teamCharId ?? ind}>
-            {teamCharId ? (
+        {loadoutData.map((loadoutDatum, ind) => (
+          <Grid item xs={1} key={loadoutDatum?.teamCharId ?? ind}>
+            {loadoutDatum ? (
               <CharSelButton
                 index={ind}
-                key={teamCharId}
+                key={loadoutDatum?.teamCharId}
                 teamId={teamId}
-                teamCharId={teamCharId}
+                loadoutDatum={loadoutDatum}
                 onClickChar={() => setCharSelectIndex(ind)}
                 dataContextValue={dataContextValue}
               />
@@ -304,7 +308,7 @@ function TeamCharacterSelector({
                 key={ind}
                 onClick={() => setCharSelectIndex(ind)}
                 fullWidth
-                disabled={!!ind && !teamCharIds.some((id) => id)}
+                disabled={!!ind && !loadoutData.some((id) => id)}
                 startIcon={<AddIcon />}
               >
                 Add Character
@@ -319,36 +323,37 @@ function TeamCharacterSelector({
 function CharSelButton({
   index,
   teamId,
-  teamCharId,
+  loadoutDatum,
   dataContextValue,
   onClickChar,
 }: {
   index: number
   teamId: string
-  teamCharId: string
+  loadoutDatum: LoadoutDatum
   dataContextValue?: dataContextObj
   onClickChar: () => void
 }) {
   const database = useDatabase()
+  const { teamCharId } = loadoutDatum
   const { key: characterKey } = database.teamChars.get(teamCharId)!
   const { gender } = useDBMeta()
   const onChangeTeamCharId = (teamCharId: string) => {
     database.teams.set(teamId, (team) => {
-      team.teamCharIds[index] = teamCharId
+      team.loadoutData[index] = { teamCharId } as LoadoutDatum
     })
   }
   const onActive = () => {
     // Swap the active with current loadout
     database.teams.set(teamId, (team) => {
-      const oldActive = team.teamCharIds[0]
-      team.teamCharIds[0] = teamCharId
-      team.teamCharIds[index] = oldActive
+      const oldActive = team.loadoutData[0]
+      team.loadoutData[0] = loadoutDatum
+      team.loadoutData[index] = oldActive
     })
   }
 
   const onDel = () =>
     database.teams.set(teamId, (team) => {
-      team.teamCharIds[index] = undefined
+      team.loadoutData[index] = undefined
     })
   return (
     // <CardThemed bgt="light" sx={{ height: '100%' }}>

--- a/apps/frontend/src/app/PageTeams/TeamCard.tsx
+++ b/apps/frontend/src/app/PageTeams/TeamCard.tsx
@@ -1,5 +1,5 @@
 import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
-import { hexToColor, range } from '@genshin-optimizer/common/util'
+import { hexToColor } from '@genshin-optimizer/common/util'
 import type { CharacterKey, ElementKey } from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
 import {
@@ -47,13 +47,13 @@ export default function TeamCard({
   onClick: (cid?: CharacterKey) => void
 }) {
   const team = useTeam(teamId)!
-  const { name, description, teamCharIds } = team
+  const { name, description, loadoutData } = team
   const database = useDatabase()
 
-  const elementArray: Array<ElementKey | undefined> = teamCharIds.map(
-    (tcid) => {
-      if (!tcid) return
-      const teamChar = database.teamChars.get(tcid)
+  const elementArray: Array<ElementKey | undefined> = loadoutData.map(
+    (loadoutDatum) => {
+      if (!loadoutDatum) return
+      const teamChar = database.teamChars.get(loadoutDatum.teamCharId)
       if (!teamChar) return
       return getCharSheet(teamChar.key).elementKey
     }
@@ -97,8 +97,8 @@ export default function TeamCard({
 
         <Box sx={{ p: 1, marginTop: 'auto' }}>
           <Grid container columns={4} spacing={1}>
-            {range(0, 3).map((i) => {
-              const teamCharId = teamCharIds[i]
+            {loadoutData.map((loadoutDatum, i) => {
+              const teamCharId = loadoutDatum?.teamCharId
               const characterKey =
                 teamCharId && database.teamChars.get(teamCharId)?.key
               return (
@@ -112,6 +112,7 @@ export default function TeamCard({
                             <HoverCard
                               characterKey={characterKey}
                               teamCharId={teamCharId}
+                              teamId={teamId}
                             />
                           )
                         }
@@ -133,9 +134,11 @@ export default function TeamCard({
 }
 function HoverCard({
   characterKey,
+  teamId,
   teamCharId,
 }: {
   characterKey: CharacterKey
+  teamId: string
   teamCharId: string
 }) {
   const database = useDatabase()
@@ -143,16 +146,18 @@ function HoverCard({
   const { gender } = useDBMeta()
   const characterSheet = getCharSheet(characterKey, gender)
 
-  const { name, buildType, buildTcId } = useTeamChar(teamCharId)!
-  const buildname = database.teamChars.getActiveBuildName(teamCharId)
+  const { name } = useTeamChar(teamCharId)!
+  const buildname = database.teams.getActiveBuildName(teamId, teamCharId)
+  const loadoutDatum = database.teams.getLoadoutDatum(teamId, teamCharId)!
   const weapon = (() => {
-    return database.teamChars.getLoadoutWeapon(teamCharId)
+    return database.teams.getLoadoutWeapon(loadoutDatum)
   })()
   const arts = (() => {
+    const { buildType, buildTcId } = loadoutDatum
     if (buildType === 'tc' && buildTcId)
       return getArtifactData(database.buildTcs.get(buildTcId)!)
     return Object.values(
-      database.teamChars.getLoadoutArtifacts(teamCharId)
+      database.teams.getLoadoutArtifacts(loadoutDatum)
     ).filter((a) => a) as ICachedArtifact[]
   })()
 
@@ -208,7 +213,7 @@ function HoverCard({
                   <CheckroomIcon />
                   <span>{buildname}</span>
                 </Typography>
-                {buildType === 'tc' && buildTcId ? (
+                {loadoutDatum?.buildType === 'tc' && loadoutDatum?.buildTcId ? (
                   <CharacterCardEquipmentRowTC weapon={weapon} />
                 ) : (
                   <CharacterCardEquipmentRow />

--- a/apps/frontend/src/app/PageTeams/TeamSort.ts
+++ b/apps/frontend/src/app/PageTeams/TeamSort.ts
@@ -1,4 +1,8 @@
-import type { FilterConfigs, SortConfigs } from '@genshin-optimizer/common/util'
+import {
+  notEmpty,
+  type FilterConfigs,
+  type SortConfigs,
+} from '@genshin-optimizer/common/util'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import type {
   ArtCharDatabase,
@@ -31,7 +35,8 @@ export function teamFilterConfigs(
       !filter.length ||
       !!database.teams
         .get(teamId)
-        ?.teamCharIds.some((teamCharId) =>
+        ?.loadoutData.filter(notEmpty)
+        .every(({ teamCharId }) =>
           filter.includes(
             database.teamChars.get(teamCharId)?.key as CharacterKey
           )

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -80,10 +80,12 @@ export class BuildTcDataManager extends DataManager<
   }
   override remove(key: string, notify?: boolean): BuildTc | undefined {
     const buildTc = super.remove(key, notify)
-    this.database.teamChars.keys.map((teamCharId) => {
-      const { buildTcId } = this.database.teamChars.get(teamCharId)!
-      if (buildTcId === key) this.database.teamChars.set(teamCharId, {}) // trigger a validation
-    })
+    this.database.teams.entries.forEach(
+      ([teamId, team]) =>
+        team.loadoutData?.some(
+          (loadoutDatum) => loadoutDatum?.buildTcId === key
+        ) && this.database.teams.set(teamId, {}) // trigger a validation
+    )
     return buildTc
   }
   export(buildTcId: string): object {

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -1,8 +1,7 @@
 import type { DataManagerCallback } from '@genshin-optimizer/common/database'
-import { deepClone, objKeyMap, objMap } from '@genshin-optimizer/common/util'
+import { deepClone } from '@genshin-optimizer/common/util'
 import type {
   ArtifactSetKey,
-  ArtifactSlotKey,
   HitModeKey,
   WeaponKey,
   WeaponTypeKey,
@@ -10,11 +9,9 @@ import type {
 import {
   allAdditiveReactions,
   allAmpReactionKeys,
-  allArtifactSlotKeys,
   allCharacterKeys,
   allHitModeKeys,
   allInfusionAuraElementKeys,
-  charKeyToLocCharKey,
   type AdditiveReactionKey,
   type AmpReactionKey,
   type CharacterKey,
@@ -29,13 +26,8 @@ import { DataManager } from '../DataManager'
 import type { Build } from './BuildDataManager'
 import { initCharTC, toBuildTc } from './BuildTcDataManager'
 import { validateCustomMultiTarget } from './CustomMultiTarget'
-import {
-  defaultInitialWeapon,
-  defaultInitialWeaponKey,
-  initialWeapon,
-} from './WeaponDataManager'
-const buildTypeKeys = ['equipped', 'real', 'tc'] as const
-type buildTypeKey = (typeof buildTypeKeys)[number]
+import { defaultInitialWeaponKey, initialWeapon } from './WeaponDataManager'
+
 type CondKey = CharacterKey | ArtifactSetKey | WeaponKey
 export type IConditionalValues = Partial<
   Record<CondKey, { [key: string]: string }>
@@ -59,17 +51,10 @@ export interface TeamCharacter {
   hitMode: HitModeKey
   reaction?: AmpReactionKey | AdditiveReactionKey
 
-  buildType: buildTypeKey
-  buildId: string
   buildIds: string[]
-  buildTcId: string
+
   buildTcIds: string[]
   optConfigId: string
-
-  compare: boolean
-  compareType: buildTypeKey
-  compareBuildId: string
-  compareBuildTcId: string
 }
 
 export interface CustomTarget {
@@ -134,17 +119,9 @@ export class TeamCharacterDataManager extends DataManager<
       hitMode,
       reaction,
 
-      buildType,
-      buildId,
       buildIds,
-      buildTcId,
       buildTcIds,
       optConfigId,
-
-      compare,
-      compareType,
-      compareBuildId,
-      compareBuildTcId,
     } = obj as TeamCharacter
     if (!allCharacterKeys.includes(characterKey)) return undefined // non-recoverable
 
@@ -190,56 +167,18 @@ export class TeamCharacterDataManager extends DataManager<
     )
       reaction = undefined
 
-    if (!buildTypeKeys.includes(buildType)) buildType = 'equipped'
-
-    if (
-      typeof buildId !== 'string' ||
-      !this.database.builds.keys.includes(buildId)
-    )
-      buildId = ''
     if (!Array.isArray(buildIds)) buildIds = []
     buildIds = buildIds.filter((buildId) =>
       this.database.builds.keys.includes(buildId)
     )
 
-    if (
-      typeof buildTcId !== 'string' ||
-      !this.database.buildTcs.keys.includes(buildTcId)
-    )
-      buildTcId = ''
     if (!Array.isArray(buildTcIds)) buildTcIds = []
     buildTcIds = buildTcIds.filter((buildTcId) =>
       this.database.buildTcs.keys.includes(buildTcId)
     )
-    if (
-      (!buildId && !buildTcId) ||
-      (buildType === 'real' && !buildId) ||
-      (buildType === 'tc' && !buildTcId)
-    )
-      buildType = 'equipped'
 
     if (!optConfigId || !this.database.optConfigs.keys.includes(optConfigId))
       optConfigId = this.database.optConfigs.new()
-
-    if (typeof compare !== 'boolean') compare = false
-    if (!buildTypeKeys.includes(compareType)) compareType = 'equipped'
-
-    if (
-      typeof compareBuildId !== 'string' ||
-      !buildIds.includes(compareBuildId) ||
-      !this.database.builds.get(compareBuildId)?.weaponId
-    ) {
-      compareBuildId = ''
-      if (compareType === 'real') compareType = 'equipped'
-    }
-
-    if (
-      typeof compareBuildTcId !== 'string' ||
-      !buildTcIds.includes(compareBuildTcId)
-    ) {
-      compareBuildTcId = ''
-      if (compareType === 'tc') compareType = 'equipped'
-    }
 
     return {
       key: characterKey,
@@ -251,16 +190,10 @@ export class TeamCharacterDataManager extends DataManager<
       infusionAura,
       hitMode,
       reaction,
-      buildType,
-      buildId,
+
       buildIds,
-      buildTcId,
       buildTcIds,
       optConfigId,
-      compare,
-      compareType,
-      compareBuildId,
-      compareBuildTcId,
     }
   }
 
@@ -270,13 +203,22 @@ export class TeamCharacterDataManager extends DataManager<
     this.set(id, { key, optConfigId, ...data })
     return id
   }
-  override remove(key: string, notify?: boolean): TeamCharacter | undefined {
-    const rem = super.remove(key, notify)
+  override remove(
+    teamCharId: string,
+    notify?: boolean
+  ): TeamCharacter | undefined {
+    const rem = super.remove(teamCharId, notify)
     if (!rem) return
     const { optConfigId, buildIds, buildTcIds } = rem
     this.database.optConfigs.remove(optConfigId)
     this.database.teams.keys.forEach((teamId) => {
-      if (this.database.teams.get(teamId)!.teamCharIds.includes(key))
+      if (
+        this.database.teams
+          .get(teamId)!
+          .loadoutData.some(
+            (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
+          )
+      )
         this.database.teams.set(teamId, {}) // use validator to remove teamCharId entries
     })
 
@@ -291,22 +233,14 @@ export class TeamCharacterDataManager extends DataManager<
     const teamCharRaw = this.get(teamcharId)
     if (!teamCharRaw) return ''
     const teamChar = deepClone(teamCharRaw)
-    const buildIdInd = teamChar.buildIds.findIndex(
-      (buildId) => buildId === teamChar.buildId
-    )
+
     teamChar.buildIds = teamChar.buildIds.map((buildId) =>
       this.database.builds.duplicate(buildId)
     )
-    if (buildIdInd >= 0) teamChar.buildId = teamChar.buildIds[buildIdInd]
 
-    const buildTcIdInd = teamChar.buildTcIds.findIndex(
-      (buildTcId) => buildTcId === teamChar.buildTcId
-    )
     teamChar.buildTcIds = teamChar.buildTcIds.map((buildTcId) =>
       this.database.buildTcs.duplicate(buildTcId)
     )
-    if (buildTcIdInd >= 0)
-      teamChar.buildTcId = teamChar.buildTcIds[buildTcIdInd]
 
     teamChar.optConfigId = this.database.optConfigs.duplicate(
       teamChar.optConfigId
@@ -365,85 +299,11 @@ export class TeamCharacterDataManager extends DataManager<
     })
     return buildTcId
   }
-  /**
-   *
-   * @param teamCharId
-   * @returns a ICached weapon, because in WR a lack of a weapon can have strange effects
-   */
-  getLoadoutWeapon(teamCharId: string): ICachedWeapon {
-    const teamChar = this.get(teamCharId)
-    if (!teamChar) return defaultInitialWeapon()
-    const { key: characterKey, buildType, buildId, buildTcId } = teamChar
-    switch (buildType) {
-      case 'equipped': {
-        const char = this.database.chars.get(characterKey)
-        if (!char) return defaultInitialWeapon()
-        return (
-          this.database.weapons.get(char.equippedWeapon) ??
-          defaultInitialWeapon()
-        )
-      }
-      case 'real': {
-        const build = this.database.builds.get(buildId)
-        if (!build) return defaultInitialWeapon()
-        return (
-          this.database.weapons.get(build.weaponId) ?? defaultInitialWeapon()
-        )
-      }
-      case 'tc': {
-        const buildTc = this.database.buildTcs.get(buildTcId)
-        if (!buildTc) return defaultInitialWeapon()
-        return {
-          ...buildTc.weapon,
-          location: charKeyToLocCharKey(teamChar.key),
-          lock: false,
-          id: 'invalid',
-        }
-      }
-    }
-    return defaultInitialWeapon()
-  }
 
-  /**
-   * Note: this doesnt return any artifacts(all undefined) when the current teamchar is using a TC Build.
-   */
-  getLoadoutArtifacts(
-    teamCharId: string
-  ): Record<ArtifactSlotKey, ICachedArtifact | undefined> {
-    const teamChar = this.get(teamCharId)
-    if (!teamChar) return objKeyMap(allArtifactSlotKeys, () => undefined)
-    const { key: characterKey, buildType, buildId } = teamChar
-    switch (buildType) {
-      case 'equipped': {
-        const char = this.database.chars.get(characterKey)
-        if (!char) return objKeyMap(allArtifactSlotKeys, () => undefined)
-        return objMap(char.equippedArtifacts, (id) =>
-          this.database.arts.get(id)
-        )
-      }
-      case 'real': {
-        const build = this.database.builds.get(buildId)
-        if (!build) return objKeyMap(allArtifactSlotKeys, () => undefined)
-        return objMap(build.artifactIds, (id) => this.database.arts.get(id))
-      }
-    }
-    return objKeyMap(allArtifactSlotKeys, () => undefined)
-  }
   export(teamCharId: string): object {
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return {}
-    const {
-      buildType,
-      buildId,
-      buildIds,
-      buildTcId,
-      buildTcIds,
-      optConfigId,
-      compareType,
-      compareBuildId: comareBuildId,
-      compareBuildTcId,
-      ...rest
-    } = teamChar
+    const { buildIds, buildTcIds, optConfigId, ...rest } = teamChar
     return {
       ...rest,
       buildTcs: buildTcIds.map((buildTcId) =>
@@ -473,71 +333,5 @@ export class TeamCharacterDataManager extends DataManager<
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return () => {}
     return this.database.chars.follow(teamChar.key, callback)
-  }
-  followBuild(teamCharId: string, callback: () => void) {
-    const teamChar = this.database.teamChars.get(teamCharId)
-    if (!teamChar) return () => {}
-    // in the case of buildType ==='equipped', that is covered by following the char with `followChar`
-    if (teamChar.buildType === 'real') {
-      const build = this.database.builds.get(teamChar.buildId)
-      if (!build) return () => {}
-      const unfollowBuild = this.database.builds.follow(
-        teamChar.buildId,
-        callback
-      )
-      const unfollowWeapon = build.weaponId
-        ? this.database.weapons.follow(build.weaponId, callback)
-        : () => {}
-      const unfollowArts = Object.values(build.artifactIds).map((id) =>
-        id ? this.database.arts.follow(id, callback) : () => {}
-      )
-      return () => {
-        unfollowBuild()
-        unfollowWeapon()
-        unfollowArts.forEach((unfollow) => unfollow())
-      }
-    } else if (teamChar.buildType === 'tc')
-      return this.database.buildTcs.follow(teamChar.buildTcId, callback)
-    return () => {}
-  }
-  followCompareBuild(teamCharId: string, callback: () => void) {
-    const teamChar = this.database.teamChars.get(teamCharId)
-    if (!teamChar) return () => {}
-    if (!teamChar.compare) return () => {}
-    // in the case of teamChar.compareType ==='equipped', that is covered by following the char with `followChar`
-    if (teamChar.compareType === 'real') {
-      const build = this.database.builds.get(teamChar.compareBuildId)
-      if (!build) return () => {}
-      const unfollowBuild = this.database.builds.follow(
-        teamChar.compareBuildId,
-        callback
-      )
-      const unfollowWeapon = build.weaponId
-        ? this.database.weapons.follow(build.weaponId, callback)
-        : () => {}
-      const unfollowArts = Object.values(build.artifactIds).map((id) =>
-        id ? this.database.arts.follow(id, callback) : () => {}
-      )
-      return () => {
-        unfollowBuild()
-        unfollowWeapon()
-        unfollowArts.forEach((unfollow) => unfollow())
-      }
-    } else if (teamChar.buildType === 'tc')
-      return this.database.buildTcs.follow(teamChar.compareBuildTcId, callback)
-    return () => {}
-  }
-  getActiveBuildName(teamCharId: string, equippedName = 'Equipped Build') {
-    const teamChar = this.database.teamChars.get(teamCharId)
-    if (!teamChar) return
-    const { buildType, buildId, buildTcId } = teamChar
-    switch (buildType) {
-      case 'equipped':
-        return equippedName
-      case 'real':
-        return this.database.builds.get(buildId)?.name ?? ''
-      case 'tc':
-        return this.database.buildTcs.get(buildTcId)?.name ?? ''
-    }
   }
 }

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -1,8 +1,33 @@
-import { deepClone, range } from '@genshin-optimizer/common/util'
-import { allElementWithPhyKeys } from '@genshin-optimizer/gi/consts'
+import {
+  deepClone,
+  objKeyMap,
+  objMap,
+  range,
+} from '@genshin-optimizer/common/util'
+import type { ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
+import {
+  allArtifactSlotKeys,
+  allElementWithPhyKeys,
+  charKeyToLocCharKey,
+} from '@genshin-optimizer/gi/consts'
 import type { EleEnemyResKey } from '@genshin-optimizer/gi/keymap'
+import type { ICachedArtifact, ICachedWeapon } from '../../Interfaces'
 import type { ArtCharDatabase } from '../ArtCharDatabase'
 import { DataManager } from '../DataManager'
+import { defaultInitialWeapon } from './WeaponDataManager'
+
+const buildTypeKeys = ['equipped', 'real', 'tc'] as const
+type BuildTypeKey = (typeof buildTypeKeys)[number]
+export type LoadoutDatum = {
+  teamCharId: string
+  buildType: BuildTypeKey
+  buildId: string
+  buildTcId: string
+  compare: boolean
+  compareType: BuildTypeKey
+  compareBuildId: string
+  compareBuildTcId: string
+}
 export interface Team {
   name: string
   description: string
@@ -16,7 +41,7 @@ export interface Team {
   conditional: {
     resonance: { [key: string]: string }
   }
-  teamCharIds: Array<string | undefined>
+  loadoutData: Array<LoadoutDatum | undefined>
   lastEdit: number
 }
 
@@ -47,7 +72,7 @@ export class TeamDataManager extends DataManager<
       description,
       enemyOverride,
       conditional,
-      teamCharIds,
+      loadoutData,
       lastEdit,
     } = obj as Team
     if (typeof name !== 'string') name = this.newName()
@@ -76,21 +101,80 @@ export class TeamDataManager extends DataManager<
 
     {
       // validate teamCharIds
-      if (!Array.isArray(teamCharIds))
-        teamCharIds = range(0, 3).map(() => undefined)
+      if (!Array.isArray(loadoutData))
+        loadoutData = range(0, 3).map(() => undefined)
 
-      const charIds = this.database.teamChars.keys
-      teamCharIds = range(0, 3).map((ind) => {
-        const id = teamCharIds[ind]
-        if (id && charIds.includes(id)) return id
-        return undefined
+      loadoutData = range(0, 3).map((ind) => {
+        const loadoutDatum = loadoutData[ind]
+        if (!loadoutDatum || typeof loadoutDatum !== 'object') return undefined
+        console.log({ loadoutDatum, type: typeof loadoutDatum })
+        const { teamCharId } = loadoutDatum
+        let {
+          buildType,
+          buildId,
+          buildTcId,
+          compare,
+          compareType,
+          compareBuildId,
+          compareBuildTcId,
+        } = loadoutDatum
+        const teamChar = this.database.teamChars.get(teamCharId)
+        if (!teamChar) return undefined
+
+        if (!buildTypeKeys.includes(buildType)) buildType = 'equipped'
+        if (typeof buildId !== 'string' || !teamChar.buildIds.includes(buildId))
+          buildId = ''
+
+        if (
+          typeof buildTcId !== 'string' ||
+          !teamChar.buildTcIds.includes(buildTcId)
+        )
+          buildTcId = ''
+
+        if (
+          (!buildId && !buildTcId) ||
+          (buildType === 'real' && !buildId) ||
+          (buildType === 'tc' && !buildTcId)
+        )
+          buildType = 'equipped'
+
+        if (typeof compare !== 'boolean') compare = false
+        if (!buildTypeKeys.includes(compareType)) compareType = 'equipped'
+
+        if (
+          typeof compareBuildId !== 'string' ||
+          !teamChar.buildIds.includes(compareBuildId) ||
+          !this.database.builds.get(compareBuildId)?.weaponId
+        ) {
+          compareBuildId = ''
+          if (compareType === 'real') compareType = 'equipped'
+        }
+
+        if (
+          typeof compareBuildTcId !== 'string' ||
+          !teamChar.buildTcIds.includes(compareBuildTcId)
+        ) {
+          compareBuildTcId = ''
+          if (compareType === 'tc') compareType = 'equipped'
+        }
+
+        return {
+          teamCharId,
+          buildType,
+          buildId,
+          buildTcId,
+          compare,
+          compareType,
+          compareBuildId,
+          compareBuildTcId,
+        } as LoadoutDatum
       })
 
       // make sure there isnt a team without "Active" character, by shifting characters forward.
-      if (!teamCharIds[0] && teamCharIds.some((tcid) => tcid)) {
-        const index = teamCharIds.findIndex((tcid) => !!tcid)
-        teamCharIds[0] = teamCharIds[index]
-        teamCharIds[index] = undefined
+      if (!loadoutData[0] && loadoutData.some((loadoutData) => loadoutData)) {
+        const index = loadoutData.findIndex((loadoutData) => !!loadoutData)
+        loadoutData[0] = loadoutData[index]
+        loadoutData[index] = undefined
       }
     }
 
@@ -101,7 +185,7 @@ export class TeamDataManager extends DataManager<
       description,
       enemyOverride,
       conditional,
-      teamCharIds,
+      loadoutData,
       lastEdit,
     }
   }
@@ -125,12 +209,13 @@ export class TeamDataManager extends DataManager<
   export(teamId: string): object {
     const team = this.database.teams.get(teamId)
     if (!team) return {}
-    const { teamCharIds, ...rest } = team
+    const { loadoutData, ...rest } = team
     return {
       ...rest,
-      teamChars: teamCharIds.map(
-        (teamCharId) => teamCharId && this.database.teamChars.export(teamCharId)
-      ),
+      loadoutData: loadoutData.map((loadoutData) => {
+        loadoutData?.teamCharId &&
+          this.database.teamChars.export(loadoutData?.teamCharId)
+      }),
     }
   }
   import(data: object): string {
@@ -140,9 +225,9 @@ export class TeamDataManager extends DataManager<
       !this.set(id, {
         ...rest,
         name: `${rest.name ?? ''} (Imported)`,
-        teamCharIds: teamChars.map((obj) =>
-          this.database.teamChars.import(obj)
-        ),
+        loadoutData: teamChars.map((obj) => ({
+          teamCharId: this.database.teamChars.import(obj),
+        })),
       } as Team)
     )
       return ''
@@ -151,7 +236,174 @@ export class TeamDataManager extends DataManager<
 
   getActiveTeamChar(teamId: string) {
     const team = this.database.teams.get(teamId)
-    const teamCharId = team?.teamCharIds[0]
+    const teamCharId = team?.loadoutData[0]?.teamCharId
     return this.database.teamChars.get(teamCharId)
+  }
+
+  /**
+   *
+   * @param teamCharId
+   * @returns a ICached weapon, because in WR a lack of a weapon can have strange effects
+   */
+  getLoadoutWeapon({
+    buildType,
+    buildId,
+    buildTcId,
+    teamCharId,
+  }: LoadoutDatum): ICachedWeapon {
+    const teamChar = this.database.teamChars.get(teamCharId)
+    if (!teamChar) return defaultInitialWeapon()
+    const { key: characterKey } = teamChar
+    switch (buildType) {
+      case 'equipped': {
+        const char = this.database.chars.get(characterKey)
+        if (!char) return defaultInitialWeapon()
+        return (
+          this.database.weapons.get(char.equippedWeapon) ??
+          defaultInitialWeapon()
+        )
+      }
+      case 'real': {
+        const build = this.database.builds.get(buildId)
+        if (!build) return defaultInitialWeapon()
+        return (
+          this.database.weapons.get(build.weaponId) ?? defaultInitialWeapon()
+        )
+      }
+      case 'tc': {
+        const buildTc = this.database.buildTcs.get(buildTcId)
+        if (!buildTc) return defaultInitialWeapon()
+        return {
+          ...buildTc.weapon,
+          location: charKeyToLocCharKey(teamChar.key),
+          lock: false,
+          id: 'invalid',
+        }
+      }
+    }
+    return defaultInitialWeapon()
+  }
+  getLoadoutDatum(teamId: string, teamCharId: string) {
+    const team = this.get(teamId)
+    if (!team) return undefined
+    return team.loadoutData.find(
+      (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
+    )
+  }
+  setLoadoutDatum(
+    teamId: string,
+    teamCharId: string,
+    data: Partial<LoadoutDatum>
+  ) {
+    this.set(teamId, (team) => {
+      const loadoutDataInd = team.loadoutData.findIndex(
+        (loadoutDatum) => loadoutDatum && loadoutDatum.teamCharId === teamCharId
+      )
+      if (loadoutDataInd < 0) return
+
+      team.loadoutData[loadoutDataInd]! = {
+        ...team.loadoutData[loadoutDataInd]!,
+        ...data,
+      }
+    })
+  }
+  /**
+   * Note: this doesnt return any artifacts(all undefined) when the current teamchar is using a TC Build.
+   */
+  getLoadoutArtifacts({
+    teamCharId,
+    buildType,
+    buildId,
+  }: LoadoutDatum): Record<ArtifactSlotKey, ICachedArtifact | undefined> {
+    const teamChar = this.database.teamChars.get(teamCharId)
+    if (!teamChar) return objKeyMap(allArtifactSlotKeys, () => undefined)
+    const { key: characterKey } = teamChar
+    switch (buildType) {
+      case 'equipped': {
+        const char = this.database.chars.get(characterKey)
+        if (!char) return objKeyMap(allArtifactSlotKeys, () => undefined)
+        return objMap(char.equippedArtifacts, (id) =>
+          this.database.arts.get(id)
+        )
+      }
+      case 'real': {
+        const build = this.database.builds.get(buildId)
+        if (!build) return objKeyMap(allArtifactSlotKeys, () => undefined)
+        return objMap(build.artifactIds, (id) => this.database.arts.get(id))
+      }
+    }
+    return objKeyMap(allArtifactSlotKeys, () => undefined)
+  }
+
+  followLoadoutDatum(
+    { buildType, buildId, buildTcId }: LoadoutDatum,
+    callback: () => void
+  ) {
+    if (buildType === 'real') {
+      const build = this.database.builds.get(buildId)
+      if (!build) return () => {}
+      const unfollowBuild = this.database.builds.follow(buildId, callback)
+      const unfollowWeapon = build.weaponId
+        ? this.database.weapons.follow(build.weaponId, callback)
+        : () => {}
+      const unfollowArts = Object.values(build.artifactIds).map((id) =>
+        id ? this.database.arts.follow(id, callback) : () => {}
+      )
+      return () => {
+        unfollowBuild()
+        unfollowWeapon()
+        unfollowArts.forEach((unfollow) => unfollow())
+      }
+    } else if (buildType === 'tc')
+      return this.database.buildTcs.follow(buildTcId, callback)
+    return () => {}
+  }
+  followLoadoutDatumCompare(
+    { compareType, compareBuildId, compareBuildTcId }: LoadoutDatum,
+    callback: () => void
+  ) {
+    if (compareType === 'real') {
+      const build = this.database.builds.get(compareBuildId)
+      if (!build) return () => {}
+      const unfollowBuild = this.database.builds.follow(
+        compareBuildId,
+        callback
+      )
+      const unfollowWeapon = build.weaponId
+        ? this.database.weapons.follow(build.weaponId, callback)
+        : () => {}
+      const unfollowArts = Object.values(build.artifactIds).map((id) =>
+        id ? this.database.arts.follow(id, callback) : () => {}
+      )
+      return () => {
+        unfollowBuild()
+        unfollowWeapon()
+        unfollowArts.forEach((unfollow) => unfollow())
+      }
+    } else if (compareType === 'tc')
+      return this.database.buildTcs.follow(compareBuildTcId, callback)
+    return () => {}
+  }
+  getActiveBuildName(
+    teamId: string,
+    teamCharId: string,
+    equippedName = 'Equipped Build'
+  ) {
+    const team = this.get(teamId)
+    if (!team) return
+
+    const loadoutDatum = team.loadoutData.find(
+      (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
+    )
+    if (!loadoutDatum) return
+    const { buildType, buildId, buildTcId } = loadoutDatum
+    switch (buildType) {
+      case 'equipped':
+        return equippedName
+      case 'real':
+        return this.database.builds.get(buildId)?.name ?? ''
+      case 'tc':
+        return this.database.buildTcs.get(buildTcId)?.name ?? ''
+    }
   }
 }

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -23,7 +23,7 @@ import {
   maxBuildsToShowList,
 } from './OptConfigDataManager'
 import type { TeamCharacter } from './TeamCharacterDataManager'
-import type { Team } from './TeamDataManager'
+import type { LoadoutDatum, Team } from './TeamDataManager'
 import {
   defaultInitialWeapon,
   defaultInitialWeaponKey,
@@ -53,6 +53,7 @@ export type {
   ArtSetExclusion,
   ArtSetExclusionKey,
   GeneratedBuild,
+  LoadoutDatum,
   MinTotalStatKey,
   StatFilterSetting,
   StatFilters,


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Since loadouts are now sharable across different teams, the data associated with "which build is active" should not be stored on the loadout, but rather on the team. This allow you to have a loadout that generates a specific build at different ER breakpoints, and have different ER builds active on different teams.


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->
Showing a duplicated build (that shares loadout) with different "active" builds
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/098f0c99-7530-4a3d-affa-52bc1abed9e8)
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/fc40e3ac-d5e8-4b6f-9edb-37cbbfb5c077)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
