### PR TITLE
Update clean-pr.yml to merge on divergent branches

### DIFF
--- a/.github/workflows/clean-pr.yml
+++ b/.github/workflows/clean-pr.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase false
           git rm -r ./${{ steps.build-info.outputs.deploy_path }}
           git commit -m "clean ${{ steps.build-info.outputs.deploy_path }}"
         working-directory: gh-pages


### PR DESCRIPTION
## Describe your changes

Without this config, git would not automatically reconcile when we had diverging branches. Since our deployments are always in different folders, merge default should work fine to allow retries to work. Before this, all retries would fail, so a lot of manual deployment cleanup needed to happen if we were merging multiple PRs simultaneously.
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/8d055524-7fc1-419d-ac2d-f46b8c3907a1)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
