### PR TITLE
Move Team setting to a tab

### DIFF
--- a/libs/gi/localization/assets/locales/en/page_character.json
+++ b/libs/gi/localization/assets/locales/en/page_character.json
@@ -1,6 +1,7 @@
 {
   "addNew": "Add Character",
   "tabs": {
+    "setting": "Loadout/Build",
     "overview": "Overview",
     "talent": "Talents",
     "optimize": "Optimize",

--- a/libs/gi/page-team/src/CharacterDisplay/Content.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Content.tsx
@@ -1,16 +1,26 @@
+import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
+import { characterAsset } from '@genshin-optimizer/gi/assets'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
-
+import {
+  TeamCharacterContext,
+  useDBMeta,
+  useDatabase,
+} from '@genshin-optimizer/gi/db-ui'
+import { getCharEle } from '@genshin-optimizer/gi/stats'
+import { shouldShowDevComponents } from '@genshin-optimizer/gi/ui'
+import CheckroomIcon from '@mui/icons-material/Checkroom'
 import FactCheckIcon from '@mui/icons-material/FactCheck'
 import PersonIcon from '@mui/icons-material/Person'
 import ScienceIcon from '@mui/icons-material/Science'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
-
-import { CardThemed } from '@genshin-optimizer/common/ui'
-import { characterAsset } from '@genshin-optimizer/gi/assets'
-import { TeamCharacterContext, useDBMeta } from '@genshin-optimizer/gi/db-ui'
-import { getCharEle } from '@genshin-optimizer/gi/stats'
-import { shouldShowDevComponents } from '@genshin-optimizer/gi/ui'
-import { Skeleton, Tab, Tabs } from '@mui/material'
+import {
+  CardContent,
+  Divider,
+  Skeleton,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
 import { Suspense, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Navigate, Route, Link as RouterLink, Routes } from 'react-router-dom'
@@ -21,8 +31,7 @@ import TabOverview from './Tabs/TabOverview'
 import TabTalent from './Tabs/TabTalent'
 import TabTheorycraft from './Tabs/TabTheorycraft'
 import TabUpopt from './Tabs/TabUpgradeOpt'
-
-export default function Content({ tab }: { tab: string }) {
+export default function Content({ tab }: { tab?: string }) {
   const {
     loadoutDatum,
     teamChar: { key: characterKey },
@@ -30,22 +39,17 @@ export default function Content({ tab }: { tab: string }) {
   const isTCBuild = !!(
     loadoutDatum.buildTcId && loadoutDatum.buildType === 'tc'
   )
-  const elementKey = getCharEle(characterKey)
   return (
     <>
       <FormulaModal />
-      <LoadoutSettingElement
-        buttonProps={{
-          fullWidth: true,
-          color: elementKey ?? 'info',
-          variant: 'outlined',
-          sx: { backgroundColor: 'contentLight.main' },
-        }}
-      />
-
       <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
       <CharacterPanel isTCBuild={isTCBuild} />
-      <TabNav tab={tab} characterKey={characterKey} isTCBuild={isTCBuild} />
+      <TabNav
+        tab={tab}
+        characterKey={characterKey}
+        isTCBuild={isTCBuild}
+        hideTitle
+      />
     </>
   )
 }
@@ -56,9 +60,10 @@ function CharacterPanel({ isTCBuild }: { isTCBuild: boolean }) {
       fallback={<Skeleton variant="rectangular" width="100%" height={500} />}
     >
       <Routes>
+        <Route path="" index element={<LoadoutSettingElement />} />
         {/* Character Panel */}
         {isTCBuild ? (
-          <Route path="overview" element={<TabTheorycraft />} />
+          <Route path="theorycraft" element={<TabTheorycraft />} />
         ) : (
           <Route path="overview" element={<TabOverview />} />
         )}
@@ -68,7 +73,7 @@ function CharacterPanel({ isTCBuild }: { isTCBuild: boolean }) {
         {!isTCBuild && shouldShowDevComponents && (
           <Route path="upopt" element={<TabUpopt />} />
         )}
-        <Route path="*" index element={<Navigate to="overview" replace />} />
+        <Route path="*" element={<Navigate to="" replace />} />
       </Routes>
     </Suspense>
   )
@@ -77,18 +82,21 @@ function TabNav({
   tab,
   characterKey,
   isTCBuild,
+  hideTitle = false,
 }: {
-  tab: string
+  tab?: string
   characterKey: CharacterKey
   isTCBuild: boolean
+  hideTitle?: boolean
 }) {
+  const { teamChar, loadoutDatum } = useContext(TeamCharacterContext)
+  const database = useDatabase()
   const { t } = useTranslation('page_character')
   const { gender } = useDBMeta()
   const elementKey = getCharEle(characterKey)
   const banner = characterAsset(characterKey, 'banner', gender)
   return (
     <CardThemed
-      bgt="light"
       sx={(theme) => {
         return {
           position: 'relative',
@@ -111,12 +119,43 @@ function TabNav({
         }
       }}
     >
+      {!hideTitle && (
+        <CardContent
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            pb: 0,
+            textShadow: '#000 0 0 10px !important',
+            position: 'relative',
+          }}
+        >
+          <BootstrapTooltip
+            title={
+              teamChar.description ? (
+                <Typography>{teamChar.description}</Typography>
+              ) : undefined
+            }
+          >
+            <Typography
+              variant="h6"
+              sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
+            >
+              <PersonIcon />
+              <strong>{teamChar.name}</strong>
+              <Divider orientation="vertical" variant="middle" flexItem />
+              <CheckroomIcon />
+              {database.teams.getActiveBuildName(loadoutDatum)}
+            </Typography>
+          </BootstrapTooltip>
+        </CardContent>
+      )}
       <Tabs
-        value={tab}
+        value={tab ?? 'setting'}
         variant="fullWidth"
         allowScrollButtonsMobile
         sx={(theme) => {
           return {
+            position: 'relative',
             '& .MuiTab-root:hover': {
               transition: 'background-color 0.25s ease',
               backgroundColor: 'rgba(255,255,255,0.1)',
@@ -134,13 +173,20 @@ function TabNav({
           }
         }}
       >
+        <Tab
+          value="setting"
+          label={t('tabs.setting')}
+          icon={<CheckroomIcon />}
+          component={RouterLink}
+          to=""
+        />
         {isTCBuild ? (
           <Tab
-            value="overview"
+            value="theorycraft"
             label={t('tabs.theorycraft')}
             icon={<ScienceIcon />}
             component={RouterLink}
-            to="overview"
+            to="theorycraft"
           />
         ) : (
           <Tab

--- a/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
@@ -1,10 +1,5 @@
 import { useBoolState } from '@genshin-optimizer/common/react-util'
-import {
-  BootstrapTooltip,
-  CardThemed,
-  ModalWrapper,
-  SqBadge,
-} from '@genshin-optimizer/common/ui'
+import { SqBadge } from '@genshin-optimizer/common/ui'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import { TeamCharacterContext, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharEle, getCharStat } from '@genshin-optimizer/gi/stats'
@@ -18,22 +13,16 @@ import AddIcon from '@mui/icons-material/Add'
 import BarChartIcon from '@mui/icons-material/BarChart'
 import CalculateIcon from '@mui/icons-material/Calculate'
 import CheckroomIcon from '@mui/icons-material/Checkroom'
-import CloseIcon from '@mui/icons-material/Close'
-import PersonIcon from '@mui/icons-material/Person'
-import SettingsIcon from '@mui/icons-material/Settings'
 import type { ButtonProps } from '@mui/material'
 import {
   Box,
   Button,
-  CardContent,
   CardHeader,
-  Divider,
   Grid,
-  IconButton,
   Skeleton,
   Typography,
 } from '@mui/material'
-import { Suspense, useContext, useState } from 'react'
+import { Suspense, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoadoutDropdown } from '../LoadoutDropdown'
 import { BuildEquipped } from './Build/BuildEquipped'
@@ -43,17 +32,10 @@ import { CustomMultiTargetButton } from './CustomMultiTarget'
 import StatModal from './StatModal'
 
 // TODO: Translation
-const columns = { xs: 1, sm: 1, md: 2, lg: 2 }
-export default function LoadoutSettingElement({
-  buttonProps = {},
-}: {
-  buttonProps?: ButtonProps
-}) {
+const columns = { xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }
+export default function LoadoutSettingElement() {
   const database = useDatabase()
-  const { teamId, teamChar, teamCharId, loadoutDatum } =
-    useContext(TeamCharacterContext)
-
-  const [open, setOpen] = useState(false)
+  const { teamId, teamChar, teamCharId } = useContext(TeamCharacterContext)
 
   const onChangeTeamCharId = (newTeamCharId: string) => {
     const index = database.teams
@@ -68,103 +50,49 @@ export default function LoadoutSettingElement({
   }
   const elementKey = getCharEle(teamChar.key)
   return (
-    <>
-      <Box display="flex" gap={1} alignItems="center">
-        <BootstrapTooltip
-          title={
-            teamChar.description ? (
-              <Typography>{teamChar.description}</Typography>
-            ) : undefined
-          }
-        >
-          <Button
-            startIcon={<PersonIcon />}
-            endIcon={<SettingsIcon />}
-            color="info"
-            onClick={() => setOpen((o) => !o)}
-            {...buttonProps}
-          >
-            <Typography
-              variant="h6"
-              sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
-            >
-              <strong>{teamChar.name}</strong>
-              <Divider orientation="vertical" variant="middle" flexItem />
-              <CheckroomIcon />
-              <strong>{database.teams.getActiveBuildName(loadoutDatum)}</strong>
-              <Divider orientation="vertical" variant="middle" flexItem />
-              <span>Loadout/Build settings</span>
-            </Typography>
-          </Button>
-        </BootstrapTooltip>
+    <Suspense
+      fallback={<Skeleton variant="rectangular" width="100%" height={1000} />}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <LoadoutInfoAlert />
+        <LoadoutDropdown
+          teamCharId={teamCharId}
+          onChangeTeamCharId={onChangeTeamCharId}
+          dropdownBtnProps={{
+            fullWidth: true,
+            sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
+            color: elementKey ?? 'info',
+            variant: 'outlined',
+          }}
+          label
+        />
+        <LoadoutNameDesc teamCharId={teamCharId} />
+        <Box display="flex" gap={2} flexWrap="wrap">
+          <DetailStatButton
+            buttonProps={{
+              sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+              color: elementKey ?? 'info',
+              variant: 'outlined',
+            }}
+          />
+          <CustomMultiTargetButton
+            buttonProps={{
+              sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+              color: elementKey ?? 'info',
+              variant: 'outlined',
+            }}
+          />
+          <FormulasButton
+            buttonProps={{
+              sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
+              color: elementKey ?? 'info',
+              variant: 'outlined',
+            }}
+          />
+        </Box>
       </Box>
-
-      <ModalWrapper open={open} onClose={() => setOpen(false)}>
-        <CardThemed>
-          <Suspense
-            fallback={
-              <Skeleton variant="rectangular" width="100%" height={1000} />
-            }
-          >
-            <CardHeader
-              title={
-                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                  <PersonIcon />
-                  <span>Loadout Settings</span>
-                </Box>
-              }
-              action={
-                <IconButton onClick={() => setOpen(false)}>
-                  <CloseIcon />
-                </IconButton>
-              }
-            />
-            <Divider />
-            <CardContent
-              sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
-            >
-              <LoadoutInfoAlert />
-              <LoadoutDropdown
-                teamCharId={teamCharId}
-                onChangeTeamCharId={onChangeTeamCharId}
-                dropdownBtnProps={{
-                  fullWidth: true,
-                  sx: { flexGrow: 1, backgroundColor: 'contentLight.main' },
-                  color: elementKey ?? 'info',
-                  variant: 'outlined',
-                }}
-              />
-              <LoadoutNameDesc teamCharId={teamCharId} />
-              <Box display="flex" gap={2} flexWrap="wrap">
-                <DetailStatButton
-                  buttonProps={{
-                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
-                    color: elementKey ?? 'info',
-                    variant: 'outlined',
-                  }}
-                />
-                <CustomMultiTargetButton
-                  buttonProps={{
-                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
-                    color: elementKey ?? 'info',
-                    variant: 'outlined',
-                  }}
-                />
-                <FormulasButton
-                  buttonProps={{
-                    sx: { backgroundColor: 'contentLight.main', flexGrow: 1 },
-                    color: elementKey ?? 'info',
-                    variant: 'outlined',
-                  }}
-                />
-              </Box>
-            </CardContent>
-            <Divider />
-            <BuildManagementContent />
-          </Suspense>
-        </CardThemed>
-      </ModalWrapper>
-    </>
+      <BuildManagementContent />
+    </Suspense>
   )
 }
 
@@ -188,8 +116,7 @@ function BuildManagementContent() {
           </Box>
         }
       />
-      <Divider />
-      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <BuildInfoAlert />
         <Grid container columns={columns} spacing={2}>
           <Grid item xs={1}>
@@ -254,7 +181,7 @@ function BuildManagementContent() {
             ))}
           </Grid>
         </Box>
-      </CardContent>
+      </Box>
     </>
   )
 }

--- a/libs/gi/page-team/src/LoadoutDropdown.tsx
+++ b/libs/gi/page-team/src/LoadoutDropdown.tsx
@@ -25,10 +25,12 @@ export function LoadoutDropdown({
   teamCharId,
   onChangeTeamCharId,
   dropdownBtnProps = {},
+  label = false,
 }: {
   teamCharId: string
   onChangeTeamCharId: (teamCharId: string) => void
   dropdownBtnProps?: Omit<DropdownButtonProps, 'children' | 'title'>
+  label?: boolean
 }) {
   const database = useDatabase()
   const { key: characterKey, name } = database.teamChars.get(teamCharId)!
@@ -108,7 +110,13 @@ export function LoadoutDropdown({
               justifyContent: 'center',
             }}
           >
-            <span>{name}</span>
+            {label ? (
+              <span>
+                Loadout: <strong>{name}</strong>
+              </span>
+            ) : (
+              <span>{name}</span>
+            )}
           </Box>
         }
         {...dropdownBtnProps}

--- a/libs/gi/page-team/src/TeamCharacterSelector.tsx
+++ b/libs/gi/page-team/src/TeamCharacterSelector.tsx
@@ -11,11 +11,11 @@ import { useNavigate } from 'react-router-dom'
 export default function TeamCharacterSelector({
   teamId,
   characterKey,
-  tab,
+  tab = '',
 }: {
   teamId: string
   characterKey?: CharacterKey
-  tab: string
+  tab?: string
 }) {
   const navigate = useNavigate()
   const database = useDatabase()

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -1,8 +1,3 @@
-import {
-  BootstrapTooltip,
-  CardThemed,
-  ModalWrapper,
-} from '@genshin-optimizer/common/ui'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import type { TeamCharacterContextObj } from '@genshin-optimizer/gi/db-ui'
@@ -25,23 +20,18 @@ import CloseIcon from '@mui/icons-material/Close'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
-import GroupsIcon from '@mui/icons-material/Groups'
-import SettingsIcon from '@mui/icons-material/Settings'
 import type { ButtonProps } from '@mui/material'
 import {
   Alert,
   Box,
   Button,
   CardContent,
-  CardHeader,
-  Divider,
   Grid,
-  IconButton,
   TextField,
   Typography,
 } from '@mui/material'
 import { Suspense, useDeferredValue, useEffect, useMemo, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import BuildDropdown from '../BuildDropdown'
 import { LoadoutDropdown } from '../LoadoutDropdown'
 import { ResonanceDisplay, TeammateDisplay } from './TeamComponents'
@@ -50,7 +40,6 @@ import { ResonanceDisplay, TeammateDisplay } from './TeamComponents'
 export default function TeamSetting({
   teamId,
   teamData,
-  buttonProps = {},
 }: {
   teamId: string
   teamData?: TeamData
@@ -60,15 +49,6 @@ export default function TeamSetting({
   const database = useDatabase()
   const team = database.teams.get(teamId)!
   const noChars = team.loadoutData.every((id) => !id)
-
-  const location = useLocation()
-
-  const { openSetting = false } = (location.state ?? {
-    openSetting: false,
-  }) as {
-    openSetting?: boolean
-  }
-  const [open, setOpen] = useState(openSetting || noChars)
 
   const [name, setName] = useState(team.name)
   const nameDeferred = useDeferredValue(name)
@@ -124,106 +104,59 @@ export default function TeamSetting({
   }
 
   return (
-    <>
-      <BootstrapTooltip
-        title={
-          team.description ? (
-            <Typography>{team.description}</Typography>
-          ) : undefined
-        }
-      >
+    <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <TeamInfoAlert />
+      <TextField
+        fullWidth
+        label="Team Name"
+        placeholder="Team Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <TextField
+        fullWidth
+        label="Team Description"
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+        multiline
+        minRows={2}
+      />
+      <Box sx={{ display: 'flex', gap: 1 }}>
         <Button
-          startIcon={<GroupsIcon />}
-          endIcon={<SettingsIcon />}
-          onClick={() => setOpen((open) => !open)}
-          {...buttonProps}
+          color="info"
+          sx={{ flexGrow: 1 }}
+          startIcon={<ContentPasteIcon />}
+          disabled={noChars}
+          onClick={onExport}
         >
-          <Typography variant="h5" display="flex" gap={1}>
-            <strong>{team.name}</strong>
-            <Divider orientation="vertical" variant="middle" flexItem />
-            <span>Team Settings</span>
-          </Typography>
+          Export Team
         </Button>
-      </BootstrapTooltip>
-
-      <ModalWrapper
-        open={open}
-        onClose={() => setOpen(false)}
-        containerProps={{ maxWidth: 'xl' }}
-      >
-        <CardThemed>
-          <CardHeader
-            title={
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                <GroupsIcon />
-                <span>Team Settings</span>
-              </Box>
-            }
-            action={
-              <IconButton onClick={() => setOpen(false)}>
-                <CloseIcon />
-              </IconButton>
-            }
-          />
-          <Divider />
-          <CardContent
-            sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
-          >
-            <TeamInfoAlert />
-            <TextField
-              fullWidth
-              label="Team Name"
-              placeholder="Team Name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-            <TextField
-              fullWidth
-              label="Team Description"
-              value={desc}
-              onChange={(e) => setDesc(e.target.value)}
-              multiline
-              minRows={2}
-            />
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button
-                color="info"
-                sx={{ flexGrow: 1 }}
-                startIcon={<ContentPasteIcon />}
-                disabled={noChars}
-                onClick={onExport}
-              >
-                Export Team
-              </Button>
-              <Button
-                color="info"
-                sx={{ flexGrow: 1 }}
-                disabled={noChars}
-                onClick={onDup}
-                startIcon={<ContentCopyIcon />}
-              >
-                Duplicate Team
-              </Button>
-              <Button
-                color="error"
-                sx={{ flexGrow: 1 }}
-                onClick={onDel}
-                startIcon={<DeleteForeverIcon />}
-              >
-                Delete Team
-              </Button>
-            </Box>
-            <EnemyExpandCard teamId={teamId} />
-            <Typography variant="h6">Team Editor</Typography>
-            <Alert severity="info">
-              The first character in the team receives any "active on-field
-              character" buffs, and cannot be empty.
-            </Alert>
-            <TeamCharacterSelector teamId={teamId} teamData={teamData} />
-          </CardContent>
-        </CardThemed>
-      </ModalWrapper>
-    </>
+        <Button
+          color="info"
+          sx={{ flexGrow: 1 }}
+          disabled={noChars}
+          onClick={onDup}
+          startIcon={<ContentCopyIcon />}
+        >
+          Duplicate Team
+        </Button>
+        <Button
+          color="error"
+          sx={{ flexGrow: 1 }}
+          onClick={onDel}
+          startIcon={<DeleteForeverIcon />}
+        >
+          Delete Team
+        </Button>
+      </Box>
+      <EnemyExpandCard teamId={teamId} />
+      <Typography variant="h6">Team Editor</Typography>
+      <Alert severity="info">
+        The first character in the team receives any "active on-field character"
+        buffs, and cannot be empty.
+      </Alert>
+      <TeamCharacterSelector teamId={teamId} teamData={teamData} />
+    </CardContent>
   )
 }
 function TeamCharacterSelector({

--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -85,11 +85,10 @@ function Page({ teamId }: { teamId: string }) {
     params: {},
   }
   const {
-    params: { tab: tabRaw },
+    params: { tab },
   } = useMatch({ path: '/teams/:teamId/:characterKey/:tab' }) ?? {
     params: {},
   }
-  const tab = tabRaw ?? 'overview'
 
   // validate characterKey
   const loadoutDatum = useMemo(() => {
@@ -199,7 +198,7 @@ function Page({ teamId }: { teamId: string }) {
     </Box>
   )
 }
-function InnerContent({ tab }: { tab: string }) {
+function InnerContent({ tab }: { tab?: string }) {
   const {
     teamCharId,
     teamChar: { key: characterKey },

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -229,7 +229,7 @@ function InTeam() {
     database.teams.set(teamId, (team) => {
       team.loadoutData[0] = { teamCharId } as LoadoutDatum
     })
-    navigate(`/teams/${teamId}`, { state: { openSetting: true } })
+    navigate(`/teams/${teamId}`)
   }
   // TODO: Translation
   return (

--- a/libs/gi/ui/src/components/character/editor/LoadoutCard.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutCard.tsx
@@ -39,7 +39,7 @@ export function LoadoutCard({
     database.teams.set(teamId, (team) => {
       team.loadoutData[0] = { teamCharId } as LoadoutDatum
     })
-    navigate(`/teams/${teamId}`, { state: { openSetting: true } })
+    navigate(`/teams/${teamId}`)
   }
   const [show, onShow, onHide] = useBoolState()
   return (

--- a/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
@@ -78,7 +78,7 @@ export function LoadoutEditor({
     database.teams.set(teamId, (team) => {
       team.loadoutData[0] = { teamCharId } as LoadoutDatum
     })
-    navigate(`/teams/${teamId}`, { state: { openSetting: true } })
+    navigate(`/teams/${teamId}`)
   }
   const conditionalCount = useMemo(() => {
     let count = 0


### PR DESCRIPTION
## Describe your changes

### Convert Team setting to a Tab
- Convert the team setting from a modal, to a tab in the team selection UI.
- Simplify routing logic, /teams/teamXXX/ is now used for team setting

### Convert Loadout setting to a Tab
- Convert the loadout setting from a modal, to a tab in the character UI.
- Simply routing logic, /teams/teamXXX/CharName/ is now used for Loadout setting.
- /teams/teamXXX/CharName/theorycraft is now used for TC, instead of overview.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<img width="1447" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/03ac0b34-c0ca-40ef-bc37-8abc34816b56">
### Team Setting as a tab
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/337f80c2-6c69-4270-8f36-676aa8c904f9)

### Loadout Setting as a tab
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/18158f05-0a73-4b1b-8d0d-3d4697b25cbe)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
