### PR TITLE
center elements in layout

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -139,7 +139,7 @@ function Content() {
       <Box
         display="flex"
         ref={ref}
-        justifyContent="space-between"
+        justifyContent="center"
         alignItems="flex-start"
       >
         {/* left Rail ad */}
@@ -159,7 +159,10 @@ function Content() {
           )}
         </Box>
         {/* Content */}
-        <Container maxWidth="xl" sx={{ px: { xs: 0.5, sm: 1 }, flexGrow: 1 }}>
+        <Container
+          maxWidth="xl"
+          sx={{ px: { xs: 0.5, sm: 1 }, flexGrow: 1, mx: 0 }}
+        >
           <Suspense
             fallback={
               <Skeleton


### PR DESCRIPTION
## Describe your changes

update layout where side-banners are being pushed to the side, to a more centered approach.

## Issue or discord link

Before
![Screenshot 2024-05-01 215818](https://github.com/frzyc/genshin-optimizer/assets/1754901/b87ab3ce-0bc5-45db-bdb2-45d1a5913614)

After
![Screenshot 2024-05-01 215656](https://github.com/frzyc/genshin-optimizer/assets/1754901/85e3bddd-a6be-4644-bc4a-6706d1940485)


## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
