### PR TITLE
Fix formula text in tooltip

### DIFF
--- a/libs/gi/sheets/src/Weapons/Polearm/EngulfingLightning/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Polearm/EngulfingLightning/index.tsx
@@ -26,7 +26,8 @@ const atk_ = equal(
       sum(input.premod.enerRech_, percent(-1))
     ),
     subscript(input.weapon.refinement, atkMax)
-  )
+  ),
+  { pivot: true }
 )
 
 const enerRech = [-1, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55]

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -158,7 +158,7 @@ function computeFormulaDisplay(
   function addComponents(node: CalcResult<number>, p: number) {
     const display = getCalcDisplay(node)
     if (p > display.prec) components.push('(')
-    if (node.info.pivot && display.name)
+    if (display.name && (node.info.pivot || node.meta.op === 'const'))
       components.push(
         <>
           <span style={{ fontSize: '85%' }}>{display.name}</span>{' '}

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -202,16 +202,16 @@ function computeFormulaDisplay(
       const [preRes] = ops
       if (preRes.value >= 0.75) {
         result.prec = details.mul.prec
-        components.push('1 / (1 + 4 * ')
+        components.push('100% / (100% + 4 * ')
         addComponents(preRes, details.mul.prec)
         components.push(')')
       } else if (preRes.value >= 0) {
         result.prec = details.add.prec
-        components.push('1 - ')
+        components.push('100% - ')
         addComponents(preRes, details.add.prec)
       } else {
         result.prec = details.add.prec
-        components.push('1 - ')
+        components.push('100% - ')
         addComponents(preRes, details.mul.prec)
         components.push(' / 2')
       }

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -125,12 +125,6 @@ function _getCalcDisplay(
 
     if (node.info.pivot || node.meta.op === 'const') {
       result.prec = Infinity
-      result.formula = (
-        <>
-          <span style={{ fontSize: '85%' }}>{result.name}</span>{' '}
-          {result.valueString}
-        </>
-      )
 
       if (result.assignment) {
         result.formulas = [result.assignment, ...result.formulas]
@@ -164,7 +158,14 @@ function computeFormulaDisplay(
   function addComponents(node: CalcResult<number>, p: number) {
     const display = getCalcDisplay(node)
     if (p > display.prec) components.push('(')
-    components.push(display.formula)
+    if (node.info.pivot && display.name)
+      components.push(
+        <>
+          <span style={{ fontSize: '85%' }}>{display.name}</span>{' '}
+          {display.valueString}
+        </>
+      )
+    else components.push(display.formula)
     if (p > display.prec) components.push(')')
   }
 


### PR DESCRIPTION
## Describe your changes

Fix the CalcDisplay rules so that `formula` always contain node formula. Previously, it contains `name` of the nodes in specific cases.

## Issue or discord link

- https://discord.com/channels/785153694478893126/1232772226105737216

## Testing/validation

- n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
