### PR TITLE
Standardize compare number

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/index.tsx
@@ -60,7 +60,7 @@ function CharacterEditorContent({
     return {
       data: charUIData,
       teamData,
-      oldData: undefined,
+      compareData: undefined,
     }
   }, [charUIData, teamData])
 

--- a/apps/frontend/src/app/Components/Character/StatDisplayComponent.tsx
+++ b/apps/frontend/src/app/Components/Character/StatDisplayComponent.tsx
@@ -48,7 +48,7 @@ function Section({
   sectionKey: string
 }) {
   const optimizationTarget = useContext(OptimizationTargetContext)
-  const { data, oldData } = useContext(DataContext)
+  const { data, compareData } = useContext(DataContext)
   const database = useDatabase()
   const header = useMemo(
     () => getDisplayHeader(data, sectionKey, database),
@@ -77,8 +77,10 @@ function Section({
           <NodeFieldDisplay
             key={nodeKey}
             node={n}
-            oldValue={
-              oldData ? oldData.get(displayNsReads[nodeKey]!).value : undefined
+            compareValue={
+              compareData
+                ? compareData.get(displayNsReads[nodeKey]!).value
+                : undefined
             }
             component={ListItem}
             emphasize={

--- a/apps/frontend/src/app/Components/CompareBuildButton.tsx
+++ b/apps/frontend/src/app/Components/CompareBuildButton.tsx
@@ -73,7 +73,7 @@ function TeamWrapper({ artId, weaponId, onHide }: WrapperProps) {
     teamChar: { optConfigId },
   } = useContext(TeamCharacterContext)
   const { mainStatAssumptionLevel } = useOptConfig(optConfigId)!
-  const { data: oldData } = useContext(DataContext)
+  const { data } = useContext(DataContext)
   const build = useMemo(() => {
     const newArt = database.arts.get(artId ?? '')
     const equippedArtifacts = database.teams.getLoadoutArtifacts(loadoutDatum)
@@ -89,8 +89,12 @@ function TeamWrapper({ artId, weaponId, onHide }: WrapperProps) {
   )
   const dataProviderValue = useMemo(
     () =>
-      teamData && { data: teamData[characterKey]!.target, teamData, oldData },
-    [characterKey, teamData, oldData]
+      teamData && {
+        data: teamData[characterKey]!.target,
+        teamData,
+        compareData: data,
+      },
+    [characterKey, teamData, data]
   )
   if (!dataProviderValue) return null
   return <BuildDisplay dataProviderValue={dataProviderValue} onHide={onHide} />
@@ -101,7 +105,7 @@ function CharacterWrapper({ artId, weaponId, onHide }: WrapperProps) {
   const {
     character: { key: characterKey, equippedArtifacts },
   } = useContext(CharacterContext)
-  const { data: oldData } = useContext(DataContext)
+  const { data: compareData } = useContext(DataContext)
   const build = useMemo(() => {
     const newArt = database.arts.get(artId ?? '')
     const artmap = objMap(equippedArtifacts, (id, slot) =>
@@ -117,8 +121,12 @@ function CharacterWrapper({ artId, weaponId, onHide }: WrapperProps) {
   )
   const dataProviderValue = useMemo(
     () =>
-      teamData && { data: teamData[characterKey]!.target, teamData, oldData },
-    [characterKey, teamData, oldData]
+      teamData && {
+        data: teamData[characterKey]!.target,
+        teamData,
+        compareData,
+      },
+    [characterKey, teamData, compareData]
   )
   if (!dataProviderValue) return
   return <BuildDisplay dataProviderValue={dataProviderValue} onHide={onHide} />

--- a/apps/frontend/src/app/Components/FieldDisplay.tsx
+++ b/apps/frontend/src/app/Components/FieldDisplay.tsx
@@ -14,7 +14,6 @@ import {
   List,
   ListItem,
   Skeleton,
-  Tooltip,
   Typography,
   styled,
 } from '@mui/material'
@@ -133,15 +132,13 @@ export function NodeFieldDisplay({
       <>
         <span>{valueString(nodeValue, node.info.unit, node.info.fixed)}</span>
         {Math.abs(diff) > 0.0001 && (
-          <Tooltip
+          <BootstrapTooltip
             title={
               <Typography>
                 Compare to{' '}
-                <ColorText color={diff > 0 ? 'success' : 'error'}>
-                  <strong>
-                    {valueString(compareValue, node.info.unit, node.info.fixed)}
-                  </strong>
-                </ColorText>
+                <strong>
+                  {valueString(compareValue, node.info.unit, node.info.fixed)}
+                </strong>
               </Typography>
             }
           >
@@ -166,7 +163,7 @@ export function NodeFieldDisplay({
                 </span>
               )}
             </ColorText>
-          </Tooltip>
+          </BootstrapTooltip>
         )}
       </>
     )

--- a/apps/frontend/src/app/Components/FieldDisplay.tsx
+++ b/apps/frontend/src/app/Components/FieldDisplay.tsx
@@ -1,4 +1,7 @@
-import type { CardBackgroundColor } from '@genshin-optimizer/common/ui'
+import {
+  ColorText,
+  type CardBackgroundColor,
+} from '@genshin-optimizer/common/ui'
 import { evalIfFunc, valueString } from '@genshin-optimizer/common/util'
 import type { AmpReactionKey } from '@genshin-optimizer/gi/consts'
 import { allAmpReactionKeys } from '@genshin-optimizer/gi/consts'
@@ -23,7 +26,6 @@ import { nodeVStr } from '../Formula/uiData'
 import type { IBasicFieldDisplay, IFieldDisplay } from '../Types/fieldDisplay'
 import AmpReactionModeText from './AmpReactionModeText'
 import BootstrapTooltip from './BootstrapTooltip'
-import ColorText from './ColoredText'
 
 export default function FieldsDisplay({
   fields,
@@ -48,19 +50,19 @@ function FieldDisplay({
   field: IFieldDisplay
   component?: React.ElementType
 }) {
-  const { data, oldData } = useContext(DataContext)
+  const { data, compareData } = useContext(DataContext)
   const canShow = useMemo(() => field?.canShow?.(data) ?? true, [field, data])
   if (!canShow) return null
   if ('node' in field) {
     const node = data.get(field.node)
     if (node.isEmpty) return null
-    if (oldData) {
-      const oldNode = oldData.get(field.node)
-      const oldValue = oldNode.isEmpty ? 0 : oldNode.value
+    if (compareData) {
+      const compareNode = compareData.get(field.node)
+      const compareValue = compareNode.isEmpty ? 0 : compareNode.value
       return (
         <NodeFieldDisplay
           node={node}
-          oldValue={oldValue}
+          compareValue={compareValue}
           component={component}
         />
       )
@@ -101,12 +103,12 @@ export function BasicFieldDisplay({
 
 export function NodeFieldDisplay({
   node,
-  oldValue,
+  compareValue,
   component,
   emphasize,
 }: {
   node: NodeDisplay
-  oldValue?: number
+  compareValue?: number
   component?: React.ElementType
   emphasize?: boolean
 }) {
@@ -121,25 +123,27 @@ export function NodeFieldDisplay({
   const { multi } = node.info
 
   const multiDisplay = multi && <span>{multi}&#215;</span>
+  const nodeValue = node.value
   let fieldVal = false as ReactNode
-  if (oldValue !== undefined) {
-    const diff = node.value - oldValue
-    const pctDiff = valueString(Math.abs(diff / oldValue), '%', node.info.fixed)
+  if (compareValue !== undefined) {
+    const diff = nodeValue - compareValue
+    const pctDiff = valueString(diff / compareValue, '%', node.info.fixed)
     fieldVal = (
       <>
-        <span>{valueString(oldValue, node.info.unit, node.info.fixed)}</span>
+        <span>{valueString(nodeValue, node.info.unit, node.info.fixed)}</span>
         {Math.abs(diff) > 0.0001 && (
-          <>
-            <ColorText color={diff > 0 ? 'success' : 'error'}>
-              {diff > 0 ? '+' : ''}
-              {valueString(diff, node.info.unit, node.info.fixed)}
-            </ColorText>
-            {node.info.unit !== '%' && oldValue !== 0 && (
-              <ColorText color={diff > 0 ? 'success' : 'error'}>
-                ({pctDiff})
-              </ColorText>
+          <ColorText color={diff > 0 ? 'success' : 'error'}>
+            <span>
+              ({diff > 0 ? '+' : ''}
+              {valueString(diff, node.info.unit, node.info.fixed)})
+            </span>
+            {node.info.unit !== '%' && compareValue !== 0 && (
+              <span>
+                ({diff > 0 ? '+' : ''}
+                {pctDiff})
+              </span>
             )}
-          </>
+          </ColorText>
         )}
       </>
     )
@@ -214,6 +218,7 @@ export function NodeFieldDisplay({
 export function NodeFieldDisplayText({ node }: { node: NodeDisplay }) {
   const { textSuffix } = node.info
   const suffixDisplay = textSuffix && <span> {textSuffix}</span>
+  const variant = node.info.variant
   return (
     <Typography
       component="div"
@@ -226,7 +231,7 @@ export function NodeFieldDisplayText({ node }: { node: NodeDisplay }) {
     >
       {!!node.info.isTeamBuff && <Groups />}
       {node.info.icon}
-      <ColorText color={node.info.variant}>
+      <ColorText color={variant !== 'invalid' ? variant : 'error'}>
         {node.info.name}
         {suffixDisplay}
       </ColorText>

--- a/apps/frontend/src/app/Components/FieldDisplay.tsx
+++ b/apps/frontend/src/app/Components/FieldDisplay.tsx
@@ -14,6 +14,7 @@ import {
   List,
   ListItem,
   Skeleton,
+  Tooltip,
   Typography,
   styled,
 } from '@mui/material'
@@ -132,18 +133,40 @@ export function NodeFieldDisplay({
       <>
         <span>{valueString(nodeValue, node.info.unit, node.info.fixed)}</span>
         {Math.abs(diff) > 0.0001 && (
-          <ColorText color={diff > 0 ? 'success' : 'error'}>
-            <span>
-              ({diff > 0 ? '+' : ''}
-              {valueString(diff, node.info.unit, node.info.fixed)})
-            </span>
-            {node.info.unit !== '%' && compareValue !== 0 && (
+          <Tooltip
+            title={
+              <Typography>
+                Compare to{' '}
+                <ColorText color={diff > 0 ? 'success' : 'error'}>
+                  <strong>
+                    {valueString(compareValue, node.info.unit, node.info.fixed)}
+                  </strong>
+                </ColorText>
+              </Typography>
+            }
+          >
+            <ColorText
+              color={diff > 0 ? 'success' : 'error'}
+              sx={{
+                display: 'flex',
+                gap: 0.5,
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                flexWrap: 'wrap',
+              }}
+            >
               <span>
                 ({diff > 0 ? '+' : ''}
-                {pctDiff})
+                {valueString(diff, node.info.unit, node.info.fixed)})
               </span>
-            )}
-          </ColorText>
+              {node.info.unit !== '%' && compareValue !== 0 && (
+                <span>
+                  ({diff > 0 ? '+' : ''}
+                  {pctDiff})
+                </span>
+              )}
+            </ColorText>
+          </Tooltip>
         )}
       </>
     )
@@ -231,7 +254,7 @@ export function NodeFieldDisplayText({ node }: { node: NodeDisplay }) {
     >
       {!!node.info.isTeamBuff && <Groups />}
       {node.info.icon}
-      <ColorText color={variant !== 'invalid' ? variant : 'error'}>
+      <ColorText color={variant !== 'invalid' ? variant : undefined}>
         {node.info.name}
         {suffixDisplay}
       </ColorText>

--- a/apps/frontend/src/app/Context/DataContext.tsx
+++ b/apps/frontend/src/app/Context/DataContext.tsx
@@ -19,7 +19,7 @@ export type TeamData = Partial<
 >
 export type dataContextObj = {
   data: UIData
-  oldData?: UIData
+  compareData?: UIData
   teamData: TeamData
 }
 

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/CompareBtn.tsx
@@ -9,7 +9,7 @@ import { TeamCharacterContext } from '../../Context/TeamCharacterContext'
 
 /**
  * The UI component that modifies the compare data in a TeamChar.
- * This is used in conjuction with useOldData hook to supply a oldData to the compare UI.
+ * This is used in conjuction with useCompareData hook to supply a compareData to the compare UI.
  */
 
 // TODO: Translation

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/StatModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/StatModal.tsx
@@ -153,7 +153,7 @@ function StatDisplayContent({
   nodes: ReadNode<number>[]
   extra?: Displayable
 }) {
-  const { data, oldData } = useContext(DataContext)
+  const { data, compareData } = useContext(DataContext)
   return (
     <FieldDisplayList>
       {nodes.map((rn) => (
@@ -161,7 +161,7 @@ function StatDisplayContent({
           component={ListItem}
           key={JSON.stringify(rn.info)}
           node={data.get(rn)}
-          oldValue={oldData?.get(rn)?.value}
+          compareValue={compareData?.get(rn)?.value}
         />
       ))}
       {extra}

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/BuildDisplayItem.tsx
@@ -95,7 +95,7 @@ export default function BuildDisplayItem({
     character: { key: characterKey, equippedArtifacts, equippedWeapon },
   } = useContext(CharacterContext)
   const database = useDatabase()
-  const { data, oldData } = useContext(DataContext)
+  const { data, compareData } = useContext(DataContext)
 
   const [dbDirty, setDbDirty] = useForceUpdate()
   // update when a build is changed
@@ -109,10 +109,10 @@ export default function BuildDisplayItem({
   // update when data is recalc'd
   const weaponNewOld = useMemo(
     () => ({
-      oldId: oldData?.get(input.weapon.id)?.value,
+      oldId: compareData?.get(input.weapon.id)?.value,
       newId: data.get(input.weapon.id).value ?? '',
     }),
-    [data, oldData]
+    [data, compareData]
   )
 
   // state for showing weapon compare modal
@@ -122,10 +122,10 @@ export default function BuildDisplayItem({
   const artifactNewOldBySlot: Record<ArtifactSlotKey, NewOld> = useMemo(
     () =>
       objKeyMap(allArtifactSlotKeys, (slotKey) => ({
-        oldId: oldData?.get(input.art[slotKey].id)?.value,
+        oldId: compareData?.get(input.art[slotKey].id)?.value,
         newId: data.get(input.art[slotKey].id).value ?? '',
       })),
-    [data, oldData]
+    [data, compareData]
   )
 
   // state for showing art compare modal

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -101,7 +101,7 @@ import type { OptProblemInput } from '../../../../Solver'
 import { GOSolver } from '../../../../Solver/GOSolver/GOSolver'
 import { mergeBuilds, mergePlot } from '../../../../Solver/common'
 import { bulkCatTotal } from '../../../../Util/totalUtils'
-import useOldData from '../../../useOldData'
+import useCompareData from '../../../useCompareData'
 import CompareBtn from '../../CompareBtn'
 import AllowChar from './Components/AllowChar'
 import ArtifactSetConfig from './Components/ArtifactSetConfig'
@@ -193,7 +193,7 @@ export default function TabBuild() {
     allowLocationsState,
   } = buildSetting
   const { data } = useContext(DataContext)
-  const oldData = useOldData()
+  const compareData = useCompareData()
   const optimizationTargetNode =
     optimizationTarget && objPathValue(data?.getDisplay(), optimizationTarget)
   const isSM = ['xs', 'sm'].includes(useMediaQueryUp())
@@ -1003,7 +1003,7 @@ export default function TabBuild() {
         {graphBuilds && (
           <BuildList
             builds={graphBuilds}
-            oldData={oldData}
+            compareData={compareData}
             disabled={!!generatingBuilds}
             getLabel={getGraphBuildLabel}
             setBuilds={setGraphBuilds}
@@ -1013,7 +1013,7 @@ export default function TabBuild() {
         )}
         <BuildList
           builds={builds}
-          oldData={oldData}
+          compareData={compareData}
           disabled={!!generatingBuilds}
           getLabel={getNormBuildLabel}
           mainStatAssumptionLevel={mainStatAssumptionLevel}
@@ -1027,7 +1027,7 @@ export default function TabBuild() {
 function BuildList({
   builds,
   setBuilds,
-  oldData,
+  compareData,
   disabled,
   getLabel,
   mainStatAssumptionLevel,
@@ -1035,7 +1035,7 @@ function BuildList({
 }: {
   builds: GeneratedBuild[]
   setBuilds?: (builds: GeneratedBuild[] | undefined) => void
-  oldData?: UIData
+  compareData?: UIData
   disabled: boolean
   getLabel: (index: number) => Displayable
   mainStatAssumptionLevel: number
@@ -1070,7 +1070,7 @@ function BuildList({
               key={index + Object.values(build.artifactIds).join()}
               characterKey={characterKey}
               build={build}
-              oldData={oldData}
+              compareData={compareData}
               mainStatAssumptionLevel={mainStatAssumptionLevel}
             >
               <BuildItemWrapper
@@ -1090,7 +1090,7 @@ function BuildList({
       teamCharacterContextValue,
       builds,
       characterKey,
-      oldData,
+      compareData,
       disabled,
       getLabel,
       deleteBuild,
@@ -1293,14 +1293,14 @@ type Prop = {
   children: React.ReactNode
   characterKey: CharacterKey
   build: GeneratedBuild
-  oldData?: UIData
+  compareData?: UIData
   mainStatAssumptionLevel: number
 }
 function DataContextWrapper({
   children,
   characterKey,
   build,
-  oldData,
+  compareData,
   mainStatAssumptionLevel,
 }: Prop) {
   const { artifactIds, weaponId } = build
@@ -1336,8 +1336,8 @@ function DataContextWrapper({
   const providerValue = useMemo(() => {
     const tdc = teamData?.[characterKey]
     if (!tdc) return undefined
-    return { data: tdc.target, teamData, oldData }
-  }, [teamData, oldData, characterKey])
+    return { data: tdc.target, teamData, compareData }
+  }, [teamData, compareData, characterKey])
   if (!providerValue) return null
   return (
     <DataContext.Provider value={providerValue}>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOverview/index.tsx
@@ -12,7 +12,7 @@ import WeaponCardNano from '../../../../Components/Weapon/WeaponCardNano'
 import { DataContext } from '../../../../Context/DataContext'
 import { uiInput as input } from '../../../../Formula'
 import CharacterProfileCard from '../../../CharProfileCard'
-import useOldData from '../../../useOldData'
+import useCompareData from '../../../useCompareData'
 import CompareBtn from '../../CompareBtn'
 import EquipmentSection from './EquipmentSection'
 
@@ -24,13 +24,13 @@ export default function TabOverview() {
   )
 
   const data = useContext(DataContext)
-  const oldData = useOldData()
+  const compareData = useCompareData()
   const dataContextObj = useMemo(
     () => ({
       ...data,
-      oldData,
+      compareData,
     }),
-    [data, oldData]
+    [data, compareData]
   )
   return (
     <Stack spacing={1}>

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabTheorycraft/index.tsx
@@ -30,7 +30,7 @@ import { TeamCharacterContext } from '../../../../Context/TeamCharacterContext'
 import { getTeamDataCalc } from '../../../../ReactHooks/useTeamData'
 import { isDev } from '../../../../Util/Util'
 import CharacterProfileCard from '../../../CharProfileCard'
-import useOldData from '../../../useOldData'
+import useCompareData from '../../../useCompareData'
 import CompareBtn from '../../CompareBtn'
 import OptimizationTargetSelector from '../TabOptimize/Components/OptimizationTargetSelector'
 import { ArtifactMainStatAndSetEditor } from './ArtifactMainStatAndSetEditor'
@@ -73,14 +73,15 @@ export default function TabTheorycraft() {
   const weaponTypeKey = getCharData(characterKey).weaponType
 
   const dataContextValue = useContext(DataContext)
-  const oldData = useOldData()
-  const dataContextValueWithOld: dataContextObj | undefined = useMemo(() => {
-    if (!dataContextValue) return undefined
-    return {
-      ...dataContextValue,
-      oldData,
-    }
-  }, [dataContextValue, oldData])
+  const compareData = useCompareData()
+  const dataContextValueWithCompare: dataContextObj | undefined =
+    useMemo(() => {
+      if (!dataContextValue) return undefined
+      return {
+        ...dataContextValue,
+        compareData,
+      }
+    }, [dataContextValue, compareData])
 
   const optimizationTarget = buildTc.optimization.target
   const setOptimizationTarget = useCallback(
@@ -271,8 +272,8 @@ export default function TabTheorycraft() {
             >
               <CardLight sx={{ flexGrow: 1, p: 1 }}>
                 <OptimizationTargetContext.Provider value={optimizationTarget}>
-                  {dataContextValueWithOld ? (
-                    <DataContext.Provider value={dataContextValueWithOld}>
+                  {dataContextValueWithCompare ? (
+                    <DataContext.Provider value={dataContextValueWithCompare}>
                       <StatDisplayComponent
                         columns={{ xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }}
                       />

--- a/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/TeamComponents.tsx
@@ -50,7 +50,7 @@ import { input } from '../../Formula'
 import type { NodeDisplay } from '../../Formula/uiData'
 
 export function TeamBuffDisplay() {
-  const { data, oldData } = useContext(DataContext)
+  const { data, compareData } = useContext(DataContext)
   const teamBuffs = data.getTeamBuff() as any
   const nodes: Array<[string[], NodeDisplay<number>]> = []
   Object.entries(teamBuffs.total ?? {}).forEach(
@@ -97,8 +97,8 @@ export function TeamBuffDisplay() {
                     <Grid item xs={12} key={JSON.stringify(n.info)}>
                       <NodeFieldDisplay
                         node={n}
-                        oldValue={
-                          objPathValue(oldData?.getTeamBuff(), path)?.value
+                        compareValue={
+                          objPathValue(compareData?.getTeamBuff(), path)?.value
                         }
                       />
                     </Grid>

--- a/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
+++ b/apps/frontend/src/app/PageTeam/TeamSetting/index.tsx
@@ -297,7 +297,7 @@ function TeamCharacterSelector({
     return {
       data: charUIData,
       teamData,
-      oldData: undefined,
+      compareData: undefined,
     }
   }, [charUIData, teamData])
   return (
@@ -396,7 +396,7 @@ function CharSelButton({
     return {
       data: charUIData,
       teamData,
-      oldData: undefined,
+      compareData: undefined,
     }
   }, [charUIData, teamData])
 

--- a/apps/frontend/src/app/PageTeam/index.tsx
+++ b/apps/frontend/src/app/PageTeam/index.tsx
@@ -160,7 +160,7 @@ function Page({ teamId }: { teamId: string }) {
     return {
       data: charUIData,
       teamData,
-      oldData: undefined,
+      compareData: undefined,
     }
   }, [charUIData, teamData])
 

--- a/apps/frontend/src/app/PageTeam/useCompareData.tsx
+++ b/apps/frontend/src/app/PageTeam/useCompareData.tsx
@@ -10,9 +10,9 @@ import { getTeamDataCalc } from '../ReactHooks/useTeamData'
 import { getArtifactData } from './CharacterDisplay/Tabs/TabTheorycraft/optimizeTc'
 
 /**
- * generate data for the "compare build function", usually used in conjunction with `DataContext.oldData`
+ * generate data for the "compare build function", usually used in conjunction with `DataContext.compareData`
  */
-export default function useOldData(): undefined | UIData {
+export default function useCompareData(): undefined | UIData {
   const database = useDatabase()
   const {
     teamId,


### PR DESCRIPTION
## Describe your changes
When comparing builds, the "white text" should always be the focused build, and the "delta" colored text will be the diff between the focused/compare build. This prevents the "white text" from changing regardless of the compare state, which should give a more "stable" experience to compare numbers for users.

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1817
## Testing/validation

<!--- Add screenshots if possible -->
For screenshot, Left is new, Right is production
Overview screen 
![Screenshot 2024-03-25 011002](https://github.com/frzyc/genshin-optimizer/assets/1754901/aa7b113c-94e9-4e41-94ca-0aafacde16c9)
Theorycraft
![Screenshot 2024-03-25 010707](https://github.com/frzyc/genshin-optimizer/assets/1754901/2b256235-2df0-4972-8e6f-bdf1cfd58d40)
Generated Build
![Screenshot 2024-03-25 011418](https://github.com/frzyc/genshin-optimizer/assets/1754901/a7d24e54-58d8-49b5-abb0-fd2109afc4a6)
Compare build (swapping single artifact)
![Screenshot 2024-03-25 012342](https://github.com/frzyc/genshin-optimizer/assets/1754901/58c092d2-da1c-4691-9cea-96e0dea679bb)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
