### PR TITLE
fix team page rerender after revalidating character

### DIFF
--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -29,7 +29,14 @@ import { SillyContext } from '@genshin-optimizer/gi/uidata'
 import { Box, CardContent, Skeleton } from '@mui/material'
 import { Suspense, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Navigate, Route, Routes, useMatch, useParams } from 'react-router-dom'
+import {
+  Navigate,
+  Route,
+  Routes,
+  useMatch,
+  useNavigate,
+  useParams,
+} from 'react-router-dom'
 import Content from './CharacterDisplay/Content'
 import TeamCharacterSelector from './TeamCharacterSelector'
 import TeamSetting from './TeamSetting'
@@ -59,6 +66,8 @@ export default function PageTeam() {
 }
 function PageLoadoutWrapper({ teamId }: { teamId: string }) {
   const database = useDatabase()
+  const navigate = useNavigate()
+
   const team = useTeam(teamId)!
   const { loadoutData } = team
   // use the current URL as the "source of truth" for characterKey and tab.
@@ -85,13 +94,19 @@ function PageLoadoutWrapper({ teamId }: { teamId: string }) {
     return loadoutDatum
   }, [loadoutData, database.teamChars, characterKeyRaw])
 
-  // make sure the characterKey path is valid
-  if ((characterKeyRaw && !loadoutDatum) || (loadoutData[0] && !loadoutDatum)) {
-    const ld = loadoutData[0]
-    const ck = ld && database.teamChars.get(ld.teamCharId)?.key
-    if (ck) return <Navigate to={ck} replace />
-    else return <Navigate to="" replace />
-  }
+  useEffect(() => {
+    // make sure the characterKey path is valid
+    if (
+      (characterKeyRaw && !loadoutDatum) ||
+      (loadoutData[0] && !loadoutDatum)
+    ) {
+      const ld = loadoutData[0]
+      const ck = ld && database.teamChars.get(ld.teamCharId)?.key
+      if (ck) return navigate(ck, { replace: true })
+      else return navigate('', { replace: true })
+    }
+  }, [characterKeyRaw, database, loadoutData, loadoutDatum, navigate])
+
   return <Page loadoutDatum={loadoutDatum} teamId={teamId} tab={tab} />
 }
 


### PR DESCRIPTION
## Describe your changes

Revert to using `navigate`, but to not conflict with rendering state, wrap the function in a `useEffect`

## Issue or discord link

- Resolves #1968

## Testing/validation

- Create new team, add a character then remove character, does not close team setting
- Create team with 2 char, removing the 1st char would cause 2nd char to shift to 1st slot without closing team setting

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
