### PR TITLE
BuildDisplayItem fixes for build comparisons done from character editor

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
@@ -21,6 +21,7 @@ import {
 import { useContext, useState } from 'react'
 import ArtifactCardNano from '../../../Components/Artifact/ArtifactCardNano'
 import WeaponCardNano from '../../../Components/Weapon/WeaponCardNano'
+import { CharacterContext } from '../../../Context/CharacterContext'
 import { TeamCharacterContext } from '../../../Context/TeamCharacterContext'
 
 type EquipChangeProps = {
@@ -47,10 +48,10 @@ export default function EquipBuildModal({
   // const [showPrompt, onShowPrompt, OnHidePrompt] = useBoolState()
 
   const database = useDatabase()
+  const { teamCharId } = useContext(TeamCharacterContext)
   const {
-    teamCharId,
-    teamChar: { key: characterKey },
-  } = useContext(TeamCharacterContext)
+    character: { key: characterKey },
+  } = useContext(CharacterContext)
   const weaponTypeKey = getCharData(characterKey).weaponType
 
   const toEquip = () => {

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Build/EquipBuildModal.tsx
@@ -184,22 +184,24 @@ export default function EquipBuildModal({
           <Typography sx={{ fontSize: 20 }}>
             Do you want to make the changes shown above?
           </Typography>
-          <FormControlLabel
-            label={
-              <>
-                Copy the current equipment in{' '}
-                <strong>{equipChangeProps.currentName}</strong> to a new build.
-                Otherwise, they will be overwritten.
-              </>
-            }
-            control={
-              <Checkbox
-                checked={copyCurrent}
-                onChange={(event) => setCopyCurrent(event.target.checked)}
-                color={copyCurrent ? 'success' : 'secondary'}
-              />
-            }
-          />
+          {teamCharId && (
+            <FormControlLabel
+              label={
+                <>
+                  Copy the current equipment in{' '}
+                  <strong>{equipChangeProps.currentName}</strong> to a new
+                  build. Otherwise, they will be overwritten.
+                </>
+              }
+              control={
+                <Checkbox
+                  checked={copyCurrent}
+                  onChange={(event) => setCopyCurrent(event.target.checked)}
+                  color={copyCurrent ? 'success' : 'secondary'}
+                />
+              }
+            />
+          )}
           {copyCurrent && (
             <TextField
               label="Build Name"

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -245,31 +245,43 @@ export default function BuildDisplayItem({
   const isActiveBuildOrEquip =
     isActiveBuild || (buildType === 'equipped' && currentlyEquipped)
 
+  // An undefined buildType indicates this was accessed from outside a team. This currently occurs
+  // when comparing from the character editor.
+  const compareFromCharEditor = buildType === undefined
+
   const activeWeapon = useMemo(() => {
     if (dbDirty && buildType === 'real')
       return database.builds.get(buildId)!.weaponId
     if (dbDirty && buildType === 'equipped') return equippedWeapon
-
-    // An undefined buildType indicates this was accessed from outside a team. This currently occurs
-    // when comparing from the character editor.
-    if (buildType === undefined) return equippedWeapon
+    if (compareFromCharEditor) return equippedWeapon
 
     // default
     return ''
-  }, [dbDirty, database, buildType, buildId, equippedWeapon])
+  }, [
+    dbDirty,
+    database,
+    buildType,
+    buildId,
+    equippedWeapon,
+    compareFromCharEditor,
+  ])
 
   const activeArtifacts = useMemo(() => {
     if (dbDirty && buildType === 'real')
       return database.builds.get(buildId)!.artifactIds
     if (dbDirty && buildType === 'equipped') return equippedArtifacts
-
-    // An undefined buildType indicates this was accessed from outside a team. This currently occurs
-    // when comparing from the character editor.
-    if (buildType === undefined) return equippedArtifacts
+    if (compareFromCharEditor) return equippedArtifacts
 
     // default
     return objKeyMap(allArtifactSlotKeys, () => '')
-  }, [dbDirty, database, buildType, buildId, equippedArtifacts])
+  }, [
+    dbDirty,
+    database,
+    buildType,
+    buildId,
+    equippedArtifacts,
+    compareFromCharEditor,
+  ])
 
   const [showEquipChange, onShowEquipChange, onHideEquipChange] = useBoolState()
 
@@ -309,6 +321,7 @@ export default function BuildDisplayItem({
             mainStatAssumptionLevel={mainStatAssumptionLevel}
             onClose={closeArt}
             allowLocationsState={allowLocationsState}
+            compareFromCharEditor={compareFromCharEditor}
           />
         )}
         <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -474,11 +487,13 @@ function CompareArtifactModal({
   mainStatAssumptionLevel,
   onClose,
   allowLocationsState,
+  compareFromCharEditor,
 }: {
   newOld: NewOld
   mainStatAssumptionLevel: number
   onClose: () => void
   allowLocationsState: AllowLocationsState
+  compareFromCharEditor: boolean
 }) {
   const database = useDatabase()
   const {
@@ -532,7 +547,9 @@ function CompareArtifactModal({
                 />
               )}
 
-              {oldId !== 'tc' && <ArtInclusionButton id={oldId} />}
+              {oldId !== 'tc' && !compareFromCharEditor && (
+                <ArtInclusionButton id={oldId} />
+              )}
             </Box>
           )}
           {oldId && <Box display="flex" flexGrow={1} />}
@@ -557,20 +574,24 @@ function CompareArtifactModal({
                 fixedSlotKey: newArtifact?.slotKey,
               }}
             />
-            {newArtifact && <ArtInclusionButton id={newId} />}
-            {newLoc &&
-              newLoc !== charKeyToLocCharKey(characterKey) &&
-              allowLocationsState !== 'all' && (
-                <ExcludeEquipButton locationKey={newLoc} />
-              )}
-            {newArtifact &&
-              allArtifactSetExclusionKeys.includes(
-                newArtifact.setKey as ArtSetExclusionKey
-              ) && (
-                <SetInclusionButton
-                  setKey={newArtifact.setKey as ArtSetExclusionKey}
-                />
-              )}
+            {!compareFromCharEditor && (
+              <>
+                {newArtifact && <ArtInclusionButton id={newId} />}
+                {newLoc &&
+                  newLoc !== charKeyToLocCharKey(characterKey) &&
+                  allowLocationsState !== 'all' && (
+                    <ExcludeEquipButton locationKey={newLoc} />
+                  )}
+                {newArtifact &&
+                  allArtifactSetExclusionKeys.includes(
+                    newArtifact.setKey as ArtSetExclusionKey
+                  ) && (
+                    <SetInclusionButton
+                      setKey={newArtifact.setKey as ArtSetExclusionKey}
+                    />
+                  )}
+              </>
+            )}
           </Box>
         </CardContent>
       </CardDark>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -250,6 +250,10 @@ export default function BuildDisplayItem({
       return database.builds.get(buildId)!.weaponId
     if (dbDirty && buildType === 'equipped') return equippedWeapon
 
+    // An undefined buildType indicates this was accessed from outside a team. This currently occurs
+    // when comparing from the character editor.
+    if (buildType === undefined) return equippedWeapon
+
     // default
     return ''
   }, [dbDirty, database, buildType, buildId, equippedWeapon])
@@ -258,6 +262,10 @@ export default function BuildDisplayItem({
     if (dbDirty && buildType === 'real')
       return database.builds.get(buildId)!.artifactIds
     if (dbDirty && buildType === 'equipped') return equippedArtifacts
+
+    // An undefined buildType indicates this was accessed from outside a team. This currently occurs
+    // when comparing from the character editor.
+    if (buildType === undefined) return equippedArtifacts
 
     // default
     return objKeyMap(allArtifactSlotKeys, () => '')

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -250,10 +250,10 @@ export default function BuildDisplayItem({
   const compareFromCharEditor = buildType === undefined
 
   const activeWeapon = useMemo(() => {
+    if (compareFromCharEditor) return equippedWeapon
     if (dbDirty && buildType === 'real')
       return database.builds.get(buildId)!.weaponId
     if (dbDirty && buildType === 'equipped') return equippedWeapon
-    if (compareFromCharEditor) return equippedWeapon
 
     // default
     return ''
@@ -267,10 +267,10 @@ export default function BuildDisplayItem({
   ])
 
   const activeArtifacts = useMemo(() => {
+    if (compareFromCharEditor) return equippedArtifacts
     if (dbDirty && buildType === 'real')
       return database.builds.get(buildId)!.artifactIds
     if (dbDirty && buildType === 'equipped') return equippedArtifacts
-    if (compareFromCharEditor) return equippedArtifacts
 
     // default
     return objKeyMap(allArtifactSlotKeys, () => '')


### PR DESCRIPTION
## Describe your changes
In `BuildDisplayItem.tsx`:
- Added boolean `compareFromCharEditor` tracking whether `buildType ` is undefined - Due to `buildType` being pulled from `TeamCharacterContext`, this value is undefined when build comparisons are made from the character editor, which is the only other location which currently uses `BuildDisplayItem`.
- Modified logic for `activeArtifacts` and `activeWeapon` to return the weapon/artifacts in Equipped when `compareFromCharEditor` is `true`
- Added prop to `compareArtifactModal` for the bool indicating whether this is a build comparison from the character editor - This value is used to disable rendering the artifact and character inclusion/exclusion buttons as these make little sense when not in the Optimize tab.

In `EquipBuildModal.tsx`:
- `characterKey` is now pulled from `CharacterContext` instead of `TeamCharacterContext` to account for the possibility of access from outside the Teams tab where `characterKey` would otherwise be undefined
- Option to copy current equipment is no longer present when comparing/equipping through the character editor
<!--- Provide a general summary of your changes -->

## Issue or discord link

- Resolves #1802 <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
Manually checked from editor in Characters tab and confirmed behavior when working within a team remains unaffected.
<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
