### PR TITLE
Update SRO Header totals to change only on add/remove

### DIFF
--- a/apps/sr-frontend/src/app/Header.tsx
+++ b/apps/sr-frontend/src/app/Header.tsx
@@ -1,4 +1,3 @@
-import { useForceUpdate } from '@genshin-optimizer/common/react-util'
 import { AnvilIcon } from '@genshin-optimizer/common/svgicons'
 import { useDatabaseContext } from '@genshin-optimizer/sr/ui'
 import { Diamond, Menu as MenuIcon } from '@mui/icons-material'
@@ -23,7 +22,7 @@ import {
   useTheme,
 } from '@mui/material'
 import type { ReactElement, ReactNode } from 'react'
-import { Suspense, useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink, useMatch } from 'react-router-dom'
 
@@ -53,28 +52,29 @@ const lightCones: ITab = {
 
 function RelicChip() {
   const { database } = useDatabaseContext()
-  const [dirty, setDirty] = useForceUpdate()
+  const [total, setTotal] = useState(database.relics.keys.length)
   useEffect(
-    () => database.relics.followAny(() => setDirty()),
-    [database, setDirty]
-  )
-  const total = useMemo(
-    () => dirty && database.relics.keys.length,
-    [dirty, database]
+    () =>
+      database.relics.followAny(
+        (_k, r) =>
+          ['new', 'remove'].includes(r) && setTotal(database.relics.keys.length)
+      ),
+    [database]
   )
   return <Chip label={<strong>{total}</strong>} size="small" />
 }
 
 function LightConeChip() {
   const { database } = useDatabaseContext()
-  const [dirty, setDirty] = useForceUpdate()
+  const [total, setTotal] = useState(database.lightCones.keys.length)
   useEffect(
-    () => database.lightCones.followAny(() => setDirty()),
-    [database, setDirty]
-  )
-  const total = useMemo(
-    () => dirty && database.lightCones.keys.length,
-    [database, dirty]
+    () =>
+      database.lightCones.followAny(
+        (_k, r) =>
+          ['new', 'remove'].includes(r) &&
+          setTotal(database.lightCones.keys.length)
+      ),
+    [database]
   )
   return <Chip label={<strong>{total}</strong>} size="small" />
 }

--- a/libs/common/database/src/lib/DataManagerBase.ts
+++ b/libs/common/database/src/lib/DataManagerBase.ts
@@ -95,8 +95,8 @@ export class DataManagerBase<
       this.trigger(key, 'invalid', value)
       return false
     }
-    if (!old && notify) this.trigger(key, 'new', cached)
     this.setCached(key, cached)
+    if (!old && notify) this.trigger(key, 'new', cached)
     return true
   }
   setCached(key: CacheKey, cached: CacheValue) {


### PR DESCRIPTION
## Describe your changes
- Changes SRO Header tab totals to only update if 'add'/'remove' events occur
- Changes `DataManagerBase.set` to trigger `setCached` before notifying of 'new' event, instead of after

## Issue or discord link
Comes directly off of feedback from #2025, related to issue #2051

## Testing/validation
Add items to lightcones/relics and watch totals on Header tab to make sure it updates properly

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
