### PR TITLE
Fix incorrect usage of main stat display value for optimization

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/foreground.ts
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/foreground.ts
@@ -5,7 +5,7 @@ import {
   artMaxLevel,
 } from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
-import { getMainStatDisplayValue } from '@genshin-optimizer/gi/util'
+import { getMainStatValue } from '@genshin-optimizer/gi/util'
 import { input } from '../../../../Formula'
 import { computeUIData } from '../../../../Formula/api'
 import { formulaString } from '../../../../Formula/debug'
@@ -39,7 +39,7 @@ export function compactArtifacts(
   const keys = new Set<string>()
 
   for (const art of arts) {
-    const mainStatVal = getMainStatDisplayValue(
+    const mainStatVal = getMainStatValue(
       art.mainStatKey,
       art.rarity,
       Math.max(
@@ -53,9 +53,7 @@ export function compactArtifacts(
       set: art.setKey,
       values: {
         [art.setKey]: 1,
-        [art.mainStatKey]: art.mainStatKey.endsWith('_')
-          ? mainStatVal / 100
-          : mainStatVal,
+        [art.mainStatKey]: mainStatVal,
         ...Object.fromEntries(
           art.substats.map((substat) => [
             substat.key,

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
@@ -13,7 +13,7 @@ import { allSubstatKeys, artMaxLevel } from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
 import type { MainStatKey, SubstatKey } from '@genshin-optimizer/gi/dm'
 import {
-  getMainStatDisplayValue,
+  getMainStatValue,
   getRollsRemaining,
   getSubstatValue,
 } from '@genshin-optimizer/gi/util'
@@ -216,11 +216,7 @@ export class UpOptCalculator {
   /** Adds an artifact to be tracked by UpOptCalc. It is initially un-evaluated. */
   _addArtifact(art: ICachedArtifact) {
     const maxLevel = artMaxLevel[art.rarity]
-    const mainStatVal = getMainStatDisplayValue(
-      art.mainStatKey,
-      art.rarity,
-      maxLevel
-    ) // 5* only
+    const mainStatVal = getMainStatValue(art.mainStatKey, art.rarity, maxLevel) // 5* only
 
     this.artifacts.push({
       id: art.id,
@@ -232,7 +228,7 @@ export class UpOptCalculator {
         .filter((v) => v !== '') as SubstatKey[],
       values: {
         [art.setKey]: 1,
-        [art.mainStatKey]: toDecimal(art.mainStatKey, mainStatVal),
+        [art.mainStatKey]: mainStatVal,
         ...Object.fromEntries(
           art.substats
             .filter(({ key }) => key !== '')
@@ -678,10 +674,7 @@ export class UpOptCalculator {
 
 /* ICachedArtifact to ArtifactBuildData. Maybe this should go in common? */
 export function toArtifact(art: ICachedArtifact): ArtifactBuildData {
-  const mainStatVal = toDecimal(
-    art.mainStatKey,
-    getMainStatDisplayValue(art.mainStatKey, art.rarity, art.level)
-  ) // 5* only
+  const mainStatVal = getMainStatValue(art.mainStatKey, art.rarity, art.level) // 5* only
   const buildData = {
     id: art.id,
     slot: art.slotKey,


### PR DESCRIPTION
## Describe your changes

Change opt and up-opt to use the raw mainstat value, rather than the display value (which rounded EM and caused minor calculation errors.

This was harder to spot because we still recalculate and display the values to the user using the correctly un-rounded EM. We were just optimizing with the wrong value. So in this case, this caused the 2 builds to sort incorrectly, revealing the issue.

TC opt doesn't look like it calls this function

## Issue or discord link

- Resolves #1744 

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
