### PR TITLE
fix crash when comparing artifacts in character editor

### DIFF
--- a/apps/frontend/src/app/Context/TeamCharacterContext.tsx
+++ b/apps/frontend/src/app/Context/TeamCharacterContext.tsx
@@ -17,4 +17,5 @@ export type TeamCharacterContextObj = {
 export const TeamCharacterContext = createContext({
   teamChar: {},
   team: {},
+  loadoutDatum: {},
 } as TeamCharacterContextObj)


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
`BuildDisplayItem` depends on `TeamCharacterContext`, but that context does not exist in character editor. Provide a default value since its only the shallow values being compared.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
