### PR TITLE
more responsive ads

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -121,9 +121,18 @@ function Content() {
     >
       <Header anchor="back-to-top-anchor" />
       {/* Top banner ad */}
-      <Box className="ad-wrapper" m={1} display="flex" justifyContent="center">
-        {/* limit the height of top banner ad */}
-        <AdWrapper dataAdSlot="3477080462" height={90} />
+      <Box m={1}>
+        {width && (
+          <AdWrapper
+            dataAdSlot="3477080462"
+            sx={{
+              height: 90,
+              minWidth: 300,
+              maxWidth: Math.min(1000, width - 20),
+              width: '100%',
+            }}
+          />
+        )}
       </Box>
       {/* Main content */}
       <Box
@@ -133,14 +142,18 @@ function Content() {
         alignItems="flex-start"
       >
         {/* left Rail ad */}
-        <Box
-          className="ad-wrapper"
-          sx={{ flexShrink: 1, position: 'sticky', top: 0 }}
-        >
-          {adWidth >= 160 && (
+        {/* Adding a padding of 60 ensures that there is at least 60px between ads (from top or bottom) */}
+        <Box sx={{ flexShrink: 1, position: 'sticky', top: 0, py: '60px' }}>
+          {width && adWidth >= 160 && (
             <AdWrapper
               dataAdSlot="2411728037"
-              width={adWidth >= 160 && adWidth <= 320 ? adWidth : adWidth * 0.5}
+              sx={{
+                minWidth: 160,
+                maxWidth:
+                  adWidth >= 160 && adWidth <= 320 ? adWidth : adWidth * 0.5,
+                height: 600,
+                width: '100%',
+              }}
             />
           )}
         </Box>
@@ -172,12 +185,18 @@ function Content() {
           </Suspense>
         </Container>
         {/* right rail ad */}
-        <Box
-          className="ad-wrapper"
-          sx={{ flexShrink: 1, position: 'sticky', top: 0 }}
-        >
-          {adWidth > 320 && (
-            <AdWrapper dataAdSlot="2411728037" width={adWidth * 0.5} />
+        {/* Adding a padding of 60 ensures that there is at least 60px between ads (from top or bottom) */}
+        <Box sx={{ flexShrink: 1, position: 'sticky', top: 0, py: '60px' }}>
+          {width && adWidth > 320 && (
+            <AdWrapper
+              dataAdSlot="2411728037"
+              sx={{
+                minWidth: 160,
+                maxWidth: adWidth * 0.5,
+                height: 600,
+                width: '100%',
+              }}
+            />
           )}
         </Box>
       </Box>
@@ -186,8 +205,19 @@ function Content() {
       <Box flexGrow={1} />
       <Snow />
       {/* Footer Ad */}
-      <Box className="ad-wrapper" m={1} display="flex" justifyContent="center">
-        <AdWrapper dataAdSlot="2396256483" />
+      <Box m={1}>
+        {width && (
+          <AdWrapper
+            dataAdSlot="2396256483"
+            sx={{
+              mx: 'auto',
+              height: 90,
+              minWidth: 300,
+              maxWidth: Math.min(1000, width - 20),
+              width: '100%',
+            }}
+          />
+        )}
       </Box>
       <Footer />
     </Box>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -16,3 +16,8 @@ a {
   font-family: monospace;
   color: white;
 }
+
+/* Use Margin to move the google intent ad up so it does not overlap the footer */
+#google-anno-sa {
+  margin-bottom: 20px !important;
+}

--- a/libs/common/ui/src/components/AdBlockContextWrapper.tsx
+++ b/libs/common/ui/src/components/AdBlockContextWrapper.tsx
@@ -1,9 +1,22 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { IsAdBlockedContext } from '../context'
 import { useIsAdblocked } from '../hooks/useIsAdblocked'
 
 export function AdBlockContextWrapper({ children }: { children: ReactNode }) {
   const isAdBlocked = useIsAdblocked()
+
+  useEffect(() => {
+    // observe changes on the <body> and reset them. This prevents padding from being added below the footer for intent ads.
+    const observer = new MutationObserver(() =>
+      document.body.removeAttribute('style')
+    )
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['style'],
+    })
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <IsAdBlockedContext.Provider value={isAdBlocked}>
       {children}

--- a/libs/common/ui/src/components/AdBlockContextWrapper.tsx
+++ b/libs/common/ui/src/components/AdBlockContextWrapper.tsx
@@ -5,10 +5,19 @@ import { useIsAdblocked } from '../hooks/useIsAdblocked'
 export function AdBlockContextWrapper({ children }: { children: ReactNode }) {
   const isAdBlocked = useIsAdblocked()
 
+  useIntentAdHandler()
+
+  return (
+    <IsAdBlockedContext.Provider value={isAdBlocked}>
+      {children}
+    </IsAdBlockedContext.Provider>
+  )
+}
+function useIntentAdHandler() {
   useEffect(() => {
     // observe changes on the <body> and reset them. This prevents padding from being added below the footer for intent ads.
     const observer = new MutationObserver(() =>
-      document.body.removeAttribute('style')
+      document.body.style.removeProperty('padding-bottom')
     )
     observer.observe(document.body, {
       attributes: true,
@@ -16,10 +25,4 @@ export function AdBlockContextWrapper({ children }: { children: ReactNode }) {
     })
     return () => observer.disconnect()
   }, [])
-
-  return (
-    <IsAdBlockedContext.Provider value={isAdBlocked}>
-      {children}
-    </IsAdBlockedContext.Provider>
-  )
 }

--- a/libs/common/ui/src/components/AdSenseUnit.tsx
+++ b/libs/common/ui/src/components/AdSenseUnit.tsx
@@ -1,13 +1,13 @@
+import type { BoxProps } from '@mui/material'
+import { Box } from '@mui/material'
 import { useEffect } from 'react'
 
 export function AdSenseUnit({
   dataAdSlot,
-  height,
-  width,
+  sx = {},
 }: {
   dataAdSlot: string
-  height?: number
-  width?: number
+  sx?: BoxProps['sx']
 }) {
   useEffect(() => {
     try {
@@ -20,13 +20,12 @@ export function AdSenseUnit({
   }, [])
 
   return (
-    <ins
+    <Box
+      component="ins"
       className="adsbygoogle"
-      style={{ display: 'block', height: `${height}px`, width: `${width}px` }}
+      sx={{ display: 'block', margin: 'auto', ...sx }}
       data-ad-client="ca-pub-2443965532085844"
       data-ad-slot={dataAdSlot}
-      data-ad-format="auto"
-      data-full-width-responsive="true"
-    ></ins>
+    />
   )
 }

--- a/libs/gi/ui/src/components/ad/AdWrapper.tsx
+++ b/libs/gi/ui/src/components/ad/AdWrapper.tsx
@@ -1,6 +1,7 @@
 import { useBoolState } from '@genshin-optimizer/common/react-util'
 import { AdSenseUnit, IsAdBlockedContext } from '@genshin-optimizer/common/ui'
 import { getRandomElementFromArray } from '@genshin-optimizer/common/util'
+import type { BoxProps } from '@mui/material'
 import { Box } from '@mui/material'
 import type { FunctionComponent } from 'react'
 import { useContext, useMemo, type ReactNode } from 'react'
@@ -12,22 +13,22 @@ import { SRODevAd, canshowSroDevAd } from './SRODevAd'
 
 export function AdWrapper({
   dataAdSlot,
-  height,
-  width,
+  sx,
 }: {
   dataAdSlot: string
   height?: number
   width?: number
+  sx?: BoxProps['sx']
 }) {
   const [show, _, onHide] = useBoolState(true)
   const adblockEnabled = useContext(IsAdBlockedContext)
   const hostname = window.location.hostname
 
   if (hostname === 'frzyc.github.io' && !adblockEnabled)
-    return <AdSenseUnit dataAdSlot={dataAdSlot} height={height} width={width} />
+    return <AdSenseUnit dataAdSlot={dataAdSlot} sx={sx} />
   if (!show) return null
   return (
-    <GOAdWrapper height={height} width={width}>
+    <GOAdWrapper sx={sx}>
       <AdButtons
         onClose={(e) => {
           e.stopPropagation()
@@ -38,35 +39,25 @@ export function AdWrapper({
   )
 }
 function GOAdWrapper({
-  height,
-  width,
+  sx = {},
   children,
 }: {
-  height?: number
-  width?: number
+  sx?: BoxProps['sx']
   children: ReactNode
 }) {
+  const maxHeight = (sx as any)?.['maxHeight'] || (sx as any)?.['height']
   const Comp = useMemo(() => {
     const components: Array<FunctionComponent<{ children: ReactNode }>> = [GOAd]
-    if (height === undefined || canshowGoDevAd(height)) components.push(GODevAd)
-    if (height === undefined || canshowSroDevAd(height))
+    if (maxHeight === undefined || canshowGoDevAd(maxHeight))
+      components.push(GODevAd)
+    if (maxHeight === undefined || canshowSroDevAd(maxHeight))
       components.push(SRODevAd)
-    if (height === undefined || canShowDrakeAd(height)) components.push(DrakeAd)
+    if (maxHeight === undefined || canShowDrakeAd(maxHeight))
+      components.push(DrakeAd)
     return getRandomElementFromArray(components)
-  }, [height])
+  }, [maxHeight])
   return (
-    <Box
-      id="go-ad-wrapper"
-      sx={{
-        height,
-        width,
-        maxHeight: height,
-        maxWidth: width,
-        display: 'flex',
-        alignItems: 'stretch',
-        justifyContent: 'center',
-      }}
-    >
+    <Box className="go-ad-wrapper" sx={{ margin: 'auto', ...sx }}>
       <Comp>{children}</Comp>
     </Box>
   )

--- a/libs/gi/ui/src/components/ad/DrakeAd.tsx
+++ b/libs/gi/ui/src/components/ad/DrakeAd.tsx
@@ -10,6 +10,7 @@ export function DrakeAd({ children }: { children: ReactNode }) {
         justifyContent: 'center',
         cursor: 'pointer',
         position: 'relative',
+        backgroundColor: 'white !important',
       }}
       onClick={() =>
         window.alert(


### PR DESCRIPTION
## Describe your changes

Ads are not being displayed properly, needed to make ads more adjustable for different layout conditions.
https://support.google.com/adsense/answer/9183363?hl=en&ref_topic=9183242&sjid=6550905263099832313-NC#
This should resolve top/bottom banner ad not rendering:
![Screenshot 2024-04-23 134920](https://github.com/frzyc/genshin-optimizer/assets/1754901/14489465-a283-40fc-a178-83a1c9f727e5)
Also some handling of intent ads


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
(open this in a incognito window to avoid db contamination)  https://frzyc.github.io/genshin-optimizer-beta/
<img width="1920" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/8c04de55-1a9c-4c84-ab3e-1422efa68b5c">

Moving Intend Ad above the footer
![Screenshot 2024-04-24 002828](https://github.com/frzyc/genshin-optimizer/assets/1754901/bd69e97e-5944-4777-a0e7-42e7724d003d)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
