### PR TITLE
Fix bug in RV filter

### DIFF
--- a/libs/gi/util/src/artifact/artifact.ts
+++ b/libs/gi/util/src/artifact/artifact.ts
@@ -179,9 +179,13 @@ export function getArtifactEfficiency(
   const { substats, rarity, level } = artifact
   const { artifactMeta } = getArtifactMeta(artifact)
   // Relative to max star, so comparison between different * makes sense.
-  const currentEfficiency = artifact.substats
-    .filter(({ key }) => key && filter.has(key))
-    .reduce((sum, _, i) => sum + (artifactMeta.substats[i]?.efficiency ?? 0), 0)
+  const currentEfficiency = artifact.substats.reduce(
+    (sum, { key }, i) =>
+      key && filter.has(key)
+        ? sum + (artifactMeta.substats[i]?.efficiency ?? 0)
+        : sum,
+    0
+  )
 
   const rollsRemaining = getRollsRemaining(level, rarity)
   const emptySlotCount = substats.filter((s) => !s.key).length


### PR DESCRIPTION
## Describe your changes

Fix bug caused by refactor where filtered RV calculation was wrong

## Issue or discord link

- Resolve #1917

## Testing/validation

Validated RV filter works as expected

Before
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/7fa77ff5-2988-4690-9889-aef53b56314e)

190+100 != 430

After
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/b254c7af-2ac4-497b-acdf-6004a5aadcc8)

190+100 = 290

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
