### PR TITLE
Add missing tooltip to AllowChar CharacterCard component

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/AllowChar.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/AllowChar.tsx
@@ -36,6 +36,7 @@ import {
 import { getCharEle, getCharStat } from '@genshin-optimizer/gi/stats'
 import { SlotIcon } from '@genshin-optimizer/gi/svgicons'
 import {
+  CharacterCard,
   CharacterCardPico,
   CharacterRarityToggle,
   ElementToggle,
@@ -604,12 +605,18 @@ function SelectItem({
     ),
     [char?.equippedArtifacts]
   )
+  const characterKey = database.chars.LocationToCharacterKey(locKey)
   return (
     <CardThemed bgt="light" sx={sx}>
       <CharacterCardPico
-        characterKey={database.chars.LocationToCharacterKey(locKey)}
+        characterKey={characterKey}
         onMouseDown={onMouseDown}
         onMouseEnter={onMouseEnter}
+        hoverChild={
+          <Box sx={{ width: 300, m: -1 }}>
+            <CharacterCard hideStats characterKey={characterKey} />
+          </Box>
+        }
       />
       {content}
     </CardThemed>


### PR DESCRIPTION
## Describe your changes

It looks like in this PR https://github.com/frzyc/genshin-optimizer/pull/1656 when adding tooltips to the team page and the `CharacterCardPico` component was refactored to receive the tooltip content from props, the tooltip content wasn't passed to the card in the `AllowChar` component.

EDIT: Maybe it wasn't that PR because it was reverted 🤔
But still the prop was missing.

## Issue or discord link

Resolve https://github.com/frzyc/genshin-optimizer/issues/1840

## Testing/validation

| Before | After |
| -- | -- |
| <video src="https://github.com/frzyc/genshin-optimizer/assets/31373060/9a7620d3-2b60-4fe5-9b7b-0482b5b8bc67" /> | <video src="https://github.com/frzyc/genshin-optimizer/assets/31373060/ad60712e-c5e6-4ec1-ba87-0bfa2c22b305" /> |

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [X] I have run `yarn run mini-ci` locally to validate format and lint.
- [X] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
