### PR TITLE
Move loadout-related buttons

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Content.tsx
@@ -1,8 +1,5 @@
-import { useBoolState } from '@genshin-optimizer/common/react-util'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 
-import BarChartIcon from '@mui/icons-material/BarChart'
-import CalculateIcon from '@mui/icons-material/Calculate'
 import FactCheckIcon from '@mui/icons-material/FactCheck'
 import PersonIcon from '@mui/icons-material/Person'
 import ScienceIcon from '@mui/icons-material/Science'
@@ -12,19 +9,14 @@ import { CardThemed } from '@genshin-optimizer/common/ui'
 import { characterAsset } from '@genshin-optimizer/gi/assets'
 import { useDBMeta } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
-import type { ButtonProps } from '@mui/material'
-import { Box, Button, Skeleton, Tab, Tabs } from '@mui/material'
+import { Skeleton, Tab, Tabs } from '@mui/material'
 import { Suspense, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Route, Link as RouterLink, Routes } from 'react-router-dom'
-import SqBadge from '../../Components/SqBadge'
-import { FormulaDataContext } from '../../Context/FormulaDataContext'
 import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
 import { shouldShowDevComponents } from '../../Util/Util'
-import { CustomMultiTargetButton } from './CustomMultiTarget'
 import FormulaModal from './FormulaModal'
 import LoadoutSettingElement from './LoadoutSettingElement'
-import StatModal from './StatModal'
 import TabBuild from './Tabs/TabOptimize'
 import TabOverview from './Tabs/TabOverview'
 import TabTalent from './Tabs/TabTalent'
@@ -42,6 +34,7 @@ export default function Content({ tab }: { tab: string }) {
   const elementKey = getCharData(characterKey).ele
   return (
     <>
+      <FormulaModal />
       <LoadoutSettingElement
         buttonProps={{
           fullWidth: true,
@@ -50,35 +43,7 @@ export default function Content({ tab }: { tab: string }) {
           sx: { backgroundColor: 'contentLight.main' },
         }}
       />
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          flexWrap: 'wrap',
-        }}
-      >
-        <DetailStatButton
-          buttonProps={{
-            sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
-            color: elementKey ?? 'info',
-            variant: 'outlined',
-          }}
-        />
-        <CustomMultiTargetButton
-          buttonProps={{
-            sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
-            color: elementKey ?? 'info',
-            variant: 'outlined',
-          }}
-        />
-        <FormulasButton
-          buttonProps={{
-            sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
-            color: elementKey ?? 'info',
-            variant: 'outlined',
-          }}
-        />
-      </Box>
+
       <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
       <CharacterPanel isTCBuild={isTCBuild} />
       <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
@@ -216,48 +181,5 @@ function TabNav({
         )}
       </Tabs>
     </CardThemed>
-  )
-}
-
-function DetailStatButton({ buttonProps = {} }: { buttonProps?: ButtonProps }) {
-  const { t } = useTranslation('page_character')
-  const [open, onOpen, onClose] = useBoolState()
-  const {
-    teamChar: { bonusStats },
-  } = useContext(TeamCharacterContext)
-  const bStatsNum = Object.keys(bonusStats).length
-  return (
-    <>
-      <Button
-        color="info"
-        startIcon={<BarChartIcon />}
-        onClick={onOpen}
-        {...buttonProps}
-      >
-        {t`addStats.title`}
-        {!!bStatsNum && (
-          <SqBadge sx={{ ml: 1 }} color="success">
-            {bStatsNum}
-          </SqBadge>
-        )}
-      </Button>
-      <StatModal open={open} onClose={onClose} />
-    </>
-  )
-}
-function FormulasButton({ buttonProps = {} }: { buttonProps?: ButtonProps }) {
-  const { onModalOpen } = useContext(FormulaDataContext)
-  return (
-    <>
-      <Button
-        color="info"
-        startIcon={<CalculateIcon />}
-        onClick={onModalOpen}
-        {...buttonProps}
-      >
-        Formulas {'&'} Calcs
-      </Button>
-      <FormulaModal />
-    </>
   )
 }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -128,30 +128,29 @@ export default function LoadoutSettingElement({
                 }}
               />
               <LoadoutNameDesc teamCharId={teamCharId} />
-                <Box display="flex" gap={2} flexWrap="wrap">
+              <Box display="flex" gap={2} flexWrap="wrap">
                 <DetailStatButton
-                buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main', flexGrow:1 },
-                  color: elementKey ?? 'info',
-                  variant: 'outlined',
-                }}
-              />
-              <CustomMultiTargetButton
-                buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main', flexGrow:1 },
-                  color: elementKey ?? 'info',
-                  variant: 'outlined',
-                }}
-              />
-              <FormulasButton
-                buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main' , flexGrow:1},
-                  color: elementKey ?? 'info',
-                  variant: 'outlined',
-                }}
-              />
-                </Box>
-
+                  buttonProps={{
+                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+                    color: elementKey ?? 'info',
+                    variant: 'outlined',
+                  }}
+                />
+                <CustomMultiTargetButton
+                  buttonProps={{
+                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+                    color: elementKey ?? 'info',
+                    variant: 'outlined',
+                  }}
+                />
+                <FormulasButton
+                  buttonProps={{
+                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+                    color: elementKey ?? 'info',
+                    variant: 'outlined',
+                  }}
+                />
+              </Box>
             </CardContent>
             <Divider />
             <BuildManagementContent />

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -131,21 +131,21 @@ export default function LoadoutSettingElement({
 
               <DetailStatButton
                 buttonProps={{
-                  sx: {  backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main' },
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}
               />
               <CustomMultiTargetButton
                 buttonProps={{
-                  sx: {  backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main' },
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}
               />
               <FormulasButton
                 buttonProps={{
-                  sx: {  backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main' },
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -1,12 +1,16 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
 import {
   BootstrapTooltip,
   CardThemed,
   ModalWrapper,
+  SqBadge,
 } from '@genshin-optimizer/common/ui'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import { TeamCharacterContext, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharData } from '@genshin-optimizer/gi/stats'
 import AddIcon from '@mui/icons-material/Add'
+import BarChartIcon from '@mui/icons-material/BarChart'
+import CalculateIcon from '@mui/icons-material/Calculate'
 import CheckroomIcon from '@mui/icons-material/Checkroom'
 import CloseIcon from '@mui/icons-material/Close'
 import PersonIcon from '@mui/icons-material/Person'
@@ -24,13 +28,17 @@ import {
   Typography,
 } from '@mui/material'
 import { Suspense, useContext, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import BuildInfoAlert from '../../Components/Team/Loadout/Build/BuildInfoAlert'
 import LoadoutInfoAlert from '../../Components/Team/Loadout/LoadoutInfoAlert'
 import LoadoutNameDesc from '../../Components/Team/Loadout/LoadoutNameDesc'
+import { FormulaDataContext } from '../../Context/FormulaDataContext'
 import { LoadoutDropdown } from '../LoadoutDropdown'
 import { BuildEquipped } from './Build/BuildEquipped'
 import BuildReal from './Build/BuildReal'
 import BuildTc from './Build/BuildTc'
+import { CustomMultiTargetButton } from './CustomMultiTarget'
+import StatModal from './StatModal'
 
 // TODO: Translation
 const columns = { xs: 1, sm: 1, md: 2, lg: 2 }
@@ -56,6 +64,7 @@ export default function LoadoutSettingElement({
       team.loadoutData[index] = { teamCharId: newTeamCharId } as LoadoutDatum
     })
   }
+  const elementKey = getCharData(teamChar.key).ele
   return (
     <>
       <Box display="flex" gap={1} alignItems="center">
@@ -111,9 +120,36 @@ export default function LoadoutSettingElement({
               <LoadoutDropdown
                 teamCharId={teamCharId}
                 onChangeTeamCharId={onChangeTeamCharId}
-                dropdownBtnProps={{ fullWidth: true }}
+                dropdownBtnProps={{
+                  fullWidth: true,
+                  sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
+                  color: elementKey ?? 'info',
+                  variant: 'outlined',
+                }}
               />
               <LoadoutNameDesc teamCharId={teamCharId} />
+
+              <DetailStatButton
+                buttonProps={{
+                  sx: {  backgroundColor: 'contentLight.main' },
+                  color: elementKey ?? 'info',
+                  variant: 'outlined',
+                }}
+              />
+              <CustomMultiTargetButton
+                buttonProps={{
+                  sx: {  backgroundColor: 'contentLight.main' },
+                  color: elementKey ?? 'info',
+                  variant: 'outlined',
+                }}
+              />
+              <FormulasButton
+                buttonProps={{
+                  sx: {  backgroundColor: 'contentLight.main' },
+                  color: elementKey ?? 'info',
+                  variant: 'outlined',
+                }}
+              />
             </CardContent>
             <Divider />
             <BuildManagementContent />
@@ -212,5 +248,44 @@ function BuildManagementContent() {
         </Box>
       </CardContent>
     </>
+  )
+}
+function DetailStatButton({ buttonProps = {} }: { buttonProps?: ButtonProps }) {
+  const { t } = useTranslation('page_character')
+  const [open, onOpen, onClose] = useBoolState()
+  const {
+    teamChar: { bonusStats },
+  } = useContext(TeamCharacterContext)
+  const bStatsNum = Object.keys(bonusStats).length
+  return (
+    <>
+      <Button
+        color="info"
+        startIcon={<BarChartIcon />}
+        onClick={onOpen}
+        {...buttonProps}
+      >
+        {t`addStats.title`}
+        {!!bStatsNum && (
+          <SqBadge sx={{ ml: 1 }} color="success">
+            {bStatsNum}
+          </SqBadge>
+        )}
+      </Button>
+      <StatModal open={open} onClose={onClose} />
+    </>
+  )
+}
+function FormulasButton({ buttonProps = {} }: { buttonProps?: ButtonProps }) {
+  const { onModalOpen } = useContext(FormulaDataContext)
+  return (
+    <Button
+      color="info"
+      startIcon={<CalculateIcon />}
+      onClick={onModalOpen}
+      {...buttonProps}
+    >
+      Show Formulas {'&'} Calcs
+    </Button>
   )
 }

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/LoadoutSettingElement.tsx
@@ -128,28 +128,30 @@ export default function LoadoutSettingElement({
                 }}
               />
               <LoadoutNameDesc teamCharId={teamCharId} />
-
-              <DetailStatButton
+                <Box display="flex" gap={2} flexWrap="wrap">
+                <DetailStatButton
                 buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main', flexGrow:1 },
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}
               />
               <CustomMultiTargetButton
                 buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main', flexGrow:1 },
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}
               />
               <FormulasButton
                 buttonProps={{
-                  sx: { backgroundColor: 'contentLight.main' },
+                  sx: { backgroundColor: 'contentLight.main' , flexGrow:1},
                   color: elementKey ?? 'info',
                   variant: 'outlined',
                 }}
               />
+                </Box>
+
             </CardContent>
             <Divider />
             <BuildManagementContent />

--- a/apps/frontend/src/app/PageTeam/LoadoutDropdown.tsx
+++ b/apps/frontend/src/app/PageTeam/LoadoutDropdown.tsx
@@ -31,13 +31,7 @@ export function LoadoutDropdown({
   dropdownBtnProps?: Omit<DropdownButtonProps, 'children' | 'title'>
 }) {
   const database = useDatabase()
-  const {
-    key: characterKey,
-    name,
-    buildIds,
-    buildTcIds,
-    customMultiTargets,
-  } = database.teamChars.get(teamCharId)!
+  const { key: characterKey, name } = database.teamChars.get(teamCharId)!
   const { gender } = useDBMeta()
   const teamCharIds = database.teamChars.keys.filter(
     (teamCharId) => database.teamChars.get(teamCharId)!.key === characterKey
@@ -115,17 +109,6 @@ export function LoadoutDropdown({
             }}
           >
             <span>{name}</span>
-            <SqBadge color={buildIds.length ? 'success' : 'secondary'}>
-              {buildIds.length} Builds
-            </SqBadge>
-            <SqBadge color={buildTcIds.length ? 'success' : 'secondary'}>
-              {buildTcIds.length} TC Builds
-            </SqBadge>
-            <SqBadge
-              color={customMultiTargets.length ? 'success' : 'secondary'}
-            >
-              {customMultiTargets.length} Multi-Opt
-            </SqBadge>
           </Box>
         }
         {...dropdownBtnProps}


### PR DESCRIPTION
## Describe your changes
Since the bonus stats, mtargets are rarely set, (especially since loadout now encapsulates context), move the bonus stats and mtarget popup into the loadout settings. The formula button is also moved, since user can access the formula by clicking the (?) next to the formulas
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/2ee64585-bca9-4a3d-ac13-b8092c421d8f)
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/659f8dea-cfc3-4417-b5d0-55dc1221b48f)

## Issue or discord link

- Partially resolves #1642

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
