### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Run `nx graph` to see a diagram of the dependencies of the projects.
 
 ## Acknowledgments
 
-✨ The tesseract model used was trained and provided by the creator of [Inventory Kamera](https://github.com/Andrewthe13th/Inventory_Kamera.)
+✨ The tesseract model used was trained and provided by the creator of [Inventory Kamera](https://github.com/Andrewthe13th/Inventory_Kamera).
 
 ✨ The creator of Silly Wisher has granted us permission to incorporate their artwork into Silly Optimizer. Silly Wisher [discord](https://discord.com/invite/sillywisher), [App store](https://apps.apple.com/lv/app/silly-wisher/id6444465724https://apps.apple.com/lv/app/silly-wisher/id6444465724), [Google Play](https://play.google.com/store/apps/details?id=com.sketchi.sillywisher)
 


### PR DESCRIPTION
## Describe your changes

A dot was misplaced which caused the link of the Inventory Kamera to break. This PR moves the dot outside of the parentheses.

## Issue or discord link

- #1809

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
