### PR TITLE
Remove melee infusion button from teams UI, move hitmode buttons

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
@@ -2,6 +2,7 @@ import { DropdownButton, SqBadge } from '@genshin-optimizer/common/ui'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
+import type { ButtonGroupProps } from '@mui/material'
 import { Button, ButtonGroup, MenuItem } from '@mui/material'
 import { useContext } from 'react'
 import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
@@ -12,7 +13,11 @@ import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
  */
 
 // TODO: Translation
-export default function CompareBtn() {
+export default function CompareBtn({
+  buttonGroupProps = {},
+}: {
+  buttonGroupProps?: ButtonGroupProps
+}) {
   const database = useDatabase()
   const {
     teamId,
@@ -51,7 +56,7 @@ export default function CompareBtn() {
       buildType === 'tc' &&
       buildTcId === compareBuildTcId)
   return (
-    <ButtonGroup>
+    <ButtonGroup {...buttonGroupProps}>
       <Button
         startIcon={compare ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
         color={compare ? 'success' : 'secondary'}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
@@ -13,11 +13,6 @@ import { Suspense, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Route, Link as RouterLink, Routes } from 'react-router-dom'
 import CardLight from '../../Components/Card/CardLight'
-import {
-  HitModeToggle,
-  InfusionAuraDropdown,
-  ReactionToggle,
-} from '../../Components/HitModeEditor'
 import SqBadge from '../../Components/SqBadge'
 import { FormulaDataContext } from '../../Context/FormulaDataContext'
 import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
@@ -56,20 +51,6 @@ export default function Content({ tab }: { tab: string }) {
         <DetailStatButton />
         <CustomMultiTargetButton />
         <FormulasButton />
-      </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          flexWrap: 'wrap',
-          '& button,.MuiToggleButtonGroup-root': {
-            flexGrow: 1,
-          },
-        }}
-      >
-        <HitModeToggle size="small" />
-        <InfusionAuraDropdown />
-        <ReactionToggle size="small" />
       </Box>
       <CardLight>
         <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
@@ -4,6 +4,10 @@ import { useCallback, useContext, useMemo, useRef } from 'react'
 import ArtifactCardNano from '../../../../Components/Artifact/ArtifactCardNano'
 import CardLight from '../../../../Components/Card/CardLight'
 import StatDisplayComponent from '../../../../Components/Character/StatDisplayComponent'
+import {
+  HitModeToggle,
+  ReactionToggle,
+} from '../../../../Components/HitModeEditor'
 import WeaponCardNano from '../../../../Components/Weapon/WeaponCardNano'
 import { DataContext } from '../../../../Context/DataContext'
 import { uiInput as input } from '../../../../Formula'
@@ -53,14 +57,23 @@ export default function TabOverview() {
                 gap: 1,
               }}
             >
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'flex-end',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <HitModeToggle size="small" />
+                <ReactionToggle size="small" />
+                <CompareBtn buttonGroupProps={{ sx: { marginLeft: 'auto' } }} />
+              </Box>
               <DataContext.Provider value={dataContextObj}>
                 <StatDisplayComponent
                   columns={{ xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }}
                 />
               </DataContext.Provider>
-              <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <CompareBtn />
-              </Box>
             </CardLight>
           </Grid>
         </Grid>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTalent.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTalent.tsx
@@ -1,3 +1,4 @@
+import { CardThemed } from '@genshin-optimizer/common/ui'
 import { maxConstellationCount } from '@genshin-optimizer/gi/consts'
 import type { ICharacter } from '@genshin-optimizer/gi/good'
 import {
@@ -18,6 +19,10 @@ import TalentDropdown from '../../../Components/Character/TalentDropdown'
 import ConditionalWrapper from '../../../Components/ConditionalWrapper'
 import DocumentDisplay from '../../../Components/DocumentDisplay'
 import { NodeFieldDisplay } from '../../../Components/FieldDisplay'
+import {
+  HitModeToggle,
+  ReactionToggle,
+} from '../../../Components/HitModeEditor'
 import { CharacterContext } from '../../../Context/CharacterContext'
 import { DataContext } from '../../../Context/DataContext'
 import type { TalentSheetElementKey } from '../../../Data/Characters/ICharacterSheet'
@@ -75,6 +80,22 @@ export default function CharacterTalentPane() {
 
   return (
     <>
+      <CardThemed bgt="light">
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 1,
+              flexWrap: 'wrap',
+            }}
+          >
+            <HitModeToggle size="small" />
+            <ReactionToggle size="small" />
+          </Box>
+        </CardContent>
+      </CardThemed>
+
       <ReactionDisplay />
       <Grid container spacing={1}>
         {/* constellations for 4column */}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -19,6 +19,10 @@ import { ArtifactStatWithUnit } from '../../../../Components/Artifact/ArtifactSt
 import CardLight from '../../../../Components/Card/CardLight'
 import StatDisplayComponent from '../../../../Components/Character/StatDisplayComponent'
 import CustomNumberInput from '../../../../Components/CustomNumberInput'
+import {
+  HitModeToggle,
+  ReactionToggle,
+} from '../../../../Components/HitModeEditor'
 import type { dataContextObj } from '../../../../Context/DataContext'
 import { DataContext } from '../../../../Context/DataContext'
 import { OptimizationTargetContext } from '../../../../Context/OptimizationTargetContext'
@@ -282,12 +286,12 @@ export default function TabTheorycraft() {
           </Grid>
         </Box>
         <CardLight>
-          <Box sx={{ display: 'flex', gap: 1, p: 1 }}>
-            <Box sx={{ flexGrow: 1, display: 'flex', gap: 1 }}>
-              <KQMSButton action={kqms} disabled={solving} />
-              <GcsimButton disabled={solving} />
-            </Box>
-            <CompareBtn />
+          <Box sx={{ display: 'flex', gap: 1, p: 1, flexWrap: 'wrap' }}>
+            <KQMSButton action={kqms} disabled={solving} />
+            <GcsimButton disabled={solving} />
+            <HitModeToggle size="small" />
+            <ReactionToggle size="small" />
+            <CompareBtn buttonGroupProps={{ sx: { marginLeft: 'auto' } }} />
           </Box>
         </CardLight>
         {dataContextValue ? (


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
Removes melee infusion dropdown, and move hitmode buttons to clean up team UI header
## Issue or discord link

- Resolves #1646 
- Resolves https://github.com/frzyc/genshin-optimizer/issues/1645

## Testing/validation

<!--- Add screenshots if possible -->
Talent
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/9ebe11da-69e4-4442-8277-0add71a86aa8)
TC
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/ffd5913e-8941-4274-9a18-6473a4d992e0)
Overview
<img width="1150" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/b8fa0f3e-6421-49b8-b4ea-fef24887187a">


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
