### PR TITLE
v10 migration patch

### DIFF
--- a/libs/gi/db/src/Database/migrate.ts
+++ b/libs/gi/db/src/Database/migrate.ts
@@ -172,6 +172,8 @@ export function migrateGOOD(good: IGOOD & IGO): IGOOD & IGO {
       const optConfig =
         buildSettings.find(({ id }: { id: string }) => id === characterKey) ??
         {}
+      // Only migrate characters with either a mtarget or an opttarget
+      if (!customMultiTarget.length && !optConfig.optimizationTarget) return
       const optConfigId = `optConfig_${optConfigInd++}`
       ;(good as any).optConfigs.push({ ...optConfig, id: optConfigId })
 
@@ -416,6 +418,8 @@ export function migrate(storage: DBStorage) {
           teamConditional,
         } = storage.get(key) as IGOCharacter
         const optConfig = storage.get(`buildSetting_${characterKey}`) ?? {}
+        // Only migrate characters with either a mtarget or an opttarget
+        if (!customMultiTarget.length && !optConfig.optimizationTarget) continue
         const optConfigId = `optConfig_${optConfigInd++}`
         storage.set(optConfigId, optConfig)
 

--- a/libs/gi/db/src/Database/migrate.ts
+++ b/libs/gi/db/src/Database/migrate.ts
@@ -173,7 +173,7 @@ export function migrateGOOD(good: IGOOD & IGO): IGOOD & IGO {
         buildSettings.find(({ id }: { id: string }) => id === characterKey) ??
         {}
       // Only migrate characters with either a mtarget or an opttarget
-      if (!customMultiTarget.length && !optConfig.optimizationTarget) return
+      if (!customMultiTarget?.length && !optConfig.optimizationTarget) return
       const optConfigId = `optConfig_${optConfigInd++}`
       ;(good as any).optConfigs.push({ ...optConfig, id: optConfigId })
 
@@ -419,7 +419,8 @@ export function migrate(storage: DBStorage) {
         } = storage.get(key) as IGOCharacter
         const optConfig = storage.get(`buildSetting_${characterKey}`) ?? {}
         // Only migrate characters with either a mtarget or an opttarget
-        if (!customMultiTarget.length && !optConfig.optimizationTarget) continue
+        if (!customMultiTarget?.length && !optConfig.optimizationTarget)
+          continue
         const optConfigId = `optConfig_${optConfigInd++}`
         storage.set(optConfigId, optConfig)
 


### PR DESCRIPTION
## Describe your changes

V10 Migration creates a team+loadout for every character in db.
Amend logic to only create a team+loadout if that character had either mtargets or an opt-target selected. 
This should reduce some of the migration noise/cleanup. 
Teammate loadout for characters with mtargets/optargets are still created, to preserver teammate conditionals.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
