### PR TITLE
Allow pressing Enter from the Build Name field to create a team

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -1285,7 +1285,11 @@ function CopyBuildButton({
       </Button>
       {/* TODO: Dialog Wanted to use a Dialog here, but was having some weird issues with closing out of it */}
       {/* TODO: Translation */}
-      <ModalWrapper open={showPrompt} onClose={OnHidePrompt}>
+      <ModalWrapper
+        open={showPrompt}
+        onClose={OnHidePrompt}
+        disableRestoreFocus
+      >
         <CardThemed>
           <CardHeader
             title="New Build"

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -96,7 +96,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import type { ReactNode } from 'react'
+import type { FormEventHandler, ReactNode } from 'react'
 import React, {
   Suspense,
   memo,
@@ -1262,7 +1262,8 @@ function CopyBuildButton({
   const database = useDatabase()
   const { teamCharId } = useContext(TeamCharacterContext)
 
-  const toLoadout = () => {
+  const toLoadout: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
     database.teamChars.newBuild(teamCharId, {
       name,
       artifactIds,
@@ -1299,20 +1300,22 @@ function CopyBuildButton({
             sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
           >
             <Typography>Copy over this build to a new build</Typography>
-            <TextField
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              autoFocus
-              margin="dense"
-              label="Build Name"
-              fullWidth
-            />
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-              <Button onClick={OnHidePrompt}>Cancel</Button>
-              <Button color="success" disabled={!name} onClick={toLoadout}>
-                Create
-              </Button>
-            </Box>
+            <form onSubmit={toLoadout}>
+              <TextField
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
+                margin="dense"
+                label="Build Name"
+                fullWidth
+              />
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+                <Button onClick={OnHidePrompt}>Cancel</Button>
+                <Button type="submit" color="success" disabled={!name}>
+                  Create
+                </Button>
+              </Box>
+            </form>
           </CardContent>
         </CardThemed>
       </ModalWrapper>


### PR DESCRIPTION
## Describe your changes

- Allows triggering the Create action using `Enter`.
- Also fixed the `TextField` auto-focus that wasn't working. Got the solution from [here](https://stackoverflow.com/a/76533962).

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1769

## Testing/validation

https://github.com/frzyc/genshin-optimizer/assets/31373060/b235aec4-f43e-44fd-b65e-224d08619c48


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
