### PR TITLE
show team buff per character

### DIFF
--- a/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
@@ -213,6 +213,7 @@ export function TeammateDisplay({
             <CharacterCardWeaponFull loadoutDatum={loadoutDatum} />
             <CharWeaponCondDisplay />
             <CharTalentCondDisplay />
+            <TeamBuffDisplay />
           </Suspense>
         </CharacterContext.Provider>
       </DataContext.Provider>

--- a/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
@@ -68,7 +68,7 @@ export function TeamBuffDisplay() {
   return (
     <CardLight>
       <CardContent>
-        <Typography>Team Buffs</Typography>
+        <Typography>Received Team Buffs</Typography>
       </CardContent>
       <Divider />
       <CardContent>
@@ -209,11 +209,11 @@ export function TeammateDisplay({
             </CardThemed>
 
             <EquipmentRow loadoutDatum={loadoutDatum} />
-            <CharArtifactCondDisplay />
             <CharacterCardWeaponFull loadoutDatum={loadoutDatum} />
+            <TeamBuffDisplay />
+            <CharArtifactCondDisplay />
             <CharWeaponCondDisplay />
             <CharTalentCondDisplay />
-            <TeamBuffDisplay />
           </Suspense>
         </CharacterContext.Provider>
       </DataContext.Provider>

--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -168,7 +168,7 @@ function Page({ teamId }: { teamId: string }) {
     <CardThemed>
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <Box sx={{ display: 'flex', gap: 1 }}>
-          <TeamSetting teamId={teamId} dataContextValue={dataContextValue} />
+          <TeamSetting teamId={teamId} teamData={teamData} />
           <EnemyEditorElement teamId={teamId} />
         </Box>
 


### PR DESCRIPTION
## Describe your changes

Show Teambuff per character to better show non-teamwide buffs between teammembers

## Issue or discord link

- Resolves #1755 

## Testing/validation

<!--- Add screenshots if possible -->
On a geo resonance team, can see the geo resonance and other on-field buffs are only applied to the first character.
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/1c69c693-5b8f-4755-a291-2bcb71f0068f)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
