### PR TITLE
Remove talent action in overview tab

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharProfileCard.tsx
+++ b/apps/frontend/src/app/PageTeam/CharProfileCard.tsx
@@ -3,9 +3,8 @@ import { CardThemed } from '@genshin-optimizer/common/ui'
 import { useDBMeta } from '@genshin-optimizer/gi/db-ui'
 import { CharacterConstellationName } from '@genshin-optimizer/gi/ui'
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline'
-import { Box, Button, CardActionArea, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
 import { useContext } from 'react'
-import { useNavigate } from 'react-router-dom'
 import CharacterEditor from '../Components/Character/CharacterEditor'
 import {
   CharacterCompactConstSelector,
@@ -19,7 +18,6 @@ export default function CharacterProfileCard() {
     character: { key: characterKey },
   } = useContext(CharacterContext)
   const { gender } = useDBMeta()
-  const navigate = useNavigate()
 
   const [showEditor, onShowEditor, onHideEditor] = useBoolState()
   return (
@@ -42,9 +40,7 @@ export default function CharacterProfileCard() {
           </Button>
         </Box>
 
-        <CardActionArea sx={{ p: 1 }} onClick={() => navigate('talent')}>
-          <CharacterCompactTalent />
-        </CardActionArea>
+        <CharacterCompactTalent />
 
         <Typography sx={{ textAlign: 'center', mt: 1 }} variant="h6">
           <CharacterConstellationName


### PR DESCRIPTION
## Describe your changes
Remove the action area in the talent in overview. It was originally wired to navigate to the talent tab, now it no longer works on click.
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/a2296921-ea95-4101-a2ec-8a02ecb71c7c)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
