### PR TITLE
Team Setting refactor: resonance revamp, clickable team char

### DIFF
--- a/libs/gi/page-team/src/TeamSetting/ResonanceDisplay.tsx
+++ b/libs/gi/page-team/src/TeamSetting/ResonanceDisplay.tsx
@@ -1,0 +1,109 @@
+import {
+  CardThemed,
+  ColorText,
+  InfoTooltipInline,
+} from '@genshin-optimizer/common/ui'
+import type { Team } from '@genshin-optimizer/gi/db'
+import type { TeamCharacterContextObj } from '@genshin-optimizer/gi/db-ui'
+import { TeamCharacterContext, useTeam } from '@genshin-optimizer/gi/db-ui'
+import { resonanceSheets } from '@genshin-optimizer/gi/sheets'
+import type { dataContextObj } from '@genshin-optimizer/gi/ui'
+import { DataContext, DocumentDisplay } from '@genshin-optimizer/gi/ui'
+import { CardContent, CardHeader, Divider, Typography } from '@mui/material'
+import { useContext, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export function ResonanceDisplay({
+  teamId,
+  team,
+  dataContextValue,
+}: {
+  teamId: string
+  team: Team
+  dataContextValue?: dataContextObj
+}) {
+  const { t } = useTranslation('page_character')
+
+  const { loadoutData } = useTeam(teamId)!
+  const teamCount = loadoutData.reduce((a, t) => a + (t ? 1 : 0), 0)
+
+  // This context is only used by the ResonanceDisplay, which needs to attach conditional values to team data.
+  const teamCharContextObj = useMemo(
+    () =>
+      ({
+        teamId,
+        team,
+        teamCharId: '', // can be left blank since its only modifying team conditional
+        teamChar: {},
+      } as TeamCharacterContextObj),
+    [team, teamId]
+  )
+
+  return (
+    <CardThemed bgt="light">
+      <CardHeader
+        title={
+          <span>
+            {t('tabTeambuff.team_reso')}{' '}
+            <strong>
+              <ColorText color={teamCount >= 4 ? 'success' : 'warning'}>
+                ({teamCount}/4)
+              </ColorText>
+            </strong>{' '}
+            <InfoTooltipInline
+              title={<Typography>{t`tabTeambuff.resonance_tip`}</Typography>}
+            />
+          </span>
+        }
+        titleTypographyProps={{ variant: 'h6' }}
+      />
+
+      {dataContextValue && (
+        <>
+          <Divider />
+          <CardContent
+            sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
+          >
+            <DataContext.Provider value={dataContextValue}>
+              <TeamCharacterContext.Provider value={teamCharContextObj}>
+                <Content />
+              </TeamCharacterContext.Provider>
+            </DataContext.Provider>
+          </CardContent>
+        </>
+      )}
+    </CardThemed>
+  )
+}
+function Content() {
+  const { data } = useContext(DataContext)
+  const hasReso = resonanceSheets.some((res) => res.canShow(data))
+  return (
+    <>
+      {resonanceSheets.map((res, i) => {
+        const show = res.canShow(data)
+        if (!show && hasReso) return null
+        return (
+          <CardThemed key={i} sx={{ opacity: show ? 1 : 0.5 }}>
+            <CardHeader
+              title={
+                <span>
+                  {res.name}{' '}
+                  <InfoTooltipInline
+                    title={<Typography>{res.desc}</Typography>}
+                  />
+                </span>
+              }
+              action={res.icon}
+              titleTypographyProps={{ variant: 'subtitle2' }}
+            />
+            {res.canShow(data) && <Divider />}
+            {res.canShow(data) && (
+              <DocumentDisplay sections={res.sections} teamBuffOnly hideDesc />
+            )}
+          </CardThemed>
+        )
+      })}
+    </>
+  )
+}

--- a/libs/gi/page-team/src/TeamSetting/TeamComponents.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamComponents.tsx
@@ -1,11 +1,4 @@
-import {
-  CardThemed,
-  ColorText,
-  ImgIcon,
-  InfoTooltipInline,
-  SqBadge,
-} from '@genshin-optimizer/common/ui'
-import { objPathValue } from '@genshin-optimizer/common/util'
+import { CardThemed, ImgIcon, SqBadge } from '@genshin-optimizer/common/ui'
 import { artifactAsset } from '@genshin-optimizer/gi/assets'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
 import type {
@@ -43,7 +36,6 @@ import {
   AccordionSummary,
   Box,
   CardActionArea,
-  CardContent,
   Divider,
   Skeleton,
   Typography,

--- a/libs/gi/page-team/src/TeamSetting/TeamComponents.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamComponents.tsx
@@ -1,10 +1,4 @@
-import {
-  CardThemed,
-  ColorText,
-  ImgIcon,
-  InfoTooltipInline,
-  SqBadge,
-} from '@genshin-optimizer/common/ui'
+import { CardThemed, ImgIcon, SqBadge } from '@genshin-optimizer/common/ui'
 import { objPathValue } from '@genshin-optimizer/common/util'
 import { artifactAsset } from '@genshin-optimizer/gi/assets'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
@@ -22,11 +16,7 @@ import {
   useTeamChar,
 } from '@genshin-optimizer/gi/db-ui'
 import type { CharacterSheet } from '@genshin-optimizer/gi/sheets'
-import {
-  dataSetEffects,
-  getArtSheet,
-  resonanceSheets,
-} from '@genshin-optimizer/gi/sheets'
+import { dataSetEffects, getArtSheet } from '@genshin-optimizer/gi/sheets'
 import type { dataContextObj } from '@genshin-optimizer/gi/ui'
 import {
   ArtifactSetName,
@@ -46,15 +36,15 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
+  CardActionArea,
   CardContent,
-  CardHeader,
   Divider,
   Grid,
   Skeleton,
   Typography,
 } from '@mui/material'
 import { Suspense, useContext, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 
 export function TeamBuffDisplay() {
   const { data, compareData } = useContext(DataContext)
@@ -118,61 +108,6 @@ export function TeamBuffDisplay() {
     </Accordion>
   )
 }
-export function ResonanceDisplay({ teamId }: { teamId: string }) {
-  const { t } = useTranslation('page_character')
-  const { data } = useContext(DataContext)
-
-  const { loadoutData } = useTeam(teamId)!
-  const teamCount = loadoutData.reduce((a, t) => a + (t ? 1 : 0), 0)
-  return (
-    <>
-      <CardThemed bgt="light">
-        <CardHeader
-          title={
-            <span>
-              {t('tabTeambuff.team_reso')}{' '}
-              <strong>
-                <ColorText color={teamCount >= 4 ? 'success' : 'warning'}>
-                  ({teamCount}/4)
-                </ColorText>
-              </strong>{' '}
-              <InfoTooltipInline
-                title={<Typography>{t`tabTeambuff.resonance_tip`}</Typography>}
-              />
-            </span>
-          }
-          titleTypographyProps={{ variant: 'subtitle2' }}
-        />
-      </CardThemed>
-      {resonanceSheets.map((res, i) => (
-        <CardThemed
-          bgt="light"
-          key={i}
-          sx={{ opacity: res.canShow(data) ? 1 : 0.5 }}
-        >
-          <CardHeader
-            title={
-              <span>
-                {res.name}{' '}
-                <InfoTooltipInline
-                  title={<Typography>{res.desc}</Typography>}
-                />
-              </span>
-            }
-            action={res.icon}
-            titleTypographyProps={{ variant: 'subtitle2' }}
-          />
-          {res.canShow(data) && <Divider />}
-          {res.canShow(data) && (
-            <CardContent>
-              <DocumentDisplay sections={res.sections} teamBuffOnly hideDesc />
-            </CardContent>
-          )}
-        </CardThemed>
-      ))}
-    </>
-  )
-}
 export function TeammateDisplay({
   teamCharId,
   dataContextValue,
@@ -234,9 +169,15 @@ export function TeammateDisplay({
             }
           >
             <CardThemed bgt="light">
-              <CharacterCardHeader characterKey={characterKey}>
-                <CharacterCardHeaderContent characterKey={characterKey} />
-              </CharacterCardHeader>
+              <CardActionArea
+                component={Link}
+                to={`${characterKey}`}
+                onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+              >
+                <CharacterCardHeader characterKey={characterKey}>
+                  <CharacterCardHeaderContent characterKey={characterKey} />
+                </CharacterCardHeader>
+              </CardActionArea>
             </CardThemed>
 
             <EquipmentRow loadoutDatum={loadoutDatum} />

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -1,18 +1,13 @@
 import { TextFieldLazy } from '@genshin-optimizer/common/ui'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
-import type { TeamCharacterContextObj } from '@genshin-optimizer/gi/db-ui'
-import {
-  TeamCharacterContext,
-  useDBMeta,
-  useDatabase,
-} from '@genshin-optimizer/gi/db-ui'
+import { useDBMeta, useDatabase } from '@genshin-optimizer/gi/db-ui'
 import type { TeamData, dataContextObj } from '@genshin-optimizer/gi/ui'
 import {
+  AdCard,
   CharIconSide,
   CharacterName,
   CharacterSelectionModal,
-  DataContext,
   EnemyExpandCard,
   TeamInfoAlert,
 } from '@genshin-optimizer/gi/ui'
@@ -22,19 +17,13 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import type { ButtonProps } from '@mui/material'
-import {
-  Alert,
-  Box,
-  Button,
-  CardContent,
-  Grid,
-  Typography,
-} from '@mui/material'
+import { Alert, Box, Button, CardContent, Grid } from '@mui/material'
 import { Suspense, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import BuildDropdown from '../BuildDropdown'
 import { LoadoutDropdown } from '../LoadoutDropdown'
-import { ResonanceDisplay, TeammateDisplay } from './TeamComponents'
+import { ResonanceDisplay } from './ResonanceDisplay'
+import { TeammateDisplay } from './TeamComponents'
 
 // TODO: Translation
 export default function TeamSetting({
@@ -121,16 +110,11 @@ export default function TeamSetting({
         </Button>
       </Box>
       <EnemyExpandCard teamId={teamId} />
-      <Typography variant="h6">Team Editor</Typography>
-      <Alert severity="info">
-        The first character in the team receives any "active on-field character"
-        buffs, and cannot be empty.
-      </Alert>
-      <TeamCharacterSelector teamId={teamId} teamData={teamData} />
+      <TeamEditor teamId={teamId} teamData={teamData} />
     </CardContent>
   )
 }
-function TeamCharacterSelector({
+function TeamEditor({
   teamId,
   teamData,
 }: {
@@ -182,18 +166,6 @@ function TeamCharacterSelector({
     loadoutData[charSelectIndex as number]?.teamCharId
   )?.key
 
-  // This context is only used by the ResonanceDisplay, which needs to attach conditional values to team data.
-  const teamCharContextObj = useMemo(
-    () =>
-      ({
-        teamId,
-        team,
-        teamCharId: '', // can be left blank since its only modifying team conditional
-        teamChar: {},
-      } as TeamCharacterContextObj),
-    [team, teamId]
-  )
-
   const firstTeamCharId = loadoutData[0]?.teamCharId
   const firstTeamCharKey =
     firstTeamCharId && database.teamChars.get(firstTeamCharId)?.key
@@ -218,20 +190,23 @@ function TeamCharacterSelector({
           onSelect={onSelect}
         />
       </Suspense>
-      <Grid container columns={{ xs: 1, md: 3, lg: 5 }} spacing={2}>
-        <Grid
-          item
-          xs={1}
-          sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
-        >
-          {dataContextValue && (
-            <DataContext.Provider value={dataContextValue}>
-              <TeamCharacterContext.Provider value={teamCharContextObj}>
-                <ResonanceDisplay teamId={teamId} />
-              </TeamCharacterContext.Provider>
-            </DataContext.Provider>
-          )}
+      <Grid container columns={{ xs: 1, md: 2 }} spacing={2}>
+        <Grid item xs={1}>
+          <ResonanceDisplay
+            teamId={teamId}
+            team={team}
+            dataContextValue={dataContextValue}
+          />
         </Grid>
+        <Grid item xs={1}>
+          <AdCard dataAdSlot="5102492054" maxHeight={400} />
+        </Grid>
+      </Grid>
+      <Alert severity="info">
+        The first character in the team receives any "active on-field character"
+        buffs, and cannot be empty.
+      </Alert>
+      <Grid container columns={{ xs: 1, md: 2, lg: 4 }} spacing={2}>
         {loadoutData.map((loadoutDatum, ind) => (
           <Grid item xs={1} key={loadoutDatum?.teamCharId ?? ind}>
             {loadoutDatum ? (


### PR DESCRIPTION
## Describe your changes

- Move Resonance above teams, so team would not seem cramped with 5 columns. Revert to 4 columns.
- Resonance adopts to team resonance status, show possible resonance when team is not full.
- Since Resonance UI adds extra space between header and team, allow clicking on char card for #1688

## Issue or discord link

- Resolves https://github.com/frzyc/genshin-optimizer/issues/1778
- Resolves https://github.com/frzyc/genshin-optimizer/issues/1688

## Testing/validation

With resonance
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/93c33e24-1ffc-45c5-a29c-b73dbf206008)

No resonance
![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/8d16c1e0-20df-4c11-9d4e-149ffa45f033)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
