### PR TITLE
Add preview build change functionality to EquipBuildModal

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
@@ -125,7 +125,8 @@ export default function BuildReal({
     return loadoutDatum && database.teamChars.get(loadoutDatum.teamCharId)!.key
   })
 
-  const buildProps = {
+  const equipChangeProps = {
+    currentName: 'Equipped',
     currentWeapon: equippedWeapon,
     currentArtifacts: equippedArtifacts,
     newWeapon: weaponId,
@@ -139,7 +140,7 @@ export default function BuildReal({
         <BuildEditor buildId={buildId} onClose={onClose} />
       </ModalWrapper>
       <EquipBuildModal
-        buildProps={buildProps}
+        equipChangeProps={equipChangeProps}
         showPrompt={showPrompt}
         onEquip={onEquip}
         OnHidePrompt={OnHidePrompt}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
@@ -50,7 +50,7 @@ export default function BuildReal({
     team: { loadoutData },
   } = useContext(TeamCharacterContext)
   const {
-    character: { equippedWeapon, equippedArtifacts }
+    character: { equippedWeapon, equippedArtifacts },
   } = useContext(CharacterContext)
   const { gender } = useDBMeta()
   const database = useDatabase()

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
@@ -12,13 +12,10 @@ import { ArtifactSlotName, CharacterName } from '@genshin-optimizer/gi/ui'
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   CardHeader,
-  Checkbox,
   Divider,
-  FormControlLabel,
   Grid,
   TextField,
   Typography,
@@ -32,6 +29,7 @@ import WeaponCardNano from '../../../Components/Weapon/WeaponCardNano'
 import { CharacterContext } from '../../../Context/CharacterContext'
 import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'
 import { BuildCard } from './BuildCard'
+import EquipBuildModal from './EquipBuildModal'
 
 const UsedCard = styled(Card)(() => ({
   boxShadow: '0px 0px 0px 2px red',
@@ -51,6 +49,9 @@ export default function BuildReal({
     teamChar: { key: characterKey },
     team: { loadoutData },
   } = useContext(TeamCharacterContext)
+  const {
+    character: { equippedWeapon, equippedArtifacts }
+  } = useContext(CharacterContext)
   const { gender } = useDBMeta()
   const database = useDatabase()
   const { name, description, weaponId, artifactIds } = useBuild(buildId)!
@@ -124,6 +125,13 @@ export default function BuildReal({
     return loadoutDatum && database.teamChars.get(loadoutDatum.teamCharId)!.key
   })
 
+  const buildProps = {
+    currentWeapon: equippedWeapon,
+    currentArtifacts: equippedArtifacts,
+    newWeapon: weaponId,
+    newArtifacts: artifactIds,
+  }
+
   const [showPrompt, onShowPrompt, OnHidePrompt] = useBoolState()
   return (
     <>
@@ -131,6 +139,7 @@ export default function BuildReal({
         <BuildEditor buildId={buildId} onClose={onClose} />
       </ModalWrapper>
       <EquipBuildModal
+        buildProps={buildProps}
         showPrompt={showPrompt}
         onEquip={onEquip}
         OnHidePrompt={OnHidePrompt}
@@ -293,94 +302,5 @@ function BuildEditor({
         </Box>
       </CardContent>
     </CardThemed>
-  )
-}
-
-function EquipBuildModal({
-  showPrompt,
-  OnHidePrompt,
-  onEquip,
-}: {
-  showPrompt: boolean
-  onEquip: () => void
-  OnHidePrompt: () => void
-}) {
-  const [name, setName] = useState('')
-  const [copyEquipped, setCopyEquipped] = useState(false)
-  // const [showPrompt, onShowPrompt, OnHidePrompt] = useBoolState()
-
-  const database = useDatabase()
-  const { teamCharId } = useContext(TeamCharacterContext)
-  const {
-    character: { equippedArtifacts, equippedWeapon },
-  } = useContext(CharacterContext)
-
-  const toEquip = () => {
-    if (copyEquipped) {
-      database.teamChars.newBuild(teamCharId, {
-        name: name !== '' ? name : 'Duplicate of Equipped',
-        artifactIds: equippedArtifacts,
-        weaponId: equippedWeapon,
-      })
-    }
-
-    onEquip()
-    setName('')
-    setCopyEquipped(false)
-    OnHidePrompt()
-  }
-
-  /* TODO: Dialog Wanted to use a Dialog here, but was having some weird issues with closing out of it */
-  /* TODO: Translation */
-  return (
-    <ModalWrapper
-      open={showPrompt}
-      onClose={OnHidePrompt}
-      containerProps={{ maxWidth: 'md' }}
-    >
-      <CardThemed>
-        <CardHeader
-          title="Do you want to equip all gear in this build to this character?"
-          action={<CloseButton onClick={OnHidePrompt} />}
-        />
-        <CardContent sx={{ display: 'flex', flexDirection: 'column' }}>
-          <FormControlLabel
-            label="Copy my current equipment to a new build. Otherwise, the currently equipped build will be overwritten."
-            control={
-              <Checkbox
-                checked={copyEquipped}
-                onChange={(event) => setCopyEquipped(event.target.checked)}
-                color={copyEquipped ? 'success' : 'secondary'}
-              />
-            }
-          />
-          {copyEquipped && (
-            <TextField
-              label="Build Name"
-              placeholder="Duplicate of Equipped"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              size="small"
-              sx={{ width: '75%', marginX: 4 }}
-            />
-          )}
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'flex-end',
-              gap: 1,
-              marginTop: 8,
-            }}
-          >
-            <Button color="error" onClick={OnHidePrompt}>
-              Cancel
-            </Button>
-            <Button color="success" onClick={toEquip}>
-              Equip
-            </Button>
-          </Box>
-        </CardContent>
-      </CardThemed>
-    </ModalWrapper>
   )
 }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
@@ -1,7 +1,4 @@
-import {
-  CardThemed,
-  ModalWrapper,
-} from '@genshin-optimizer/common/ui'
+import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
 import type { ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
@@ -51,13 +48,14 @@ export default function EquipBuildModal({
   const {
     teamCharId,
     teamChar: { key: characterKey },
-   } = useContext(TeamCharacterContext)
+  } = useContext(TeamCharacterContext)
   const weaponTypeKey = getCharData(characterKey).weaponType
 
   const toEquip = () => {
     if (copyCurrent) {
       database.teamChars.newBuild(teamCharId, {
-        name: name !== '' ? name : `Duplicate of ${equipChangeProps.currentName}`,
+        name:
+          name !== '' ? name : `Duplicate of ${equipChangeProps.currentName}`,
         artifactIds: equipChangeProps.currentArtifacts,
         weaponId: equipChangeProps.currentWeapon,
       })
@@ -72,10 +70,7 @@ export default function EquipBuildModal({
   /* TODO: Dialog Wanted to use a Dialog here, but was having some weird issues with closing out of it */
   /* TODO: Translation */
   return (
-    <ModalWrapper
-      open={showPrompt}
-      onClose={OnHidePrompt}
-    >
+    <ModalWrapper open={showPrompt} onClose={OnHidePrompt}>
       <CardThemed>
         <CardHeader
           title={
@@ -95,8 +90,11 @@ export default function EquipBuildModal({
         >
           <Box>
             {/* Active Build */}
-            <CardThemed bgt='light'>
-              <CardHeader sx={{ pb: 0 }} title={`${equipChangeProps.currentName}: Current Equipment`} />
+            <CardThemed bgt="light">
+              <CardHeader
+                sx={{ pb: 0 }}
+                title={`${equipChangeProps.currentName}: Current Equipment`}
+              />
               <CardContent
                 sx={{
                   display: 'flex',
@@ -116,14 +114,13 @@ export default function EquipBuildModal({
                       weaponTypeKey={weaponTypeKey}
                     />
                   </Grid>
-                  {Object.entries(equipChangeProps.currentArtifacts).map(([slotKey, id]) => (
-                    <Grid item key={id || slotKey} xs={1}>
-                      <ArtifactCardNano
-                        artifactId={id}
-                        slotKey={slotKey}
-                      />
-                    </Grid>
-                  ))}
+                  {Object.entries(equipChangeProps.currentArtifacts).map(
+                    ([slotKey, id]) => (
+                      <Grid item key={id || slotKey} xs={1}>
+                        <ArtifactCardNano artifactId={id} slotKey={slotKey} />
+                      </Grid>
+                    )
+                  )}
                 </Grid>
               </CardContent>
             </CardThemed>
@@ -137,7 +134,7 @@ export default function EquipBuildModal({
               <KeyboardArrowDown sx={{ fontSize: 40 }} />
             </Box>
             {/* New Build */}
-            <CardThemed bgt='light'>
+            <CardThemed bgt="light">
               <CardHeader sx={{ pb: 0 }} title={'New Equipment'} />
               <CardContent
                 sx={{
@@ -153,26 +150,27 @@ export default function EquipBuildModal({
                   columns={{ xs: 2, sm: 3, md: 4, lg: 6 }}
                 >
                   <Grid item xs={1}>
-                  <WeaponCardNano
-                    weaponId={equipChangeProps.newWeapon}
-                    weaponTypeKey={weaponTypeKey}
-                  />
+                    <WeaponCardNano
+                      weaponId={equipChangeProps.newWeapon}
+                      weaponTypeKey={weaponTypeKey}
+                    />
                   </Grid>
-                  {Object.entries(equipChangeProps.newArtifacts).map(([slotKey, id]) => (
-                    <Grid item key={id || slotKey} xs={1}>
-                      <ArtifactCardNano
-                        artifactId={id}
-                        slotKey={slotKey}
-                      />
-                    </Grid>
-                  ))}
+                  {Object.entries(equipChangeProps.newArtifacts).map(
+                    ([slotKey, id]) => (
+                      <Grid item key={id || slotKey} xs={1}>
+                        <ArtifactCardNano artifactId={id} slotKey={slotKey} />
+                      </Grid>
+                    )
+                  )}
                 </Grid>
               </CardContent>
             </CardThemed>
           </Box>
         </CardContent>
         <CardContent sx={{ pt: '0', display: 'flex', flexDirection: 'column' }}>
-          <Typography sx={{ fontSize: 20 }}>Do you want to make the changes shown above?</Typography>
+          <Typography sx={{ fontSize: 20 }}>
+            Do you want to make the changes shown above?
+          </Typography>
           <FormControlLabel
             label={`Copy the current equipment in ${equipChangeProps.currentName} to a new build. Otherwise, they will be overwritten.`}
             control={

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
@@ -1,0 +1,203 @@
+import {
+  CardThemed,
+  ModalWrapper,
+} from '@genshin-optimizer/common/ui'
+import type { ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import { getCharData } from '@genshin-optimizer/gi/stats'
+import { Checkroom, KeyboardArrowDown } from '@mui/icons-material'
+import {
+  Box,
+  Button,
+  CardContent,
+  CardHeader,
+  Checkbox,
+  Divider,
+  FormControlLabel,
+  Grid,
+  TextField,
+} from '@mui/material'
+import { useContext, useState } from 'react'
+import ArtifactCardNano from '../../../Components/Artifact/ArtifactCardNano'
+import CloseButton from '../../../Components/CloseButton'
+import WeaponCardNano from '../../../Components/Weapon/WeaponCardNano'
+import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'
+
+type CurrentNewBuildProps = {
+  currentWeapon: string | undefined
+  currentArtifacts: Record<ArtifactSlotKey, string | undefined>
+  newWeapon: string | undefined
+  newArtifacts: Record<ArtifactSlotKey, string | undefined>
+}
+
+export default function EquipBuildModal({
+  buildProps,
+  showPrompt,
+  OnHidePrompt,
+  onEquip,
+}: {
+  buildProps: CurrentNewBuildProps
+  showPrompt: boolean
+  onEquip: () => void
+  OnHidePrompt: () => void
+}) {
+  const [name, setName] = useState('')
+  const [copyEquipped, setCopyEquipped] = useState(false)
+  // const [showPrompt, onShowPrompt, OnHidePrompt] = useBoolState()
+
+  const database = useDatabase()
+  const {
+    teamCharId,
+    teamChar: { key: characterKey },
+   } = useContext(TeamCharacterContext)
+  const weaponTypeKey = getCharData(characterKey).weaponType
+
+  const toEquip = () => {
+    if (copyEquipped) {
+      database.teamChars.newBuild(teamCharId, {
+        name: name !== '' ? name : 'Duplicate of Equipped',
+        artifactIds: buildProps.currentArtifacts,
+        weaponId: buildProps.currentWeapon,
+      })
+    }
+
+    onEquip()
+    setName('')
+    setCopyEquipped(false)
+    OnHidePrompt()
+  }
+
+  /* TODO: Dialog Wanted to use a Dialog here, but was having some weird issues with closing out of it */
+  /* TODO: Translation */
+  return (
+    <ModalWrapper
+      open={showPrompt}
+      onClose={OnHidePrompt}
+    >
+      <CardThemed>
+        <CardHeader
+          title={
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <Checkroom />
+              <span>Preview Build Changes</span>
+            </Box>
+          }
+          action={<CloseButton onClick={OnHidePrompt} />}
+        />
+        <Divider />
+        <CardContent
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Grid
+            container
+            spacing={1}
+            columns={{ xs: 2, sm: 2, md: 3, lg: 6, xl: 6 }}
+          >
+            {/* Active Build */}
+            <CardThemed bgt='light'>
+              <CardContent
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 1,
+                  alignItems: 'stretch',
+                }}
+              >
+                <Grid item xs={1}>
+                  <WeaponCardNano
+                    weaponId={buildProps.currentWeapon}
+                    weaponTypeKey={weaponTypeKey}
+                  />
+                </Grid>
+                {Object.entries(buildProps.currentArtifacts).map(([slotKey, id]) => (
+                  <Grid item key={id || slotKey} xs={1}>
+                    <ArtifactCardNano
+                      artifactId={id}
+                      slotKey={slotKey}
+                    />
+                  </Grid>
+                ))}
+              </CardContent>
+            </CardThemed>
+            <Box
+              flexGrow={1}
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              padding={2}
+            >
+              <KeyboardArrowDown sx={{ fontSize: 40 }} />
+            </Box>
+            {/* New Build */}
+            <CardThemed bgt='light'>
+              <CardContent
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 1,
+                  alignItems: 'stretch',
+                }}
+              >
+                <Grid item xs={1}>
+                  <WeaponCardNano
+                    weaponId={buildProps.newWeapon}
+                    weaponTypeKey={weaponTypeKey}
+                  />
+                </Grid>
+                {Object.entries(buildProps.newArtifacts).map(([slotKey, id]) => (
+                  <Grid item key={id || slotKey} xs={1}>
+                    <ArtifactCardNano
+                      artifactId={id}
+                      slotKey={slotKey}
+                    />
+                  </Grid>
+                ))}
+              </CardContent>
+            </CardThemed>
+          </Grid>
+        </CardContent>
+        <CardContent sx={{ display: 'flex', flexDirection: 'column' }}>
+          <span>Do you want to equip all gear in this build to this character?</span>
+          <FormControlLabel
+            label="Copy my current equipment to a new build. Otherwise, the currently equipped build will be overwritten."
+            control={
+              <Checkbox
+                checked={copyEquipped}
+                onChange={(event) => setCopyEquipped(event.target.checked)}
+                color={copyEquipped ? 'success' : 'secondary'}
+              />
+            }
+          />
+          {copyEquipped && (
+            <TextField
+              label="Build Name"
+              placeholder="Duplicate of Equipped"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              size="small"
+              sx={{ width: '75%', marginX: 4 }}
+            />
+          )}
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 1,
+              marginTop: 8,
+            }}
+          >
+            <Button color="error" onClick={OnHidePrompt}>
+              Cancel
+            </Button>
+            <Button color="success" onClick={toEquip}>
+              Equip
+            </Button>
+          </Box>
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
@@ -1,4 +1,4 @@
-import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
+import { CardThemed, ModalWrapper, SqBadge } from '@genshin-optimizer/common/ui'
 import type { ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
@@ -76,7 +76,10 @@ export default function EquipBuildModal({
           title={
             <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
               <Checkroom />
-              <span>Confirm Equipment Changes</span>
+              <span>
+                Confirm Equipment Changes for{' '}
+                <strong>{equipChangeProps.currentName}</strong>
+              </span>
             </Box>
           }
           action={<CloseButton onClick={OnHidePrompt} />}
@@ -91,12 +94,12 @@ export default function EquipBuildModal({
           <Box>
             {/* Active Build */}
             <CardThemed bgt="light">
-              <CardHeader
-                sx={{ pb: 0 }}
-                title={`${equipChangeProps.currentName}: Current Equipment`}
-              />
+              <Box sx={{ pl: 2, pt: 2 }}>
+                <SqBadge color="success">Current Equipment</SqBadge>
+              </Box>
               <CardContent
                 sx={{
+                  pt: 1,
                   display: 'flex',
                   flexDirection: 'row',
                   gap: 1,
@@ -135,9 +138,12 @@ export default function EquipBuildModal({
             </Box>
             {/* New Build */}
             <CardThemed bgt="light">
-              <CardHeader sx={{ pb: 0 }} title={'New Equipment'} />
+              <Box sx={{ pl: 2, pt: 2 }}>
+                <SqBadge color="success">New Equipment</SqBadge>
+              </Box>
               <CardContent
                 sx={{
+                  pt: 1,
                   display: 'flex',
                   flexDirection: 'row',
                   gap: 1,
@@ -172,7 +178,13 @@ export default function EquipBuildModal({
             Do you want to make the changes shown above?
           </Typography>
           <FormControlLabel
-            label={`Copy the current equipment in ${equipChangeProps.currentName} to a new build. Otherwise, they will be overwritten.`}
+            label={
+              <>
+                Copy the current equipment in{' '}
+                <strong>{equipChangeProps.currentName}</strong> to a new build.
+                Otherwise, they will be overwritten.
+              </>
+            }
             control={
               <Checkbox
                 checked={copyCurrent}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -60,6 +60,7 @@ import { getCharSheet } from '../../../../../Data/Characters'
 import { uiInput as input } from '../../../../../Formula'
 import ArtifactCard from '../../../../../PageArtifact/ArtifactCard'
 import WeaponCard from '../../../../../PageWeapon/WeaponCard'
+import EquipBuildModal from '../../../Build/EquipBuildModal'
 import { ArtifactSetBadges } from './ArtifactSetBadges'
 import SetInclusionButton from './SetInclusionButton'
 type NewOld = {
@@ -248,6 +249,36 @@ export default function BuildDisplayItem({
   const isActiveBuildOrEquip =
     isActiveBuild || (buildType === 'equipped' && currentlyEquipped)
 
+  const activeWeapon = useMemo(
+    () => {
+      if (dbDirty && buildType === 'real') return database.builds.get(buildId)!.weaponId
+      if (dbDirty && buildType === 'equipped') return equippedWeapon
+
+      // default
+      return ''
+    }, [dbDirty, database, buildType, buildId, equippedWeapon]
+  )
+
+  const activeArtifacts = useMemo(
+    () => {
+      if (dbDirty && buildType === 'real') return database.builds.get(buildId)!.artifactIds
+      if (dbDirty && buildType === 'equipped') return equippedArtifacts
+
+      // default
+      return objKeyMap(allArtifactSlotKeys, () => '')
+    }, [dbDirty, database, buildType, buildId, equippedArtifacts]
+  )
+
+  const [showBuildChange, onShowBuildChange, onHideBuildChange] = useBoolState()
+
+  const buildProps = {
+    currentWeapon: activeWeapon,
+    currentArtifacts: activeArtifacts,
+    newWeapon: data.get(input.weapon.id).value!,
+    newArtifacts: objKeyMap(allArtifactSlotKeys, (s) =>
+      data.get(input.art[s].id).value!),
+  }
+
   return (
     <CardLight
       sx={{
@@ -329,10 +360,16 @@ export default function BuildDisplayItem({
               sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}
             />
             {extraButtonsLeft}
+            <EquipBuildModal
+              buildProps={buildProps}
+              showPrompt={showBuildChange}
+              onEquip={equipBuild}
+              OnHidePrompt={onHideBuildChange}
+            />
             <Button
               size="small"
               color="success"
-              onClick={equipBuild}
+              onClick={onShowBuildChange}
               disabled={disabled || isActiveBuild}
               startIcon={<Checkroom />}
             >

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -132,10 +132,6 @@ export default function BuildDisplayItem({
   const closeArt = useCallback(() => setArtNewOld(undefined), [setArtNewOld])
   const buildEquip = buildId && buildType === 'real'
   const equipBuild = useCallback(() => {
-    const confirmMsg = buildEquip
-      ? 'Do you want to equip this build to the currently active build?'
-      : 'Do you want to equip this build to this character?'
-    if (!window.confirm(confirmMsg)) return
     if (buildEquip) {
       database.builds.set(buildId, {
         weaponId: data.get(input.weapon.id).value,
@@ -269,9 +265,10 @@ export default function BuildDisplayItem({
     }, [dbDirty, database, buildType, buildId, equippedArtifacts]
   )
 
-  const [showBuildChange, onShowBuildChange, onHideBuildChange] = useBoolState()
+  const [showEquipChange, onShowEquipChange, onHideEquipChange] = useBoolState()
 
-  const buildProps = {
+  const equipChangeProps = {
+    currentName: buildType === 'real' ? database.builds.get(buildId)!.name : 'Equipped',
     currentWeapon: activeWeapon,
     currentArtifacts: activeArtifacts,
     newWeapon: data.get(input.weapon.id).value!,
@@ -361,15 +358,15 @@ export default function BuildDisplayItem({
             />
             {extraButtonsLeft}
             <EquipBuildModal
-              buildProps={buildProps}
-              showPrompt={showBuildChange}
+              equipChangeProps={equipChangeProps}
+              showPrompt={showEquipChange}
               onEquip={equipBuild}
-              OnHidePrompt={onHideBuildChange}
+              OnHidePrompt={onHideEquipChange}
             />
             <Button
               size="small"
               color="success"
-              onClick={onShowBuildChange}
+              onClick={onShowEquipChange}
               disabled={disabled || isActiveBuild}
               startIcon={<Checkroom />}
             >

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -245,35 +245,36 @@ export default function BuildDisplayItem({
   const isActiveBuildOrEquip =
     isActiveBuild || (buildType === 'equipped' && currentlyEquipped)
 
-  const activeWeapon = useMemo(
-    () => {
-      if (dbDirty && buildType === 'real') return database.builds.get(buildId)!.weaponId
-      if (dbDirty && buildType === 'equipped') return equippedWeapon
+  const activeWeapon = useMemo(() => {
+    if (dbDirty && buildType === 'real')
+      return database.builds.get(buildId)!.weaponId
+    if (dbDirty && buildType === 'equipped') return equippedWeapon
 
-      // default
-      return ''
-    }, [dbDirty, database, buildType, buildId, equippedWeapon]
-  )
+    // default
+    return ''
+  }, [dbDirty, database, buildType, buildId, equippedWeapon])
 
-  const activeArtifacts = useMemo(
-    () => {
-      if (dbDirty && buildType === 'real') return database.builds.get(buildId)!.artifactIds
-      if (dbDirty && buildType === 'equipped') return equippedArtifacts
+  const activeArtifacts = useMemo(() => {
+    if (dbDirty && buildType === 'real')
+      return database.builds.get(buildId)!.artifactIds
+    if (dbDirty && buildType === 'equipped') return equippedArtifacts
 
-      // default
-      return objKeyMap(allArtifactSlotKeys, () => '')
-    }, [dbDirty, database, buildType, buildId, equippedArtifacts]
-  )
+    // default
+    return objKeyMap(allArtifactSlotKeys, () => '')
+  }, [dbDirty, database, buildType, buildId, equippedArtifacts])
 
   const [showEquipChange, onShowEquipChange, onHideEquipChange] = useBoolState()
 
   const equipChangeProps = {
-    currentName: buildType === 'real' ? database.builds.get(buildId)!.name : 'Equipped',
+    currentName:
+      buildType === 'real' ? database.builds.get(buildId)!.name : 'Equipped',
     currentWeapon: activeWeapon,
     currentArtifacts: activeArtifacts,
     newWeapon: data.get(input.weapon.id).value!,
-    newArtifacts: objKeyMap(allArtifactSlotKeys, (s) =>
-      data.get(input.art[s].id).value!),
+    newArtifacts: objKeyMap(
+      allArtifactSlotKeys,
+      (s) => data.get(input.art[s].id).value!
+    ),
   }
 
   return (


### PR DESCRIPTION
## Describe your changes
- Moved `EquipBuildModal` from `BuildReal.tsx` into a separate file - Both the equip button from build management and the equip button on the optimize tab do functionally the same thing, so this allows both to utilize `EquipBuildModal` for this purpose
    - Modified `EquipBuildModal` to display a preview of build changes above the confirmation and copy equipped checkbox
    - Added a new prop `equipChangeProps` containing the necessary name and weapon/artifact information to be displayed in the preview
    - Changed several strings to automatically insert the correct build name instead of always using "Equipped"
- Changed the relevant call sites in `BuildDisplayItem` and `BuildReal` to use the modified version of `EquipBuildModal`
<!--- Provide a general summary of your changes -->

## Issue or discord link

- Resolves #1619 <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
The equipment swap preview when only a weapon is equipped
![image](https://github.com/frzyc/genshin-optimizer/assets/47800040/e5ae3471-39b4-43e6-9d7c-86e6c6052f38)

The equipment swap preview on a narrower window
![image](https://github.com/frzyc/genshin-optimizer/assets/47800040/09241446-c1f6-4aa2-a7a9-35e909749497)

Equip preview and confirmation from the optimize tab

https://github.com/frzyc/genshin-optimizer/assets/47800040/97569633-097e-40ac-b41a-4e3eb874aba5

Equip preview and confirmation from the loadout settings modal

https://github.com/frzyc/genshin-optimizer/assets/47800040/0d0e2f1c-3cd0-4e6c-a0f9-9c14bff88166

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
