### PR TITLE
resolve info & units from nodes in UI

### DIFF
--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/ChartCard/index.tsx
@@ -7,7 +7,7 @@ import {
 import { allArtifactSlotKeys } from '@genshin-optimizer/gi/consts'
 import type { GeneratedBuild } from '@genshin-optimizer/gi/db'
 import { useOptConfig } from '@genshin-optimizer/gi/db-ui'
-import type { NumNode } from '@genshin-optimizer/gi/wr'
+import type { Info, InfoExtra, NumNode } from '@genshin-optimizer/gi/wr'
 import { input } from '@genshin-optimizer/gi/wr'
 import {
   CheckBox,
@@ -309,12 +309,12 @@ export default function ChartCard({
               max={sliderMax}
               step={(sliderMax - sliderMin) / 20}
               valueLabelDisplay="auto"
-              valueLabelFormat={(n) =>
-                valueString(
-                  chartData.plotNode.info?.unit === '%' ? n / 100 : n,
-                  chartData.plotNode.info?.unit
-                )
-              }
+              valueLabelFormat={(n) => {
+                const info =
+                  chartData.plotNode.info &&
+                  resolveInfo(chartData.plotNode.info)
+                return valueString(info?.unit === '%' ? n / 100 : n, info?.unit)
+              }}
               sx={{ ml: '6%', width: '93%' }}
             />
           )}
@@ -361,9 +361,10 @@ function Chart({
     [setSelectedPoint, displayData]
   )
 
-  // Below works because character translation should already be loaded
-  const xLabelValue = getLabelFromNode(plotNode, t)
-  const yLabelValue = getLabelFromNode(valueNode, t)
+  const plotNodeInfo = plotNode.info && resolveInfo(plotNode.info)
+  const valueNodeInfo = valueNode.info && resolveInfo(valueNode.info)
+  const xLabelValue = plotNodeInfo && getLabelFromNode(plotNodeInfo, t)
+  const yLabelValue = valueNodeInfo && getLabelFromNode(valueNodeInfo, t)
 
   return (
     <ResponsiveContainer width="100%" height={600}>
@@ -377,7 +378,7 @@ function Chart({
         <XAxis
           dataKey="x"
           scale="linear"
-          unit={plotNode.info?.unit}
+          unit={plotNodeInfo?.unit}
           domain={['auto', 'auto']}
           tick={{ fill: 'white' }}
           type="number"
@@ -392,7 +393,7 @@ function Chart({
         <YAxis
           name="DMG"
           domain={['auto', 'auto']}
-          unit={valueNode.info?.unit}
+          unit={valueNodeInfo?.unit}
           allowDecimals={false}
           tick={{ fill: 'white' }}
           type="number"
@@ -406,10 +407,10 @@ function Chart({
         <Tooltip
           content={
             <CustomTooltip
-              xLabel={xLabelValue}
-              xUnit={plotNode.info?.unit}
-              yLabel={yLabelValue}
-              yUnit={valueNode.info?.unit}
+              xLabel={xLabelValue ?? ''}
+              xUnit={plotNodeInfo?.unit}
+              yLabel={yLabelValue ?? ''}
+              yUnit={valueNodeInfo?.unit}
               selectedPoint={selectedPoint}
               setSelectedPoint={setSelectedPoint}
               addBuildToList={addBuildToList}
@@ -541,8 +542,9 @@ function getNearestPoint(
     : undefined
 }
 
-function getLabelFromNode(node: NumNode, t: TFunction) {
-  const { name, textSuffix } = (node.info && resolveInfo(node.info)) ?? {}
+// Should work because character translation should already be loaded
+function getLabelFromNode(info: InfoExtra & Info, t: TFunction) {
+  const { name, textSuffix } = info
   return typeof name === 'string'
     ? name
     : `${t(`${name?.props.ns}:${name?.props.key18}`)}${

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetEditorList.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetEditorList.tsx
@@ -12,7 +12,7 @@ import CustomNumberInput, {
   CustomNumberInputButtonGroupWrapper,
 } from '../../../../../Components/CustomNumberInput'
 import { DataContext } from '../../../../../Context/DataContext'
-import type { NodeDisplay } from '../../../../../Formula/uiData'
+import { resolveInfo, type NodeDisplay } from '../../../../../Formula/uiData'
 import OptimizationTargetSelector from './OptimizationTargetSelector'
 
 type OptimizationTargetEditorListProps = {
@@ -147,7 +147,9 @@ function OptimizationTargetEditorItem({
     data.getDisplay(),
     path ?? []
   )
-  const isPercent = buildConstraintNode?.info?.unit === '%'
+  const resolvedInfo =
+    buildConstraintNode?.info && resolveInfo(buildConstraintNode?.info)
+  const isPercent = resolvedInfo?.unit === '%'
 
   return (
     <ButtonGroup

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -20,7 +20,7 @@ import {
   getDisplayHeader,
   getDisplaySections,
 } from '../../../../../Formula/DisplayUtil'
-import type { NodeDisplay } from '../../../../../Formula/uiData'
+import { resolveInfo, type NodeDisplay } from '../../../../../Formula/uiData'
 
 export interface TargetSelectorModalProps {
   show: boolean
@@ -52,9 +52,10 @@ export function TargetSelectorModal({
               key,
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
-                  if (flatOnly && node.info.unit === '%') return false
+                  const { unit, variant } = resolveInfo(node.info)
+                  if (flatOnly && unit === '%') return false
 
-                  if (excludeHeal && node.info.variant === 'heal') return false
+                  if (excludeHeal && variant === 'heal') return false
 
                   if (!showEmptyTargets && node.isEmpty) return false
                   return true

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -101,7 +101,7 @@ import { GraphContext } from '../../../../Context/GraphContext'
 import { OptimizationTargetContext } from '../../../../Context/OptimizationTargetContext'
 import { TeamCharacterContext } from '../../../../Context/TeamCharacterContext'
 import { mergeData, uiDataForTeam } from '../../../../Formula/api'
-import type { UIData } from '../../../../Formula/uiData'
+import { resolveInfo, type UIData } from '../../../../Formula/uiData'
 import useGlobalError from '../../../../ReactHooks/useGlobalError'
 import useTeamData, { getTeamData } from '../../../../ReactHooks/useTeamData'
 import { bulkCatTotal } from '../../../../Util/totalUtils'
@@ -402,10 +402,9 @@ export default function TabBuild() {
               workerData.display ?? {},
               JSON.parse(pathStr)
             )
+            const infoResolved = filterNode.info && resolveInfo(filterNode.info)
             const minimum =
-              filterNode.info?.unit === '%'
-                ? setting.value / 100
-                : setting.value // TODO: Conversion
+              infoResolved?.unit === '%' ? setting.value / 100 : setting.value // TODO: Conversion
             return { value: filterNode, minimum: minimum }
           })
       )
@@ -469,11 +468,14 @@ export default function TabBuild() {
       if (plotBaseNumNode) {
         const plotData = mergePlot(results.map((x) => x.plotData!))
         const solverBuilds = Object.values(plotData)
-        if (targetNode.info?.unit === '%')
+        const targetNodeinfo = targetNode.info && resolveInfo(targetNode.info)
+        const plotBaseNumNodeInfo =
+          plotBaseNumNode.info && resolveInfo(plotBaseNumNode.info)
+        if (targetNodeinfo?.unit === '%')
           solverBuilds.forEach(
             (dataEntry) => (dataEntry.value = dataEntry.value * 100)
           )
-        if (plotBaseNumNode.info?.unit === '%')
+        if (plotBaseNumNodeInfo?.unit === '%')
           solverBuilds.forEach(
             (dataEntry) => (dataEntry.plot = (dataEntry.plot ?? 0) * 100)
           )

--- a/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/apps/frontend/src/app/PageTeam/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -67,6 +67,7 @@ import {
 } from '../../../../Components/Character/CharacterCard/CharacterCardHeader'
 import { CharacterCardStats } from '../../../../Components/Character/CharacterCard/CharacterCardStats'
 import NoArtWarning from '../../../../Components/NoArtWarning'
+import { resolveInfo } from '../../../../Formula/uiData'
 import useTeamData, { getTeamData } from '../../../../ReactHooks/useTeamData'
 import type { UpOptBuild } from './upOpt'
 import { UpOptCalculator, toArtifact } from './upOpt'
@@ -235,8 +236,9 @@ export default function TabUpopt() {
             workerData.display ?? {},
             JSON.parse(pathStr)
           )
+          const infoResolved = filterNode.info && resolveInfo(filterNode.info)
           const minimum =
-            filterNode.info?.unit === '%' ? setting.value / 100 : setting.value
+            infoResolved?.unit === '%' ? setting.value / 100 : setting.value // TODO: Conversion
           return { value: filterNode, minimum }
         })
     )


### PR DESCRIPTION
## Describe your changes

Some `info` information is no longer streamed from the engine due to the migration to `gi-wr` lib, and on the UI side, extra `resolveInfo` operation is needed to recover this information. 

This makes some of the UI handling, around percentage values like ER min constraints, use decimal instead of percentage if `info` is not properly resolved. 

This PR adds extra `resolveInfo` operations to correct this.

## Issue or discord link

- Resolves #1859

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
