### PR TITLE
Remove `LoadoutCard` `Tooltip` on empty `description`

### DIFF
--- a/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutCard.tsx
+++ b/apps/frontend/src/app/Components/Character/CharacterEditor/LoadoutCard.tsx
@@ -56,9 +56,13 @@ export default function LoadoutCard({
             <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
               <PersonIcon />
               <Typography>{name}</Typography>
-              <BootstrapTooltip title={<Typography>{description}</Typography>}>
-                <InfoIcon />
-              </BootstrapTooltip>
+              {!!description && (
+                <BootstrapTooltip
+                  title={<Typography>{description}</Typography>}
+                >
+                  <InfoIcon />
+                </BootstrapTooltip>
+              )}
 
               <SettingsIcon sx={{ ml: 'auto' }} />
             </Box>


### PR DESCRIPTION
## Describe your changes
I believe the Loadout description is the last unfixed. I checked Build, TCBuild, Team, and Loadout.
<!--- Provide a general summary of your changes -->

## Issue or discord link
Fix: https://github.com/frzyc/genshin-optimizer/issues/1800

<!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Before
<img width="381" alt="Screenshot 2024-03-28 at 10 44 32 PM" src="https://github.com/frzyc/genshin-optimizer/assets/44922829/8b7921c7-dfc1-4825-87f4-83c29aaa6dde">
After
<img width="426" alt="Screenshot 2024-03-28 at 10 47 09 PM" src="https://github.com/frzyc/genshin-optimizer/assets/44922829/26ee9b7b-7663-4a88-9f73-ee6740736a19">


<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
