### PR TITLE
Add a more detailed loadout view to character page

### DIFF
--- a/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
+++ b/apps/frontend/src/app/Components/Artifact/ArtifactCardNano.tsx
@@ -86,7 +86,7 @@ export default function ArtifactCardNano({
     ? alpha(theme.palette[element].main, 0.6)
     : alpha(theme.palette.secondary.main, 0.6)
   return (
-    <BGComponent sx={{ height: '100%' }}>
+    <BGComponent sx={{ height: '100%', maxHeight: '8em' }}>
       <ConditionalWrapper condition={!!onClick} wrapper={actionWrapperFunc}>
         <Box display="flex" height="100%">
           <Box

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/BuildRealSimplified.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/BuildRealSimplified.tsx
@@ -1,0 +1,48 @@
+import type { CharacterKey } from '@genshin-optimizer/gi/consts'
+import { useBuild } from '@genshin-optimizer/gi/db-ui'
+import { getCharData } from '@genshin-optimizer/gi/stats'
+import { Box, Grid } from '@mui/material'
+import { BuildCard } from '../../../PageTeam/CharacterDisplay/Build/BuildCard'
+import ArtifactCardNano from '../../Artifact/ArtifactCardNano'
+import WeaponCardNano from '../../Weapon/WeaponCardNano'
+
+// TODO: Translation
+export default function BuildRealSimplified({
+  buildId,
+  characterKey,
+}: {
+  buildId: string
+  characterKey: CharacterKey
+}) {
+  const { name, description, weaponId, artifactIds } = useBuild(buildId)!
+
+  const weaponTypeKey = getCharData(characterKey).weaponType
+
+  return (
+    <BuildCard name={name} description={description} hideFooter>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 1,
+          alignItems: 'stretch',
+        }}
+      >
+        <Grid
+          container
+          spacing={1}
+          columns={{ xs: 2, sm: 2, md: 2, lg: 3, xl: 3 }}
+        >
+          <Grid item xs={1}>
+            <WeaponCardNano weaponId={weaponId} weaponTypeKey={weaponTypeKey} />
+          </Grid>
+          {Object.entries(artifactIds).map(([slotKey, id]) => (
+            <Grid item key={id || slotKey} xs={1}>
+              <ArtifactCardNano artifactId={id} slotKey={slotKey} />
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    </BuildCard>
+  )
+}

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/BuildTcSimplified.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/BuildTcSimplified.tsx
@@ -1,73 +1,30 @@
-import { useBoolState } from '@genshin-optimizer/common/react-util'
-import { CardThemed, ModalWrapper, SqBadge } from '@genshin-optimizer/common/ui'
+import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
 import { unit } from '@genshin-optimizer/common/util'
 import { artifactAsset } from '@genshin-optimizer/gi/assets'
 import type { ICachedWeapon } from '@genshin-optimizer/gi/db'
-import { useBuildTc, useDatabase } from '@genshin-optimizer/gi/db-ui'
+import { useBuildTc } from '@genshin-optimizer/gi/db-ui'
 import { SlotIcon } from '@genshin-optimizer/gi/svgicons'
 import { ArtifactSetName } from '@genshin-optimizer/gi/ui'
 import { artDisplayValue } from '@genshin-optimizer/gi/util'
-import CloseIcon from '@mui/icons-material/Close'
-import {
-  Box,
-  CardContent,
-  CardHeader,
-  Divider,
-  Grid,
-  IconButton,
-  TextField,
-} from '@mui/material'
-import { useContext, useDeferredValue, useEffect, useState } from 'react'
-import ImgIcon from '../../../Components/Image/ImgIcon'
-import { StatWithUnit } from '../../../Components/StatDisplay'
-import { WeaponCardNanoObj } from '../../../Components/Weapon/WeaponCardNano'
-import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'
+import { Box, Grid } from '@mui/material'
 import { getWeaponSheet } from '../../../Data/Weapons'
-import { BuildCard } from './BuildCard'
+import { BuildCard } from '../../../PageTeam/CharacterDisplay/Build/BuildCard'
+import ImgIcon from '../../Image/ImgIcon'
+import { StatWithUnit } from '../../StatDisplay'
+import { WeaponCardNanoObj } from '../../Weapon/WeaponCardNano'
 
-export default function BuildTc({
+export default function BuildTcSimplified({
   buildTcId,
-  active = false,
 }: {
   buildTcId: string
-  active?: boolean
 }) {
-  const [open, onOpen, onClose] = useBoolState()
-  const { teamId, teamCharId } = useContext(TeamCharacterContext)
-  const database = useDatabase()
   const buildTc = useBuildTc(buildTcId)!
   const { name, description } = buildTc
-  const onActive = () =>
-    database.teams.setLoadoutDatum(teamId, teamCharId, {
-      buildType: 'tc',
-      buildTcId,
-    })
-  const onRemove = () => {
-    //TODO: prompt user for removal
-    database.buildTcs.remove(buildTcId)
-  }
-  const onDupe = () =>
-    database.teamChars.newBuildTc(teamCharId, {
-      ...structuredClone(buildTc),
-      name: `Duplicate of ${name}`,
-    })
+
   return (
-    <>
-      <ModalWrapper open={open} onClose={onClose}>
-        <BuildTcEditor buildTcId={buildTcId} onClose={onClose} />
-      </ModalWrapper>
-      <BuildCard
-        name={name}
-        description={description}
-        active={active}
-        onActive={onActive}
-        onEdit={onOpen}
-        onDupe={onDupe}
-        onRemove={onRemove}
-      >
-        <TcEquip buildTcId={buildTcId} />
-      </BuildCard>
-    </>
+    <BuildCard name={name} description={description} hideFooter>
+      <TcEquip buildTcId={buildTcId} />
+    </BuildCard>
   )
 }
 function TcEquip({ buildTcId }: { buildTcId: string }) {
@@ -184,77 +141,5 @@ function TcEquip({ buildTcId }: { buildTcId: string }) {
         ))}
       </Grid>
     </Box>
-  )
-}
-
-function BuildTcEditor({
-  buildTcId,
-  onClose,
-}: {
-  buildTcId: string
-  onClose: () => void
-}) {
-  const database = useDatabase()
-  const build = useBuildTc(buildTcId)!
-
-  const [name, setName] = useState(build.name)
-  const nameDeferred = useDeferredValue(name)
-  const [desc, setDesc] = useState(build.description)
-  const descDeferred = useDeferredValue(desc)
-
-  // trigger on buildId change, to use the new team's name/desc
-  useEffect(() => {
-    const newBuild = database.buildTcs.get(buildTcId)
-    if (!newBuild) return
-    const { name, description } = newBuild
-    setName(name)
-    setDesc(description)
-  }, [database, buildTcId])
-
-  useEffect(() => {
-    database.buildTcs.set(buildTcId, (build) => {
-      build.name = nameDeferred
-    })
-    // Don't need to trigger when buildId is changed, only when the name is changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [database, nameDeferred])
-
-  useEffect(() => {
-    database.buildTcs.set(buildTcId, (build) => {
-      build.description = descDeferred
-    })
-    // Don't need to trigger when buildId is changed, only when the name is changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [database, descDeferred])
-  return (
-    <CardThemed>
-      <CardHeader
-        title="Build Settings"
-        action={
-          <IconButton onClick={onClose}>
-            <CloseIcon />
-          </IconButton>
-        }
-      />
-      <Divider />
-      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <TextField
-          fullWidth
-          label="Build Name"
-          placeholder="Build Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <TextField
-          fullWidth
-          label="Build Description"
-          placeholder="Build Description"
-          value={desc}
-          onChange={(e) => setDesc(e.target.value)}
-          multiline
-          minRows={2}
-        />
-      </CardContent>
-    </CardThemed>
   )
 }

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutCard.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutCard.tsx
@@ -1,0 +1,97 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
+import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
+import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import AddIcon from '@mui/icons-material/Add'
+import InfoIcon from '@mui/icons-material/Info'
+import PersonIcon from '@mui/icons-material/Person'
+import SettingsIcon from '@mui/icons-material/Settings'
+import {
+  Box,
+  Button,
+  CardActionArea,
+  CardContent,
+  Divider,
+  Grid,
+  Typography,
+} from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import TeamCard from '../../../PageTeams/TeamCard'
+import LoadoutEditor from './LoadoutEditor'
+const columns = {
+  xs: 1,
+  md: 2,
+} as const
+
+export default function LoadoutCard({
+  teamCharId,
+  teamIds,
+}: {
+  teamCharId: string
+  teamIds: string[]
+}) {
+  const navigate = useNavigate()
+  const database = useDatabase()
+  const { name, description } = database.teamChars.get(teamCharId)!
+
+  const onAddTeam = (teamCharId: string) => {
+    const teamId = database.teams.new()
+    database.teams.set(teamId, (team) => {
+      team.loadoutData[0] = { teamCharId } as LoadoutDatum
+    })
+    navigate(`/teams/${teamId}`, { state: { openSetting: true } })
+  }
+  const [show, onShow, onHide] = useBoolState()
+  return (
+    <>
+      <LoadoutEditor
+        show={show}
+        onHide={onHide}
+        teamCharId={teamCharId}
+        teamIds={teamIds}
+      />
+      <CardThemed key={teamCharId} bgt="light">
+        <CardActionArea onClick={onShow}>
+          <CardContent>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <PersonIcon />
+              <Typography>{name}</Typography>
+              <BootstrapTooltip title={<Typography>{description}</Typography>}>
+                <InfoIcon />
+              </BootstrapTooltip>
+
+              <SettingsIcon sx={{ ml: 'auto' }} />
+            </Box>
+          </CardContent>
+        </CardActionArea>
+        <Divider />
+        <CardContent>
+          <Grid container columns={columns} spacing={1}>
+            {teamIds.map((teamId) => (
+              <Grid item xs={1} key={teamId}>
+                <TeamCard
+                  teamId={teamId}
+                  onClick={(cid) =>
+                    navigate(`/teams/${teamId}${cid ? `/${cid}` : ''}`)
+                  }
+                />
+              </Grid>
+            ))}
+            <Grid item xs={1}>
+              <Button
+                fullWidth
+                sx={{ height: '100%', backgroundColor: 'contentNormal.main' }}
+                variant="outlined"
+                onClick={() => onAddTeam(teamCharId)}
+                color="info"
+                startIcon={<AddIcon />}
+              >
+                Add new Team
+              </Button>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </CardThemed>
+    </>
+  )
+}

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
@@ -1,0 +1,318 @@
+import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
+import { unit } from '@genshin-optimizer/common/util'
+import type { LoadoutDatum, TeamCharacter } from '@genshin-optimizer/gi/db'
+import {
+  useDatabase,
+  useOptConfig,
+  useTeamChar,
+} from '@genshin-optimizer/gi/db-ui'
+import { KeyMap } from '@genshin-optimizer/gi/keymap'
+import AddIcon from '@mui/icons-material/Add'
+import BarChartIcon from '@mui/icons-material/BarChart'
+import CheckroomIcon from '@mui/icons-material/Checkroom'
+import CloseIcon from '@mui/icons-material/Close'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import InfoIcon from '@mui/icons-material/Info'
+import PersonIcon from '@mui/icons-material/Person'
+import {
+  Box,
+  Button,
+  CardContent,
+  CardHeader,
+  Divider,
+  Grid,
+  IconButton,
+  Tooltip,
+} from '@mui/material'
+
+import DocumentDisplay from '../../DocumentDisplay'
+import BuildInfoAlert from '../../Team/Loadout/Build/BuildInfoAlert'
+import LoadoutInfoAlert from '../../Team/Loadout/LoadoutInfoAlert'
+import LoadoutNameDesc from '../../Team/Loadout/LoadoutNameDesc'
+import BuildRealSimplified from './BuildRealSimplified'
+import BuildTcSimplified from './BuildTcSimplified'
+import OptimizationTargetDisplay from './OptimizationTargetDisplay'
+
+import { useNavigate } from 'react-router-dom'
+import TeamCard from '../../../PageTeams/TeamCard'
+import TeamInfoAlert from '../../Team/TeamInfoAlert'
+
+export default function LoadoutEditor({
+  show,
+  onHide,
+  teamCharId,
+  teamIds,
+}: {
+  show: boolean
+  onHide: () => void
+  teamCharId: string
+  teamIds: string[]
+}) {
+  const navigate = useNavigate()
+  const database = useDatabase()
+  const {
+    key: characterKey,
+    name,
+    buildIds,
+    buildTcIds,
+    customMultiTargets,
+    bonusStats,
+    optConfigId,
+  } = useTeamChar(teamCharId)!
+  const { optimizationTarget } = useOptConfig(optConfigId)!
+  const onDelete = () => {
+    if (
+      !window.confirm(
+        `Delete loadout? ${
+          teamIds.length
+            ? 'Teams with this loadout will have this loadout removed from the team. Teams will not be deleted.'
+            : ''
+        }`
+      )
+    )
+      return
+    onHide()
+    database.teamChars.remove(teamCharId)
+  }
+  const onDup = () => {
+    const newTeamCharId = database.teamChars.duplicate(teamCharId)
+    if (!newTeamCharId) return
+    onHide()
+  }
+  const onAddTeam = (teamCharId: string) => {
+    const teamId = database.teams.new()
+    database.teams.set(teamId, (team) => {
+      team.loadoutData[0] = { teamCharId } as LoadoutDatum
+    })
+    navigate(`/teams/${teamId}`, { state: { openSetting: true } })
+  }
+  return (
+    <ModalWrapper
+      open={show}
+      onClose={onHide}
+      containerProps={{ maxWidth: 'lg' }}
+    >
+      <CardThemed>
+        <CardHeader
+          title={
+            <Box display="flex" gap={1} alignItems="center">
+              <PersonIcon />
+              <strong>{name}</strong>
+            </Box>
+          }
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <LoadoutInfoAlert />
+          <LoadoutNameDesc teamCharId={teamCharId} />
+          <Box>
+            <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+              <Grid item xs={1}>
+                <Button
+                  color="info"
+                  onClick={() => onDup()}
+                  fullWidth
+                  startIcon={<ContentCopyIcon />}
+                >
+                  Duplicate Loadout
+                </Button>
+              </Grid>
+              <Grid item xs={1}>
+                <Button
+                  fullWidth
+                  startIcon={<DeleteForeverIcon />}
+                  color="error"
+                  onClick={onDelete}
+                >
+                  Delete Loadout
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+
+          <Box>
+            <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+              {!!Object.keys(bonusStats).length && (
+                <Grid item xs={1}>
+                  <BonusStatsCard bonusStats={bonusStats} />
+                </Grid>
+              )}
+              {!!optimizationTarget && (
+                <Grid item xs={1}>
+                  <OptimizationTargetDisplay
+                    optimizationTarget={optimizationTarget}
+                  />
+                </Grid>
+              )}
+              {!!customMultiTargets.length && (
+                <Grid item xs={1}>
+                  <MultiTargetCard customMultiTargets={customMultiTargets} />
+                </Grid>
+              )}
+            </Grid>
+          </Box>
+        </CardContent>
+        <Divider />
+        <CardHeader
+          title={
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <CheckroomIcon />
+              <span>Builds</span>
+            </Box>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <BuildInfoAlert />
+          <Box>
+            <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+              {buildIds.map((id) => (
+                <Grid item xs={1} key={id}>
+                  <BuildRealSimplified
+                    buildId={id}
+                    characterKey={characterKey}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+
+          <Box>
+            <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+              {buildTcIds.map((id) => (
+                <Grid item xs={1} key={id}>
+                  <BuildTcSimplified buildTcId={id} />
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        </CardContent>
+        <Divider />
+        <CardHeader
+          title={
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <CheckroomIcon />
+              <span>Teams</span>
+            </Box>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TeamInfoAlert />
+          <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+            {teamIds.map((teamId) => (
+              <Grid item xs={1} key={teamId}>
+                <TeamCard
+                  bgt="light"
+                  teamId={teamId}
+                  onClick={(cid) =>
+                    navigate(`/teams/${teamId}${cid ? `/${cid}` : ''}`)
+                  }
+                />
+              </Grid>
+            ))}
+            <Grid item xs={1}>
+              <Button
+                fullWidth
+                sx={{ height: '100%', backgroundColor: 'contentLight.main' }}
+                variant="outlined"
+                onClick={() => onAddTeam(teamCharId)}
+                color="info"
+                startIcon={<AddIcon />}
+              >
+                Add new Team
+              </Button>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}
+
+function BonusStatsCard({
+  bonusStats,
+}: {
+  bonusStats: TeamCharacter['bonusStats']
+}) {
+  return (
+    <CardThemed bgt="light">
+      <CardHeader
+        title={
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+            }}
+          >
+            <BarChartIcon />
+            <span>Bonus Stats</span>
+          </Box>
+        }
+        titleTypographyProps={{ variant: 'h6' }}
+      />
+
+      <DocumentDisplay
+        bgt="light"
+        sections={[
+          {
+            fields: Object.entries(bonusStats).map(([key, value]) => ({
+              text: KeyMap.getStr(key) ?? key,
+              value: value,
+              unit: unit(key),
+            })),
+          },
+        ]}
+      />
+    </CardThemed>
+  )
+}
+function MultiTargetCard({
+  customMultiTargets,
+}: {
+  customMultiTargets: TeamCharacter['customMultiTargets']
+}) {
+  return (
+    <CardThemed bgt="light">
+      <CardHeader
+        title={
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+            }}
+          >
+            <DashboardCustomizeIcon />
+            <span>Custom multi-targets</span>
+          </Box>
+        }
+        titleTypographyProps={{ variant: 'h6' }}
+      />
+
+      <DocumentDisplay
+        bgt="light"
+        sections={[
+          {
+            fields: customMultiTargets.map(({ name, description }) => ({
+              text: name,
+              value: description ? (
+                <Tooltip title={description}>
+                  <InfoIcon />
+                </Tooltip>
+              ) : undefined,
+            })),
+          },
+        ]}
+      />
+    </CardThemed>
+  )
+}

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
@@ -1,3 +1,4 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
 import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
 import { crawlObject, unit } from '@genshin-optimizer/common/util'
 import type { LoadoutDatum, TeamCharacter } from '@genshin-optimizer/gi/db'
@@ -27,21 +28,18 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-
+import { useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import TeamCard from '../../../PageTeams/TeamCard'
 import DocumentDisplay from '../../DocumentDisplay'
 import BuildInfoAlert from '../../Team/Loadout/Build/BuildInfoAlert'
 import LoadoutInfoAlert from '../../Team/Loadout/LoadoutInfoAlert'
 import LoadoutNameDesc from '../../Team/Loadout/LoadoutNameDesc'
+import TeamInfoAlert from '../../Team/TeamInfoAlert'
 import BuildRealSimplified from './BuildRealSimplified'
 import BuildTcSimplified from './BuildTcSimplified'
 import OptimizationTargetDisplay from './OptimizationTargetDisplay'
-
-import { useBoolState } from '@genshin-optimizer/common/react-util'
-import { useNavigate } from 'react-router-dom'
-import TeamCard from '../../../PageTeams/TeamCard'
-import TeamInfoAlert from '../../Team/TeamInfoAlert'
 import RemoveLoadout from './RemoveLoadout'
-import { useMemo } from 'react'
 
 export default function LoadoutEditor({
   show,

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
@@ -1,5 +1,5 @@
 import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
-import { unit } from '@genshin-optimizer/common/util'
+import { crawlObject, unit } from '@genshin-optimizer/common/util'
 import type { LoadoutDatum, TeamCharacter } from '@genshin-optimizer/gi/db'
 import {
   useDatabase,
@@ -25,6 +25,7 @@ import {
   Grid,
   IconButton,
   Tooltip,
+  Typography,
 } from '@mui/material'
 
 import DocumentDisplay from '../../DocumentDisplay'
@@ -40,6 +41,7 @@ import { useNavigate } from 'react-router-dom'
 import TeamCard from '../../../PageTeams/TeamCard'
 import TeamInfoAlert from '../../Team/TeamInfoAlert'
 import RemoveLoadout from './RemoveLoadout'
+import { useMemo } from 'react'
 
 export default function LoadoutEditor({
   show,
@@ -63,6 +65,7 @@ export default function LoadoutEditor({
     customMultiTargets,
     bonusStats,
     optConfigId,
+    conditional,
   } = useTeamChar(teamCharId)!
   const { optimizationTarget } = useOptConfig(optConfigId)!
   const onDelete = () => {
@@ -81,6 +84,16 @@ export default function LoadoutEditor({
     })
     navigate(`/teams/${teamId}`, { state: { openSetting: true } })
   }
+  const conditionalCount = useMemo(() => {
+    let count = 0
+    crawlObject(
+      conditional,
+      [],
+      (o) => typeof o !== 'object',
+      () => count++
+    )
+    return count
+  }, [conditional])
   return (
     <ModalWrapper
       open={show}
@@ -124,6 +137,7 @@ export default function LoadoutEditor({
                   onDelete={onDelete}
                   teamCharId={teamCharId}
                   teamIds={teamIds}
+                  conditionalCount={conditionalCount}
                 />
                 <Button
                   fullWidth
@@ -156,6 +170,15 @@ export default function LoadoutEditor({
                   <MultiTargetCard customMultiTargets={customMultiTargets} />
                 </Grid>
               )}
+              <Grid item xs={1}>
+                <CardThemed bgt="light">
+                  <CardContent>
+                    <Typography variant="h6">
+                      Conditionals: <strong>{conditionalCount}</strong>
+                    </Typography>
+                  </CardContent>
+                </CardThemed>
+              </Grid>
             </Grid>
           </Box>
         </CardContent>

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutEditor.tsx
@@ -35,9 +35,11 @@ import BuildRealSimplified from './BuildRealSimplified'
 import BuildTcSimplified from './BuildTcSimplified'
 import OptimizationTargetDisplay from './OptimizationTargetDisplay'
 
+import { useBoolState } from '@genshin-optimizer/common/react-util'
 import { useNavigate } from 'react-router-dom'
 import TeamCard from '../../../PageTeams/TeamCard'
 import TeamInfoAlert from '../../Team/TeamInfoAlert'
+import RemoveLoadout from './RemoveLoadout'
 
 export default function LoadoutEditor({
   show,
@@ -50,6 +52,7 @@ export default function LoadoutEditor({
   teamCharId: string
   teamIds: string[]
 }) {
+  const [showRemoval, onShowRemoval, onHideRemoval] = useBoolState()
   const navigate = useNavigate()
   const database = useDatabase()
   const {
@@ -63,16 +66,6 @@ export default function LoadoutEditor({
   } = useTeamChar(teamCharId)!
   const { optimizationTarget } = useOptConfig(optConfigId)!
   const onDelete = () => {
-    if (
-      !window.confirm(
-        `Delete loadout? ${
-          teamIds.length
-            ? 'Teams with this loadout will have this loadout removed from the team. Teams will not be deleted.'
-            : ''
-        }`
-      )
-    )
-      return
     onHide()
     database.teamChars.remove(teamCharId)
   }
@@ -125,11 +118,18 @@ export default function LoadoutEditor({
                 </Button>
               </Grid>
               <Grid item xs={1}>
+                <RemoveLoadout
+                  show={showRemoval}
+                  onHide={onHideRemoval}
+                  onDelete={onDelete}
+                  teamCharId={teamCharId}
+                  teamIds={teamIds}
+                />
                 <Button
                   fullWidth
                   startIcon={<DeleteForeverIcon />}
                   color="error"
-                  onClick={onDelete}
+                  onClick={onShowRemoval}
                 >
                   Delete Loadout
                 </Button>

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/OptimizationTargetDisplay.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/OptimizationTargetDisplay.tsx
@@ -1,0 +1,106 @@
+import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
+import { objPathValue } from '@genshin-optimizer/common/util'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import TrackChangesIcon from '@mui/icons-material/TrackChanges'
+import {
+  Box,
+  CardContent,
+  CardHeader,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useContext, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { DataContext } from '../../../Context/DataContext'
+import { getDisplayHeader } from '../../../Formula/DisplayUtil'
+import type { NodeDisplay } from '../../../Formula/uiData'
+import ImgIcon from '../../Image/ImgIcon'
+export default function OptimizationTargetDisplay({
+  optimizationTarget,
+  showEmptyTargets = false,
+}: {
+  optimizationTarget?: string[]
+  showEmptyTargets?: boolean
+}) {
+  const { t } = useTranslation('page_character_optimize')
+
+  const { data } = useContext(DataContext)
+  const database = useDatabase()
+  const displayHeader = useMemo(
+    () =>
+      optimizationTarget &&
+      getDisplayHeader(data, optimizationTarget[0], database),
+    [data, optimizationTarget, database]
+  )
+
+  const defaultText = t('targetSelector.selectOptTarget')
+
+  const { title, icon, action } = displayHeader ?? {}
+  const node: NodeDisplay | undefined =
+    optimizationTarget &&
+    (objPathValue(data.getDisplay(), optimizationTarget) as any)
+
+  const invalidTarget =
+    !optimizationTarget ||
+    !displayHeader ||
+    !node ||
+    // Make sure the opt target is valid, if we are not in multi-target
+    (!showEmptyTargets && node.isEmpty)
+
+  const prevariant = invalidTarget ? 'secondary' : node.info.variant
+  const variant = prevariant === 'invalid' ? undefined : prevariant
+
+  const { textSuffix } = node?.info ?? {}
+  const suffixDisplay = textSuffix && <span> {textSuffix}</span>
+  const iconDisplay = icon ? <ImgIcon src={icon} size={2} /> : node?.info.icon
+  return (
+    <CardThemed bgt="light">
+      <CardHeader
+        title={
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+            }}
+          >
+            <TrackChangesIcon />
+            <span>Optimization Target</span>
+          </Box>
+        }
+      />
+      <Divider />
+      <CardContent>
+        {invalidTarget ? (
+          <strong>{defaultText}</strong>
+        ) : (
+          <Stack
+            // direction="row"
+            divider={<Divider orientation="vertical" flexItem />}
+            spacing={1}
+          >
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              {iconDisplay}
+              <span>{title}</span>
+              {!!action && (
+                <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
+                  {action}
+                </SqBadge>
+              )}
+            </Box>
+            <Typography
+              variant="h6"
+              sx={{ display: 'flex', alignItems: 'center' }}
+            >
+              <SqBadge color={variant} sx={{ whiteSpace: 'normal' }}>
+                <strong>{node.info.name}</strong>
+                {suffixDisplay}
+              </SqBadge>
+            </Typography>
+          </Stack>
+        )}
+      </CardContent>
+    </CardThemed>
+  )
+}

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/RemoveLoadout.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/RemoveLoadout.tsx
@@ -27,12 +27,14 @@ export default function RemoveLoadout({
   teamCharId,
   onDelete,
   teamIds,
+  conditionalCount,
 }: {
-  show
-  onHide
+  show: boolean
+  onHide: () => void
   teamCharId: string
   teamIds: string[]
   onDelete: () => void
+  conditionalCount: number
 }) {
   const database = useDatabase()
   const {
@@ -168,6 +170,11 @@ export default function RemoveLoadout({
             {!!Object.keys(bonusStats).length && (
               <ListItem sx={{ display: 'list-item' }}>
                 Bonus stats: {Object.keys(bonusStats).length}
+              </ListItem>
+            )}
+            {!!conditionalCount && (
+              <ListItem sx={{ display: 'list-item' }}>
+                Conditionals: {conditionalCount}
               </ListItem>
             )}
             <ListItem sx={{ display: 'list-item' }}>

--- a/apps/frontend/src/app/Components/Character/CharacterEditor/RemoveLoadout.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/RemoveLoadout.tsx
@@ -1,0 +1,227 @@
+import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import CheckroomIcon from '@mui/icons-material/Checkroom'
+import CloseIcon from '@mui/icons-material/Close'
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import GroupsIcon from '@mui/icons-material/Groups'
+import InfoIcon from '@mui/icons-material/Info'
+import {
+  Box,
+  Button,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { useCallback } from 'react'
+
+export default function RemoveLoadout({
+  show,
+  onHide,
+  teamCharId,
+  onDelete,
+  teamIds,
+}: {
+  show
+  onHide
+  teamCharId: string
+  teamIds: string[]
+  onDelete: () => void
+}) {
+  const database = useDatabase()
+  const {
+    name,
+    description,
+    buildIds,
+    buildTcIds,
+    customMultiTargets,
+    bonusStats,
+  } = database.teamChars.get(teamCharId)!
+
+  const onDeleteLoadout = useCallback(() => {
+    onHide()
+    onDelete()
+  }, [onDelete, onHide])
+  return (
+    <ModalWrapper
+      open={show}
+      onClose={onHide}
+      containerProps={{ maxWidth: 'md' }}
+    >
+      <CardThemed>
+        <CardHeader
+          title={
+            <span>
+              Delete Loadout: <strong>{name}</strong>?
+            </span>
+          }
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent>
+          {description && (
+            <CardThemed bgt="dark" sx={{ mb: 2 }}>
+              <CardContent>{description}</CardContent>
+            </CardThemed>
+          )}
+          <Typography>
+            Deleting the Loadout will also delete the following data:
+          </Typography>
+          <List sx={{ listStyleType: 'disc', pl: 4 }}>
+            {!!buildIds.length && (
+              <ListItem sx={{ display: 'list-item' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  All saved builds: {buildIds.length}{' '}
+                  <Tooltip
+                    title={
+                      <Box>
+                        {buildIds.map((bId) => (
+                          <Typography
+                            key={bId}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
+                            <CheckroomIcon />
+                            <span>{database.builds.get(bId)?.name}</span>
+                          </Typography>
+                        ))}
+                      </Box>
+                    }
+                  >
+                    <InfoIcon />
+                  </Tooltip>
+                </Box>
+              </ListItem>
+            )}
+
+            {!!buildTcIds.length && (
+              <ListItem sx={{ display: 'list-item' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  All saved TC builds: {buildTcIds.length}{' '}
+                  <Tooltip
+                    title={
+                      <Box>
+                        {buildTcIds.map((bId) => (
+                          <Typography
+                            key={bId}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
+                            <CheckroomIcon />
+                            <span>{database.buildTcs.get(bId)?.name}</span>
+                          </Typography>
+                        ))}
+                      </Box>
+                    }
+                  >
+                    <InfoIcon />
+                  </Tooltip>
+                </Box>
+              </ListItem>
+            )}
+
+            {!!customMultiTargets.length && (
+              <ListItem sx={{ display: 'list-item' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  All Custom Multi-targets: {customMultiTargets.length}{' '}
+                  <Tooltip
+                    title={
+                      <Box>
+                        {customMultiTargets.map((target, i) => (
+                          <Typography
+                            key={i}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
+                            <DashboardCustomizeIcon />
+                            <span>{target.name}</span>
+                          </Typography>
+                        ))}
+                      </Box>
+                    }
+                  >
+                    <InfoIcon />
+                  </Tooltip>
+                </Box>
+              </ListItem>
+            )}
+
+            {!!Object.keys(bonusStats).length && (
+              <ListItem sx={{ display: 'list-item' }}>
+                Bonus stats: {Object.keys(bonusStats).length}
+              </ListItem>
+            )}
+            <ListItem sx={{ display: 'list-item' }}>
+              Optimization Configuration
+            </ListItem>
+
+            {!!teamIds.length && (
+              <ListItem sx={{ display: 'list-item' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <span>
+                    Any teams with this loadout will have this loadout removed
+                    from the team. Teams will not be deleted. Teams affected:{' '}
+                    {teamIds.length}
+                  </span>
+
+                  <Tooltip
+                    title={
+                      <Box>
+                        {teamIds.map((teamId) => (
+                          <Typography
+                            key={teamId}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
+                            <GroupsIcon />
+                            <span>{database.teams.get(teamId)?.name}</span>
+                          </Typography>
+                        ))}
+                      </Box>
+                    }
+                  >
+                    <InfoIcon />
+                  </Tooltip>
+                </Box>
+              </ListItem>
+            )}
+          </List>
+        </CardContent>
+        <CardActions sx={{ float: 'right' }}>
+          <Button startIcon={<CloseIcon />} color="secondary" onClick={onHide}>
+            Cancel
+          </Button>
+          <Button
+            startIcon={<DeleteForeverIcon />}
+            color="error"
+            onClick={onDeleteLoadout}
+          >
+            Delete
+          </Button>
+        </CardActions>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}

--- a/apps/frontend/src/app/Components/Team/Loadout/Build/BuildInfoAlert.tsx
+++ b/apps/frontend/src/app/Components/Team/Loadout/Build/BuildInfoAlert.tsx
@@ -1,0 +1,12 @@
+import { Alert } from '@mui/material'
+
+// TODO: Translation
+export default function BuildInfoAlert() {
+  return (
+    <Alert severity="info">
+      A <strong>Build</strong> is comprised of a weapon and 5 artifacts. A{' '}
+      <strong>TC Build</strong> allows the artifacts to be created from its
+      stats.
+    </Alert>
+  )
+}

--- a/apps/frontend/src/app/Components/Team/Loadout/LoadoutInfoAlert.tsx
+++ b/apps/frontend/src/app/Components/Team/Loadout/LoadoutInfoAlert.tsx
@@ -1,0 +1,12 @@
+import { Alert } from '@mui/material'
+
+// TODO: Translation
+export default function LoadoutInfoAlert() {
+  return (
+    <Alert severity="info">
+      <strong>Loadouts</strong> provides character context data, including bonus
+      stats, conditionals, multi-targets, optimization config, and stores
+      builds. A single <strong>Loadout</strong> can be used for many teams.
+    </Alert>
+  )
+}

--- a/apps/frontend/src/app/Components/Team/Loadout/LoadoutNameDesc.tsx
+++ b/apps/frontend/src/app/Components/Team/Loadout/LoadoutNameDesc.tsx
@@ -1,0 +1,63 @@
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import { TextField } from '@mui/material'
+import { useDeferredValue, useEffect, useState } from 'react'
+
+// TODO: Translation
+
+export default function LoadoutNameDesc({
+  teamCharId,
+}: {
+  teamCharId: string
+}) {
+  const database = useDatabase()
+  const teamChar = database.teamChars.get(teamCharId)!
+  const [name, setName] = useState(teamChar.name)
+  const nameDeferred = useDeferredValue(name)
+  const [desc, setDesc] = useState(teamChar.description)
+  const descDeferred = useDeferredValue(desc)
+
+  // trigger on teamCharId change, to use the new team's name/desc
+  useEffect(() => {
+    const newTeamChar = database.teamChars.get(teamCharId)
+    if (!newTeamChar) return
+    const { name, description } = newTeamChar
+    setName(name)
+    setDesc(description)
+  }, [database, teamCharId])
+
+  useEffect(() => {
+    database.teamChars.set(teamCharId, (teamChar) => {
+      teamChar.name = nameDeferred
+    })
+    // Don't need to trigger when teamCharId is changed, only when the name is changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [database, nameDeferred])
+
+  useEffect(() => {
+    database.teamChars.set(teamCharId, (teamChar) => {
+      teamChar.description = descDeferred
+    })
+    // Don't need to trigger when teamCharId is changed, only when the name is changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [database, descDeferred])
+  return (
+    <>
+      <TextField
+        fullWidth
+        label="Loadout Name"
+        placeholder="Loadout Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <TextField
+        fullWidth
+        label="Loadout Description"
+        placeholder="Loadout Description"
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+        multiline
+        minRows={2}
+      />
+    </>
+  )
+}

--- a/apps/frontend/src/app/Components/Team/TeamInfoAlert.tsx
+++ b/apps/frontend/src/app/Components/Team/TeamInfoAlert.tsx
@@ -1,0 +1,12 @@
+import { Alert } from '@mui/material'
+
+// TODO: Translation
+export default function TeamInfoAlert() {
+  return (
+    <Alert severity="info">
+      <strong>Teams</strong> are a container for 4 character loadouts. It
+      provides a way for characters to apply team buffs, and configuration of
+      enemy stats. Loadouts can be shared between teams.
+    </Alert>
+  )
+}

--- a/apps/frontend/src/app/Components/Weapon/WeaponCardNano.tsx
+++ b/apps/frontend/src/app/Components/Weapon/WeaponCardNano.tsx
@@ -94,7 +94,7 @@ export function WeaponCardNanoObj({
     [weaponSheet, weapon]
   )
   return (
-    <BGComponent sx={{ height: '100%' }}>
+    <BGComponent sx={{ height: '100%', maxHeight: '8em' }}>
       <ConditionalWrapper condition={!!onClick} wrapper={actionWrapperFunc}>
         <Box display="flex" height="100%" alignItems="stretch">
           <Box

--- a/apps/frontend/src/app/Context/TeamCharacterContext.tsx
+++ b/apps/frontend/src/app/Context/TeamCharacterContext.tsx
@@ -1,21 +1,16 @@
-import type {
-  LoadoutDatum,
-  Team,
-  TeamCharacter,
-} from '@genshin-optimizer/gi/db'
-import { createContext } from 'react'
-export type TeamCharacterContextObj = {
-  teamId: string
-  team: Team
-  teamCharId: string
-  teamChar: TeamCharacter
-  loadoutDatum: LoadoutDatum
+import type { TeamCharacterContextObj } from '@genshin-optimizer/gi/db-ui'
+import { TeamCharacterContext } from '@genshin-optimizer/gi/db-ui'
+
+export type {
+  /**
+   * @deprecated use gi/ui
+   */
+  TeamCharacterContextObj,
 }
 
-// If using this context without a Provider, then stuff will crash...
-// In theory, none of the components that uses this context should work without a provider...
-export const TeamCharacterContext = createContext({
-  teamChar: {},
-  team: {},
-  loadoutDatum: {},
-} as TeamCharacterContextObj)
+export {
+  /**
+   * @deprecated use gi/ui
+   */
+  TeamCharacterContext,
+}

--- a/apps/frontend/src/app/Context/TeamCharacterContext.tsx
+++ b/apps/frontend/src/app/Context/TeamCharacterContext.tsx
@@ -1,16 +1,7 @@
 import type { TeamCharacterContextObj } from '@genshin-optimizer/gi/db-ui'
 import { TeamCharacterContext } from '@genshin-optimizer/gi/db-ui'
+// @deprecated
+export type { TeamCharacterContextObj }
 
-export type {
-  /**
-   * @deprecated use gi/ui
-   */
-  TeamCharacterContextObj,
-}
-
-export {
-  /**
-   * @deprecated use gi/ui
-   */
-  TeamCharacterContext,
-}
+// @deprecated
+export { TeamCharacterContext }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildCard.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildCard.tsx
@@ -66,7 +66,9 @@ export function BuildCard({
       }}
     >
       {onActive ? (
-        <CardActionArea onClick={onActive}>{clickableAreaContent}</CardActionArea>
+        <CardActionArea onClick={onActive}>
+          {clickableAreaContent}
+        </CardActionArea>
       ) : (
         clickableAreaContent
       )}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildCard.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildCard.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from 'react'
 export function BuildCard({
   name,
   description,
-  active,
+  active = false,
   onActive,
   children,
   onEdit,
@@ -26,18 +26,35 @@ export function BuildCard({
   onDupe,
   onEquip,
   onRemove,
+  hideFooter = false,
 }: {
   name: ReactNode
   description?: ReactNode
-  active: boolean
-  onActive: () => void
+  active?: boolean
+  onActive?: () => void
   children: ReactNode
   onEdit?: () => void
   onCopyToTc?: () => void
-  onDupe: () => void
+  onDupe?: () => void
   onEquip?: () => void
   onRemove?: () => void
+  hideFooter?: boolean
 }) {
+  const clickableAreaContent = (
+    <>
+      <CardHeader
+        title={name}
+        action={
+          description && (
+            <Tooltip title={<Typography>{description}</Typography>}>
+              <InfoIcon />
+            </Tooltip>
+          )
+        }
+      />
+      <CardContent sx={{ pt: 0, pb: 1 }}>{children}</CardContent>
+    </>
+  )
   return (
     <CardThemed
       bgt="light"
@@ -48,99 +65,93 @@ export function BuildCard({
         boxShadow: active ? '0px 0px 0px 2px green inset' : undefined,
       }}
     >
-      <CardActionArea onClick={onActive}>
-        <CardHeader
-          title={name}
-          action={
-            description && (
-              <Tooltip title={<Typography>{description}</Typography>}>
-                <InfoIcon />
-              </Tooltip>
-            )
-          }
-        />
-        <CardContent sx={{ pt: 0, pb: 1 }}>{children}</CardContent>
-      </CardActionArea>
-      <CardActions
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-around',
-          marginTop: 'auto',
-        }}
-      >
-        <Tooltip
-          title={<Typography>Edit Build Settings</Typography>}
-          placement="top"
-          arrow
+      {onActive ? (
+        <CardActionArea onClick={onActive}>{clickableAreaContent}</CardActionArea>
+      ) : (
+        clickableAreaContent
+      )}
+      {!hideFooter && (
+        <CardActions
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            marginTop: 'auto',
+          }}
         >
-          <IconButton
-            color="info"
-            size="small"
-            onClick={onEdit}
-            disabled={!onEdit}
+          <Tooltip
+            title={<Typography>Edit Build Settings</Typography>}
+            placement="top"
+            arrow
           >
-            <span>
-              <EditIcon />
-            </span>
-          </IconButton>
-        </Tooltip>
-        <Tooltip
-          title={<Typography>Copy to TC Builds</Typography>}
-          placement="top"
-          arrow
-        >
-          <IconButton
-            color="info"
-            size="small"
-            onClick={onCopyToTc}
-            disabled={!onCopyToTc}
+            <IconButton
+              color="info"
+              size="small"
+              onClick={onEdit}
+              disabled={!onEdit}
+            >
+              <span>
+                <EditIcon />
+              </span>
+            </IconButton>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Copy to TC Builds</Typography>}
+            placement="top"
+            arrow
           >
-            <ScienceIcon />
-          </IconButton>
-        </Tooltip>
-        <Tooltip
-          title={<Typography>Duplicate Build</Typography>}
-          placement="top"
-          arrow
-        >
-          <IconButton
-            color="info"
-            size="small"
-            onClick={onDupe}
-            disabled={!onDupe}
+            <IconButton
+              color="info"
+              size="small"
+              onClick={onCopyToTc}
+              disabled={!onCopyToTc}
+            >
+              <ScienceIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Duplicate Build</Typography>}
+            placement="top"
+            arrow
           >
-            <ContentCopyIcon />
-          </IconButton>
-        </Tooltip>
-        <Tooltip
-          title={<Typography>Equip Build</Typography>}
-          placement="top"
-          arrow
-        >
-          <IconButton
-            color="info"
-            size="small"
-            onClick={onEquip}
-            disabled={!onEquip}
+            <IconButton
+              color="info"
+              size="small"
+              onClick={onDupe}
+              disabled={!onDupe}
+            >
+              <ContentCopyIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Equip Build</Typography>}
+            placement="top"
+            arrow
           >
-            <CheckroomIcon />
-          </IconButton>
-        </Tooltip>
-        <Tooltip
-          title={<Typography>Delete Build</Typography>}
-          placement="top"
-          arrow
-        >
-          <IconButton
-            color="error"
-            size="small"
-            onClick={onRemove}
-            disabled={!onRemove}
+            <IconButton
+              color="info"
+              size="small"
+              onClick={onEquip}
+              disabled={!onEquip}
+            >
+              <CheckroomIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip
+            title={<Typography>Delete Build</Typography>}
+            placement="top"
+            arrow
           >
-            <DeleteForeverIcon />
-          </IconButton>
-        </Tooltip>
-      </CardActions>
+            <IconButton
+              color="error"
+              size="small"
+              onClick={onRemove}
+              disabled={!onRemove}
+            >
+              <DeleteForeverIcon />
+            </IconButton>
+          </Tooltip>
+        </CardActions>
+      )}
     </CardThemed>
   )
 }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildEquipped.tsx
@@ -10,7 +10,7 @@ import { type ArtifactSlotKey } from '@genshin-optimizer/gi/consts'
 import { Grid } from '@mui/material'
 import ArtifactCardNano from '../../../Components/Artifact/ArtifactCardNano'
 import WeaponCardNano from '../../../Components/Weapon/WeaponCardNano'
-export function BuildEquipped({ active = false }: { active: boolean }) {
+export function BuildEquipped({ active = false }: { active?: boolean }) {
   const { teamId, teamCharId } = useContext(TeamCharacterContext)
   const {
     character: { key: characterKey, equippedArtifacts, equippedWeapon },

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/BuildReal.tsx
@@ -41,7 +41,7 @@ export default function BuildReal({
   active = false,
 }: {
   buildId: string
-  active: boolean
+  active?: boolean
 }) {
   const [open, onOpen, onClose] = useBoolState()
   const {

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -19,7 +19,7 @@ import {
   Divider,
   Grid,
   IconButton,
-  Typography
+  Typography,
 } from '@mui/material'
 import { useContext, useState } from 'react'
 import BuildInfoAlert from '../../Components/Team/Loadout/Build/BuildInfoAlert'
@@ -98,13 +98,13 @@ export default function LoadoutSettingElement() {
           <CardContent
             sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
           >
-            <LoadoutInfoAlert/>
+            <LoadoutInfoAlert />
             <LoadoutDropdown
               teamCharId={teamCharId}
               onChangeTeamCharId={onChangeTeamCharId}
               dropdownBtnProps={{ fullWidth: true }}
             />
-            <LoadoutNameDesc teamCharId={teamCharId}  />
+            <LoadoutNameDesc teamCharId={teamCharId} />
           </CardContent>
           <Divider />
           <BuildManagementContent />
@@ -136,7 +136,7 @@ function BuildManagementContent() {
       />
       <Divider />
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <BuildInfoAlert/>
+        <BuildInfoAlert />
         <Grid container columns={columns} spacing={2}>
           <Grid item xs={1}>
             <BuildEquipped active={loadoutDatum?.buildType === 'equipped'} />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -5,14 +5,13 @@ import {
   SqBadge,
 } from '@genshin-optimizer/common/ui'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
-import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import { TeamCharacterContext, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
 import AddIcon from '@mui/icons-material/Add'
 import CheckroomIcon from '@mui/icons-material/Checkroom'
 import CloseIcon from '@mui/icons-material/Close'
 import PersonIcon from '@mui/icons-material/Person'
 import {
-  Alert,
   Box,
   Button,
   CardContent,
@@ -20,60 +19,25 @@ import {
   Divider,
   Grid,
   IconButton,
-  TextField,
-  Typography,
+  Typography
 } from '@mui/material'
-import { useContext, useDeferredValue, useEffect, useState } from 'react'
-import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
+import { useContext, useState } from 'react'
+import BuildInfoAlert from '../../Components/Team/Loadout/Build/BuildInfoAlert'
+import LoadoutInfoAlert from '../../Components/Team/Loadout/LoadoutInfoAlert'
+import LoadoutNameDesc from '../../Components/Team/Loadout/LoadoutNameDesc'
 import { LoadoutDropdown } from '../LoadoutDropdown'
 import { BuildEquipped } from './Build/BuildEquipped'
 import BuildReal from './Build/BuildReal'
 import BuildTc from './Build/BuildTc'
+
 // TODO: Translation
 const columns = { xs: 1, sm: 1, md: 2, lg: 2 }
 export default function LoadoutSettingElement() {
   const database = useDatabase()
-  const {
-    teamId,
-    teamCharId,
-    loadoutDatum,
-    teamChar: { key: characterKey, buildIds, buildTcIds, customMultiTargets },
-  } = useContext(TeamCharacterContext)
+  const { teamId, teamChar, teamCharId, loadoutDatum } =
+    useContext(TeamCharacterContext)
 
-  const weaponTypeKey = getCharData(characterKey).weaponType
-
-  const teamChar = database.teamChars.get(teamCharId)!
   const [open, setOpen] = useState(false)
-
-  const [name, setName] = useState(teamChar.name)
-  const nameDeferred = useDeferredValue(name)
-  const [desc, setDesc] = useState(teamChar.description)
-  const descDeferred = useDeferredValue(desc)
-
-  // trigger on teamCharId change, to use the new team's name/desc
-  useEffect(() => {
-    const newTeamChar = database.teamChars.get(teamCharId)
-    if (!newTeamChar) return
-    const { name, description } = newTeamChar
-    setName(name)
-    setDesc(description)
-  }, [database, teamCharId])
-
-  useEffect(() => {
-    database.teamChars.set(teamCharId, (teamChar) => {
-      teamChar.name = nameDeferred
-    })
-    // Don't need to trigger when teamCharId is changed, only when the name is changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [database, nameDeferred])
-
-  useEffect(() => {
-    database.teamChars.set(teamCharId, (teamChar) => {
-      teamChar.description = descDeferred
-    })
-    // Don't need to trigger when teamCharId is changed, only when the name is changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [database, descDeferred])
 
   const onChangeTeamCharId = (newTeamCharId: string) => {
     const index = database.teams
@@ -110,17 +74,6 @@ export default function LoadoutSettingElement() {
                 <CheckroomIcon />
                 <span>{database.teams.getActiveBuildName(loadoutDatum)}</span>
               </SqBadge>
-              <SqBadge color={buildIds.length ? 'primary' : 'secondary'}>
-                {buildIds.length} Builds
-              </SqBadge>
-              <SqBadge color={buildTcIds.length ? 'primary' : 'secondary'}>
-                {buildTcIds.length} TC Builds
-              </SqBadge>
-              <SqBadge
-                color={customMultiTargets.length ? 'primary' : 'secondary'}
-              >
-                {customMultiTargets.length} Multi-Opt
-              </SqBadge>
             </Typography>
           </Button>
         </BootstrapTooltip>
@@ -145,123 +98,109 @@ export default function LoadoutSettingElement() {
           <CardContent
             sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
           >
-            <Alert variant="filled" severity="info">
-              <strong>Loadouts</strong> provides character context data,
-              including bonus stats, conditionals, multi-targets, optimization
-              config, and stores builds. A single <strong>Loadout</strong> can
-              be used for many teams.
-            </Alert>
+            <LoadoutInfoAlert/>
             <LoadoutDropdown
               teamCharId={teamCharId}
               onChangeTeamCharId={onChangeTeamCharId}
               dropdownBtnProps={{ fullWidth: true }}
             />
-            <TextField
-              fullWidth
-              label="Loadout Name"
-              placeholder="Loadout Name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-            <TextField
-              fullWidth
-              label="Loadout Description"
-              placeholder="Loadout Description"
-              value={desc}
-              onChange={(e) => setDesc(e.target.value)}
-              multiline
-              minRows={2}
-            />
+            <LoadoutNameDesc teamCharId={teamCharId}  />
           </CardContent>
           <Divider />
-          <CardHeader
-            title={
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                <CheckroomIcon />
-                <span>Build Management</span>
-              </Box>
-            }
-          />
-          <Divider />
-          <CardContent
-            sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
-          >
-            <Alert variant="filled" severity="info">
-              A <strong>Build</strong> is comprised of a weapon and 5 artifacts.
-              A <strong>TC Build</strong> allows the artifacts to be created
-              from its stats.
-            </Alert>
-            <Grid container columns={columns} spacing={2}>
-              <Grid item xs={1}>
-                <BuildEquipped
-                  active={loadoutDatum?.buildType === 'equipped'}
-                />
-              </Grid>
-            </Grid>
-
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography variant="h6">Builds</Typography>
-              <Button
-                startIcon={<AddIcon />}
-                color="info"
-                size="small"
-                onClick={() => database.teamChars.newBuild(teamCharId)}
-              >
-                New Build
-              </Button>
-            </Box>
-
-            <Box>
-              <Grid container columns={columns} spacing={2}>
-                {buildIds.map((id) => (
-                  <Grid item xs={1} key={id}>
-                    <BuildReal
-                      buildId={id}
-                      active={
-                        loadoutDatum?.buildType === 'real' &&
-                        loadoutDatum?.buildId === id
-                      }
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            </Box>
-
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography variant="h6">TC Builds</Typography>
-              <Button
-                startIcon={<AddIcon />}
-                color="info"
-                size="small"
-                onClick={() =>
-                  database.teamChars.newBuildTcFromBuild(
-                    teamCharId,
-                    weaponTypeKey
-                  )
-                }
-              >
-                New TC Build
-              </Button>
-            </Box>
-
-            <Box>
-              <Grid container columns={columns} spacing={2}>
-                {buildTcIds.map((id) => (
-                  <Grid item xs={1} key={id}>
-                    <BuildTc
-                      buildTcId={id}
-                      active={
-                        loadoutDatum?.buildType === 'tc' &&
-                        loadoutDatum?.buildTcId === id
-                      }
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            </Box>
-          </CardContent>
+          <BuildManagementContent />
         </CardThemed>
       </ModalWrapper>
+    </>
+  )
+}
+
+function BuildManagementContent() {
+  const database = useDatabase()
+  const {
+    teamCharId,
+    loadoutDatum,
+    teamChar: { key: characterKey, buildIds, buildTcIds },
+  } = useContext(TeamCharacterContext)
+
+  const weaponTypeKey = getCharData(characterKey).weaponType
+
+  return (
+    <>
+      <CardHeader
+        title={
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <CheckroomIcon />
+            <span>Build Management</span>
+          </Box>
+        }
+      />
+      <Divider />
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <BuildInfoAlert/>
+        <Grid container columns={columns} spacing={2}>
+          <Grid item xs={1}>
+            <BuildEquipped active={loadoutDatum?.buildType === 'equipped'} />
+          </Grid>
+        </Grid>
+
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Typography variant="h6">Builds</Typography>
+          <Button
+            startIcon={<AddIcon />}
+            color="info"
+            size="small"
+            onClick={() => database.teamChars.newBuild(teamCharId)}
+          >
+            New Build
+          </Button>
+        </Box>
+
+        <Box>
+          <Grid container columns={columns} spacing={2}>
+            {buildIds.map((id) => (
+              <Grid item xs={1} key={id}>
+                <BuildReal
+                  buildId={id}
+                  active={
+                    loadoutDatum?.buildType === 'real' &&
+                    loadoutDatum?.buildId === id
+                  }
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Typography variant="h6">TC Builds</Typography>
+          <Button
+            startIcon={<AddIcon />}
+            color="info"
+            size="small"
+            onClick={() =>
+              database.teamChars.newBuildTcFromBuild(teamCharId, weaponTypeKey)
+            }
+          >
+            New TC Build
+          </Button>
+        </Box>
+
+        <Box>
+          <Grid container columns={columns} spacing={2}>
+            {buildTcIds.map((id) => (
+              <Grid item xs={1} key={id}>
+                <BuildTc
+                  buildTcId={id}
+                  active={
+                    loadoutDatum?.buildType === 'tc' &&
+                    loadoutDatum?.buildTcId === id
+                  }
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+      </CardContent>
     </>
   )
 }

--- a/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
@@ -36,11 +36,12 @@ import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { EnemyExpandCard } from '../../Components/EnemyEditor'
+import TeamInfoAlert from '../../Components/Team/TeamInfoAlert'
 import type { TeamCharacterContextObj } from '../../Context/TeamCharacterContext'
 import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
 import BuildDropdown from '../BuildDropdown'
-// TODO: Translation
 
+// TODO: Translation
 export default function TeamSetting({
   teamId,
   teamData,
@@ -158,12 +159,7 @@ export default function TeamSetting({
           <CardContent
             sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
           >
-            <Alert variant="filled" severity="info">
-              <strong>Teams</strong> are a container for 4 character loadouts.
-              It provides a way for characters to apply team buffs, and
-              configuration of enemy stats. Loadouts can be shared between
-              teams.
-            </Alert>
+            <TeamInfoAlert />
             <TextField
               fullWidth
               label="Team Name"
@@ -210,7 +206,7 @@ export default function TeamSetting({
             </Box>
             <EnemyExpandCard teamId={teamId} />
             <Typography variant="h6">Team Editor</Typography>
-            <Alert severity="info" variant="filled">
+            <Alert severity="info">
               The first character in the team receives any "active on-field
               character" buffs, and cannot be empty.
             </Alert>

--- a/libs/gi/db-ui/src/contexts/TeamCharacterContext.tsx
+++ b/libs/gi/db-ui/src/contexts/TeamCharacterContext.tsx
@@ -1,0 +1,21 @@
+import type {
+  LoadoutDatum,
+  Team,
+  TeamCharacter,
+} from '@genshin-optimizer/gi/db'
+import { createContext } from 'react'
+export type TeamCharacterContextObj = {
+  teamId: string
+  team: Team
+  teamCharId: string
+  teamChar: TeamCharacter
+  loadoutDatum: LoadoutDatum
+}
+
+// If using this context without a Provider, then stuff will crash...
+// In theory, none of the components that uses this context should work without a provider...
+export const TeamCharacterContext = createContext({
+  teamChar: {},
+  team: {},
+  loadoutDatum: {},
+} as TeamCharacterContextObj)

--- a/libs/gi/db-ui/src/contexts/index.ts
+++ b/libs/gi/db-ui/src/contexts/index.ts
@@ -1,4 +1,2 @@
-import type { DatabaseContextObj } from './DatabaseContext'
-import { DatabaseContext } from './DatabaseContext'
-export { DatabaseContext }
-export type { DatabaseContextObj }
+export * from './DatabaseContext'
+export * from './TeamCharacterContext'


### PR DESCRIPTION
## Describe your changes

Since the character editor is the place for loadout management, the UI is not sufficient to provide enough loadout information.
This PR seeks to address this by providing more detailed information of loadout in a popup, which should allow users to make better decision on what the loadout contains.

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1787
- Resolves https://github.com/frzyc/genshin-optimizer/issues/1699
- Resolves https://github.com/frzyc/genshin-optimizer/issues/1684
- Resolves https://github.com/frzyc/genshin-optimizer/issues/1644
- Resovles https://github.com/frzyc/genshin-optimizer/issues/1788

## Testing/validation
Updated loadout view
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/fe26a95c-0700-495b-b0eb-6638f3d63566)
Detailed loadout view, with action buttons
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/7267680a-86ad-4e96-9028-81a237241c9e)
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/8c7d36ee-8cba-4913-ae77-6cb4298586e5)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
