### PR TITLE
Convert KQMSButton from Dialog to Modal

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/KQMSButton.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/KQMSButton.tsx
@@ -1,7 +1,7 @@
 import { useBoolState } from '@genshin-optimizer/common/react-util'
+import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -31,39 +31,41 @@ export default function KQMSButton({
       >
         {t('tabTheorycraft.kqmsDialog.kqmsBtn')}
       </Button>
-      <Dialog open={open} onClose={onClose}>
-        <DialogTitle>{t('tabTheorycraft.kqmsDialog.title')}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            <Trans t={t} i18nKey="tabTheorycraft.kqmsDialog.content">
-              This will replace your current <strong>substat setup</strong> with
-              one that adheres to the{' '}
-              <Link
-                href="https://compendium.keqingmains.com/kqm-standards"
-                target="_blank"
-              >
-                KQM Standards
-              </Link>
-              .
-            </Trans>
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose} color="error">
-            {t('ui:close')}
-          </Button>
-          <Button
-            color="success"
-            onClick={() => {
-              onClose()
-              action()
-            }}
-            autoFocus
-          >
-            {t('tabTheorycraft.kqmsDialog.kqmsBtn')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ModalWrapper open={open} onClose={onClose}>
+        <CardThemed sx={{ maxWidth: 'sm', alignSelf: 'center' }}>
+          <DialogTitle>{t('tabTheorycraft.kqmsDialog.title')}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              <Trans t={t} i18nKey="tabTheorycraft.kqmsDialog.content">
+                This will replace your current <strong>substat setup</strong>{' '}
+                with one that adheres to the{' '}
+                <Link
+                  href="https://compendium.keqingmains.com/kqm-standards"
+                  target="_blank"
+                >
+                  KQM Standards
+                </Link>
+                .
+              </Trans>
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onClose} color="error">
+              {t('ui:close')}
+            </Button>
+            <Button
+              color="success"
+              onClick={() => {
+                onClose()
+                action()
+              }}
+              autoFocus
+            >
+              {t('tabTheorycraft.kqmsDialog.kqmsBtn')}
+            </Button>
+          </DialogActions>
+        </CardThemed>
+      </ModalWrapper>
     </>
   )
 }

--- a/libs/gi/localization/assets/locales/en/page_character.json
+++ b/libs/gi/localization/assets/locales/en/page_character.json
@@ -63,7 +63,7 @@
     "kqmsDialog": {
       "kqmsBtn": "Use KQMS",
       "title": "Use KQMS?",
-      "content": "This will replace your current <strong>substat setup</strong> with one that adheres to the <4>KQM Standards</4>."
+      "content": "This will replace your current <strong>substat setup</strong> with one that adheres to the <5>KQM Standards</5>."
     },
     "gcsimDialog": {
       "title": "gcsim Export",


### PR DESCRIPTION
## Describe your changes

Converting KQMSButton to use Modal (that looks like a Dialog) instead of a Dialog outright seems to fix the stuck backdrop issue for whatever reason.

## Issue or discord link

- Resolves #1497 

## Testing/validation

How the modal looks in my PR
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/031b7514-c2d1-43fe-8b60-7aa4f874d646)

How it looks in live
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/024ecab8-dada-4c1f-b4ba-a1880a34ef23)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
