### PR TITLE
Default all conditionals to 0

### DIFF
--- a/libs/sr/formula/src/data/common/index.ts
+++ b/libs/sr/formula/src/data/common/index.ts
@@ -33,5 +33,8 @@ const data: TagMapNodeEntries = [
   selfBuff.common.cappedCrit_.add(
     max(min(self.final.crit_, percent(1)), percent(0))
   ),
+
+  // Default conditionals to 0
+  reader.with('qt', 'cond').add(0),
 ]
 export default data

--- a/libs/sr/formula/src/data/util/tag.ts
+++ b/libs/sr/formula/src/data/util/tag.ts
@@ -197,10 +197,7 @@ export const allBoolConditionals = (src: Source) =>
 export const allListConditionals = <T extends string>(src: Source, list: T[]) =>
   allCustoms(src, 'cond', { type: 'list', list }, ({ max: r }) => ({
     map: (table: Record<T, number>, def = 0) =>
-      subscript(
-        r,
-        list.map((v) => table[v] ?? def)
-      ),
+      subscript(r, [def, ...list.map((v) => table[v] ?? def)]),
     value: r,
   }))
 export const allNumConditionals = (


### PR DESCRIPTION
## Describe your changes

* Default all conditionals to 0 inside sr-formula.
    * If we ever have a `NumConditional` that uses `prod` `ex` for some reason, we will need to have a new entry in `qt` for `condWithDefaultOne` or something. Otherwise, this default 0 will cause those conditionals to always be 0. That would require there to be a use case where 2 values are writing to the same conditional for some reason, which doesn't really make sense.
* Add a default value to `ListConditionals` to have `def` (default 0) when set to 0 (such as above)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Tested using WIP `CalcContext` that contains hard-coded conditional data. Default value was working as expected, and a specified conditional would override this default.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
