### PR TITLE
add a suspense to load character editor content

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
@@ -93,17 +93,23 @@ function CharacterEditorContent({
   return (
     <CardThemed>
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        {dataContextValue && characterContextValue && graphContextValue ? (
-          <CharacterContext.Provider value={characterContextValue}>
-            <DataContext.Provider value={dataContextValue}>
-              <GraphContext.Provider value={graphContextValue}>
-                <Content onClose={onClose} />
-              </GraphContext.Provider>
-            </DataContext.Provider>
-          </CharacterContext.Provider>
-        ) : (
-          <Skeleton variant="rectangular" width="100%" height={1000} />
-        )}
+        <Suspense
+          fallback={
+            <Skeleton variant="rectangular" width="100%" height={1000} />
+          }
+        >
+          {dataContextValue && characterContextValue && graphContextValue ? (
+            <CharacterContext.Provider value={characterContextValue}>
+              <DataContext.Provider value={dataContextValue}>
+                <GraphContext.Provider value={graphContextValue}>
+                  <Content onClose={onClose} />
+                </GraphContext.Provider>
+              </DataContext.Provider>
+            </CharacterContext.Provider>
+          ) : (
+            <Skeleton variant="rectangular" width="100%" height={1000} />
+          )}
+        </Suspense>
       </CardContent>
     </CardThemed>
   )


### PR DESCRIPTION
## Describe your changes
Initial load of character editor can show an empty overlay:
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/b233bd4e-3fe2-4355-a5b1-f47769c283f4)
Wrap a Suspense with fallback to show the card is being loaded.
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/a4d4f241-663e-4a68-b796-475a64275f61)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
