### PR TITLE
Fix GeneralAutocomplete label being stuck in shrink state

### DIFF
--- a/libs/common/ui/src/components/GeneralAutocomplete.tsx
+++ b/libs/common/ui/src/components/GeneralAutocomplete.tsx
@@ -76,6 +76,7 @@ export function GeneralAutocomplete<T extends string>({
         const color = variant
           ? (theme.palette[variant] as PaletteColor | undefined)?.main
           : undefined
+        const valueKey = value?.key
         const { InputLabelProps, InputProps, inputProps, ...restParams } =
           params
         return (


### PR DESCRIPTION
## Describe your changes

The `GeneralAutocomplete` component in the shared UI library had its label permanently stuck in `shrink = true` state. Added a line so now the label only shrinks upon focus/user input.

## Issue or discord link

https://discord.com/channels/785153694478893126/1183809278209970217/1223935481050300426

## Testing/validation

`yarn run mini-ci` and manually tested on local machine by changing `ArtifactSetAutocomplete` in GO frontend to call the UI library version of the component (currently, it uses the version living in `apps/frontend`). The component should look like this image when it is not focused/there is no user input:

<img width="479" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/112abcd1-f8ea-4277-8d2d-89a5025fabb2">

and transitions into shrink state when focused/user input:

<img width="466" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/ab7e5380-7a80-46a2-a704-ed8db51e1a2c">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
