### PR TITLE
Revert loadout setting page back to 2 columns

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/LoadoutSettingElement.tsx
@@ -34,7 +34,7 @@ import { CustomMultiTargetButton } from './CustomMultiTarget'
 import StatModal from './StatModal'
 
 // TODO: Translation
-const columns = { xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }
+const columns = { xs: 1, sm: 1, md: 2, lg: 2 }
 export default function LoadoutSettingElement() {
   const database = useDatabase()
   const { teamId, teamChar, teamCharId } = useContext(TeamCharacterContext)


### PR DESCRIPTION
## Describe your changes

To reduce the occurrence of weird layout squish like:
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/d3b8da33-5513-4a9a-b9a9-f4ff01680abf)

The real fix is probably reworking these elements, but aint nobody got time for that.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
