### PR TITLE
Add alerts to loadout/builds

### DIFF
--- a/libs/gi/localization/assets/locales/en/page_character.json
+++ b/libs/gi/localization/assets/locales/en/page_character.json
@@ -100,5 +100,6 @@
   "tabTeambuff": {
     "team_reso": "Team Resonance",
     "resonance_tip": "The party must be full with 4 characters in order for Elemental Resonance to take effect."
-  }
+  },
+  "noLoadout": "Looks like you haven't added any loadout/Teams with this character yet. You need to create a loadout+team with this character to <strong>create builds</strong>, <strong>theorycraft</strong>, or <strong>optimize</strong>."
 }

--- a/libs/gi/localization/assets/locales/en/page_team.json
+++ b/libs/gi/localization/assets/locales/en/page_team.json
@@ -1,0 +1,7 @@
+{
+  "buildInfo": {
+    "equipped": "This is the build currently equipped to your character, this represents in-game equipement and is persistent outside of the Loadout.",
+    "build": "A <strong>Build</strong> is comprised of a weapon and 5 artifacts.",
+    "tcbuild": "A <strong>Theorycraft Build</strong> allows defining a build by raw stats."
+  }
+}

--- a/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
@@ -5,9 +5,11 @@ import { TeamCharacterContext, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import { getCharEle, getCharStat } from '@genshin-optimizer/gi/stats'
 import {
   BuildInfoAlert,
+  EquippedBuildInfoAlert,
   FormulaDataContext,
   LoadoutInfoAlert,
   LoadoutNameDesc,
+  TCBuildInfoAlert,
 } from '@genshin-optimizer/gi/ui'
 import AddIcon from '@mui/icons-material/Add'
 import BarChartIcon from '@mui/icons-material/BarChart'
@@ -117,7 +119,7 @@ function BuildManagementContent() {
         }
       />
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <BuildInfoAlert />
+        <EquippedBuildInfoAlert />
         <Grid container columns={columns} spacing={2}>
           <Grid item xs={1}>
             <BuildEquipped active={loadoutDatum?.buildType === 'equipped'} />
@@ -135,7 +137,7 @@ function BuildManagementContent() {
             New Build
           </Button>
         </Box>
-
+        <BuildInfoAlert />
         <Box>
           <Grid container columns={columns} spacing={2}>
             {buildIds.map((id) => (
@@ -165,7 +167,7 @@ function BuildManagementContent() {
             New TC Build
           </Button>
         </Box>
-
+        <TCBuildInfoAlert />
         <Box>
           <Grid container columns={columns} spacing={2}>
             {buildTcIds.map((id) => (

--- a/libs/gi/ui/src/components/AddTeamInfo.tsx
+++ b/libs/gi/ui/src/components/AddTeamInfo.tsx
@@ -1,0 +1,16 @@
+import { Alert } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
+
+export function AddTeamInfo() {
+  const { t } = useTranslation('page_character')
+  return (
+    <Alert severity="warning">
+      <Trans t={t} i18nKey="noLoadout">
+        Looks like you haven't added any loadout/Teams with this character yet.
+        You need to create a loadout+team with this character to{' '}
+        <strong>create builds</strong>, <strong>theorycraft</strong>, or{' '}
+        <strong>optimize</strong>.
+      </Trans>
+    </Alert>
+  )
+}

--- a/libs/gi/ui/src/components/build/BuildInfoAlert.tsx
+++ b/libs/gi/ui/src/components/build/BuildInfoAlert.tsx
@@ -1,12 +1,37 @@
 import { Alert } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
 
-// TODO: Translation
-export function BuildInfoAlert() {
+export function EquippedBuildInfoAlert() {
+  const { t } = useTranslation('page_team')
   return (
     <Alert severity="info">
-      A <strong>Build</strong> is comprised of a weapon and 5 artifacts. A{' '}
-      <strong>TC Build</strong> allows the artifacts to be created from its
-      stats.
+      <Trans t={t} i18nKey="buildInfo.equipped">
+        This is the build currently equipped to your character, this represents
+        in-game equipement and is persistent outside of the Loadout.
+      </Trans>
+    </Alert>
+  )
+}
+export function BuildInfoAlert() {
+  const { t } = useTranslation('page_team')
+  return (
+    <Alert severity="info">
+      <Trans t={t} i18nKey="buildInfo.build">
+        This is the build currently equipped to your character, this represents
+        in-game equipement and is persistent outside of the Loadout.
+      </Trans>
+    </Alert>
+  )
+}
+
+export function TCBuildInfoAlert() {
+  const { t } = useTranslation('page_team')
+  return (
+    <Alert severity="info">
+      <Trans t={t} i18nKey="buildInfo.tcbuild">
+        This is the build currently equipped to your character, this represents
+        in-game equipement and is persistent outside of the Loadout.
+      </Trans>
     </Alert>
   )
 }

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -23,6 +23,7 @@ import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { DataContext, SillyContext } from '../../../context'
+import { AddTeamInfo } from '../../AddTeamInfo'
 import { LevelSelect } from '../../LevelSelect'
 import {
   CharacterCompactConstSelector,
@@ -238,6 +239,7 @@ function InTeam() {
         Team Loadouts with{' '}
         <CharacterName characterKey={characterKey} gender={gender} />
       </Typography>
+      {!Object.values(loadoutTeamMap).length && <AddTeamInfo />}
 
       {Object.entries(loadoutTeamMap).map(([teamCharId, teamIds]) => (
         <LoadoutCard

--- a/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
@@ -31,7 +31,7 @@ import {
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { DocumentDisplay } from '../../DocumentDisplay'
-import { BuildInfoAlert } from '../../build'
+import { BuildInfoAlert, TCBuildInfoAlert } from '../../build'
 import { LoadoutInfoAlert, LoadoutNameDesc } from '../../loadout'
 import { TeamCard, TeamInfoAlert } from '../../team'
 import { BuildRealSimplified } from './BuildRealSimplified'
@@ -203,6 +203,7 @@ export function LoadoutEditor({
             </Grid>
           </Box>
 
+          <TCBuildInfoAlert />
           <Box>
             <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
               {buildTcIds.map((id) => (

--- a/libs/gi/ui/src/components/index.ts
+++ b/libs/gi/ui/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AddArtInfo'
+export * from './AddTeamInfo'
 export * from './AdditiveReactionModeText'
 export * from './AmpReactionModeText'
 export * from './DocumentDisplay'


### PR DESCRIPTION
## Describe your changes

Add a prompt to prompt users to add a loadout/team when there is no loadout for a character.
![Screenshot 2024-04-25 223406](https://github.com/frzyc/genshin-optimizer/assets/1754901/db5b34b5-5e26-49e1-9b28-bd07772fd9ae)

Add some additional description for builds
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/07dfca61-3a8a-4fdf-9441-1d89ada04337)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
