### PR TITLE
fix team page routing

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Content.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Content.tsx
@@ -13,7 +13,7 @@ import { getCharEle } from '@genshin-optimizer/gi/stats'
 import { Skeleton, Tab, Tabs } from '@mui/material'
 import { Suspense, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Route, Link as RouterLink, Routes } from 'react-router-dom'
+import { Navigate, Route, Link as RouterLink, Routes } from 'react-router-dom'
 import FormulaModal from './FormulaModal'
 import LoadoutSettingElement from './LoadoutSettingElement'
 import TabBuild from './Tabs/TabOptimize'
@@ -56,20 +56,21 @@ function CharacterPanel({ isTCBuild }: { isTCBuild: boolean }) {
       fallback={<Skeleton variant="rectangular" width="100%" height={500} />}
     >
       <Routes>
-        {/* Character Panel */}
-        {isTCBuild ? (
-          <Route path="/*" element={<TabTheorycraft />} />
-        ) : (
-          <Route path="/*" element={<TabOverview />} />
-        )}
-        <Route path="/:characterKey/talent" element={<TabTalent />} />
-        {!isTCBuild && (
-          <Route path="/:characterKey/optimize" element={<TabBuild />} />
-        )}
+        <Route path=":characterKey">
+          {/* Character Panel */}
+          {isTCBuild ? (
+            <Route path="overview" element={<TabTheorycraft />} />
+          ) : (
+            <Route path="overview" element={<TabOverview />} />
+          )}
+          <Route path="talent" element={<TabTalent />} />
+          {!isTCBuild && <Route path="optimize" element={<TabBuild />} />}
 
-        {!isTCBuild && shouldShowDevComponents && (
-          <Route path="/:characterKey/upopt" element={<TabUpopt />} />
-        )}
+          {!isTCBuild && shouldShowDevComponents && (
+            <Route path="upopt" element={<TabUpopt />} />
+          )}
+          <Route path="*" index element={<Navigate to="overview" />} />
+        </Route>
       </Routes>
     </Suspense>
   )
@@ -141,7 +142,7 @@ function TabNav({
             label={t('tabs.theorycraft')}
             icon={<ScienceIcon />}
             component={RouterLink}
-            to={`${characterKey}/`}
+            to="overview"
           />
         ) : (
           <Tab
@@ -149,7 +150,7 @@ function TabNav({
             label={t('tabs.overview')}
             icon={<PersonIcon />}
             component={RouterLink}
-            to={`${characterKey}/`}
+            to="overview"
           />
         )}
         <Tab
@@ -157,7 +158,7 @@ function TabNav({
           label={t('tabs.talent')}
           icon={<FactCheckIcon />}
           component={RouterLink}
-          to={`${characterKey}/talent`}
+          to="talent"
         />
         {!isTCBuild && (
           <Tab
@@ -165,7 +166,7 @@ function TabNav({
             label={t('tabs.optimize')}
             icon={<TrendingUpIcon />}
             component={RouterLink}
-            to={`${characterKey}/optimize`}
+            to="optimize"
           />
         )}
 
@@ -175,7 +176,7 @@ function TabNav({
             label={t('tabs.upgradeopt')}
             icon={<TrendingUpIcon />}
             component={RouterLink}
-            to={`${characterKey}/upopt`}
+            to="upopt"
           />
         )}
       </Tabs>

--- a/libs/gi/page-team/src/CharacterDisplay/Content.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Content.tsx
@@ -56,21 +56,19 @@ function CharacterPanel({ isTCBuild }: { isTCBuild: boolean }) {
       fallback={<Skeleton variant="rectangular" width="100%" height={500} />}
     >
       <Routes>
-        <Route path=":characterKey">
-          {/* Character Panel */}
-          {isTCBuild ? (
-            <Route path="overview" element={<TabTheorycraft />} />
-          ) : (
-            <Route path="overview" element={<TabOverview />} />
-          )}
-          <Route path="talent" element={<TabTalent />} />
-          {!isTCBuild && <Route path="optimize" element={<TabBuild />} />}
+        {/* Character Panel */}
+        {isTCBuild ? (
+          <Route path="overview" element={<TabTheorycraft />} />
+        ) : (
+          <Route path="overview" element={<TabOverview />} />
+        )}
+        <Route path="talent" element={<TabTalent />} />
+        {!isTCBuild && <Route path="optimize" element={<TabBuild />} />}
 
-          {!isTCBuild && shouldShowDevComponents && (
-            <Route path="upopt" element={<TabUpopt />} />
-          )}
-          <Route path="*" index element={<Navigate to="overview" />} />
-        </Route>
+        {!isTCBuild && shouldShowDevComponents && (
+          <Route path="upopt" element={<TabUpopt />} />
+        )}
+        <Route path="*" index element={<Navigate to="overview" />} />
       </Routes>
     </Suspense>
   )

--- a/libs/gi/page-team/src/TeamCharacterSelector.tsx
+++ b/libs/gi/page-team/src/TeamCharacterSelector.tsx
@@ -100,6 +100,8 @@ export default function TeamCharacterSelector({
                   )
                 }
                 onClick={() =>
+                  // conserve the current tab when switching to another character
+                  teamCharKey &&
                   navigate(`/teams/${teamId}/${teamCharKey}/${tab}`)
                 }
               />

--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -29,7 +29,14 @@ import { SillyContext } from '@genshin-optimizer/gi/uidata'
 import { Box, CardContent, Skeleton } from '@mui/material'
 import { Suspense, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Navigate, useMatch, useNavigate, useParams } from 'react-router-dom'
+import {
+  Navigate,
+  Route,
+  Routes,
+  useMatch,
+  useNavigate,
+  useParams,
+} from 'react-router-dom'
 import Content from './CharacterDisplay/Content'
 import TeamCharacterSelector from './TeamCharacterSelector'
 import TeamSetting from './TeamSetting'
@@ -260,7 +267,11 @@ function InnerContent({ tab }: { tab: string }) {
     <CharacterContext.Provider value={CharacterContextValue}>
       <GraphContext.Provider value={graphContextValue}>
         <FormulaDataWrapper>
-          <Content tab={tab} />
+          <Routes>
+            <Route path=":characterKey">
+              <Route path="*" index element={<Content tab={tab} />} />
+            </Route>
+          </Routes>
         </FormulaDataWrapper>
       </GraphContext.Provider>
     </CharacterContext.Provider>


### PR DESCRIPTION
## Describe your changes

Current implementation is missing a layer in routing, which made all end route logic more complicated. 
This PR addes that extra layer in routing, and simplifies that logic.

The routing can now enforce the "tab" value in the URL eg(`/teams/team_71/RaidenShogun/overview`), whereas in prod the tab value can sometimes be omitted.(`/teams/team_71/RaidenShogun`)

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1904

## Testing/validation

- Creating a new team flow still works
- Swapping to a new character that is active (#1904)
- On Opt tab, swap to a TC build (should resolve to /overview)
- Switching from one character in a team to another conserves the tab (Yelan/talent -> Raiden/talent)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
