### PR TITLE
minor changes to opt tab

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BonusStatsCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BonusStatsCard.tsx
@@ -1,6 +1,10 @@
 import { CardThemed } from '@genshin-optimizer/common/ui'
 import { TeamCharacterContext } from '@genshin-optimizer/gi/db-ui'
-import { DataContext, NodeFieldDisplay } from '@genshin-optimizer/gi/ui'
+import {
+  DataContext,
+  FieldDisplayList,
+  NodeFieldDisplay,
+} from '@genshin-optimizer/gi/ui'
 import type { NumNode } from '@genshin-optimizer/gi/wr'
 import { uiInput as input } from '@genshin-optimizer/gi/wr'
 import { CardContent, Divider, Typography } from '@mui/material'
@@ -26,11 +30,11 @@ export default function BonusStatsCard() {
         >{t`bonusStats.title`}</Typography>
       </CardContent>
       <Divider />
-      <CardContent>
+      <FieldDisplayList bgt="light">
         {nodes.map((n) => (
           <NodeFieldDisplay key={JSON.stringify(n.info)} node={n} />
         ))}
-      </CardContent>
+      </FieldDisplayList>
     </CardThemed>
   )
 }

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptCharacterCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptCharacterCard.tsx
@@ -1,0 +1,40 @@
+import { CardThemed } from '@genshin-optimizer/common/ui'
+import type { CharacterKey } from '@genshin-optimizer/gi/consts'
+import {
+  CharacterCardEquipmentRow,
+  CharacterCardHeader,
+  CharacterCardHeaderContent,
+  CharacterCardStats,
+} from '@genshin-optimizer/gi/ui'
+import { Box, Skeleton } from '@mui/material'
+import { Suspense, memo } from 'react'
+
+export const OptCharacterCard = memo(function OptCharacterCard({
+  characterKey,
+}: {
+  characterKey: CharacterKey
+}) {
+  return (
+    <CardThemed bgt="light">
+      <Suspense
+        fallback={<Skeleton variant="rectangular" width="100%" height={600} />}
+      >
+        <CharacterCardHeader characterKey={characterKey}>
+          <CharacterCardHeaderContent characterKey={characterKey} />
+        </CharacterCardHeader>
+        <Box
+          sx={{
+            p: 1,
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+          }}
+        >
+          <CharacterCardEquipmentRow />
+        </Box>
+        <CharacterCardStats bgt="light" />
+      </Suspense>
+    </CardThemed>
+  )
+})

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/UseTeammateArt.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/UseTeammateArt.tsx
@@ -69,6 +69,7 @@ export const UseTeammateArt = memo(function UseTeammateArt({
                         flexDirection: 'column',
                         gap: 1,
                       }}
+                      key={loadoutDatum.teamCharId}
                     >
                       <Box display="flex" alignItems="center" gap={1}>
                         {characterKey && (

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -38,12 +38,9 @@ import { GOSolver, mergeBuilds, mergePlot } from '@genshin-optimizer/gi/solver'
 import { compactArtifacts, dynamicData } from '@genshin-optimizer/gi/solver-tc'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
 import {
+  AdCard,
   ArtifactLevelSlider,
   BuildDisplayItem,
-  CharacterCardEquipmentRow,
-  CharacterCardHeader,
-  CharacterCardHeaderContent,
-  CharacterCardStats,
   CharacterName,
   DataContext,
   GraphContext,
@@ -110,6 +107,7 @@ import BuildAlert from './Components/BuildAlert'
 import ChartCard from './Components/ChartCard'
 import ExcludeArt from './Components/ExcludeArt'
 import MainStatSelectionCard from './Components/MainStatSelectionCard'
+import { OptCharacterCard } from './Components/OptCharacterCard'
 import OptimizationTargetSelector from './Components/OptimizationTargetSelector'
 import StatFilterCard from './Components/StatFilterCard'
 import UseEquipped from './Components/UseEquipped'
@@ -560,7 +558,8 @@ export default function TabBuild() {
           flexDirection="column"
           gap={1}
         >
-          <CharacterCard characterKey={characterKey} />
+          <OptCharacterCard characterKey={characterKey} />
+          <BonusStatsCard />
         </Grid>
         {/* 2 */}
         <Grid
@@ -618,19 +617,6 @@ export default function TabBuild() {
               filteredArtIdMap={filteredArtIdMap}
             />
           </CardThemed>
-        </Grid>
-
-        {/* 3 */}
-        <Grid
-          item
-          xs={12}
-          sm={6}
-          lg={5}
-          display="flex"
-          flexDirection="column"
-          gap={1}
-        >
-          <ArtifactSetConfig disabled={generatingBuilds} />
 
           {/* use excluded */}
           <ExcludeArt
@@ -655,6 +641,19 @@ export default function TabBuild() {
           >
             {t`allowPartial`}
           </Button>
+        </Grid>
+
+        {/* 3 */}
+        <Grid
+          item
+          xs={12}
+          sm={6}
+          lg={5}
+          display="flex"
+          flexDirection="column"
+          gap={1}
+        >
+          <ArtifactSetConfig disabled={generatingBuilds} />
 
           {/* use equipped */}
           <UseEquipped
@@ -664,6 +663,7 @@ export default function TabBuild() {
 
           {/*Minimum Final Stat Filter */}
           <StatFilterCard disabled={generatingBuilds} />
+          <AdCard dataAdSlot="7724855772" />
         </Grid>
       </Grid>
       {/* Footer */}
@@ -671,7 +671,7 @@ export default function TabBuild() {
       <ButtonGroup>
         {!isSM && targetSelector}
         <DropdownButton
-          disabled={generatingBuilds || !characterKey}
+          disabled={generatingBuilds || !characterKey || !optimizationTarget}
           title={
             <Trans t={t} i18nKey="build" count={maxBuildsToShow}>
               {{ count: maxBuildsToShow }} Builds
@@ -698,7 +698,7 @@ export default function TabBuild() {
           ))}
         </DropdownButton>
         <DropdownButton
-          disabled={generatingBuilds || !characterKey}
+          disabled={generatingBuilds || !characterKey || !optimizationTarget}
           sx={{ borderRadius: '4px 0px 0px 4px' }}
           title={
             <Trans t={t} i18nKey="thread" count={maxWorkers}>
@@ -723,17 +723,20 @@ export default function TabBuild() {
             ))}
         </DropdownButton>
         <BootstrapTooltip placement="top" title={t`notifyTooltip`}>
-          <Button
-            sx={{ borderRadius: 0 }}
-            color="warning"
-            onClick={() => setnotification((n) => !n)}
-          >
-            {notification ? (
-              <NotificationsActiveIcon />
-            ) : (
-              <NotificationsOffIcon />
-            )}
-          </Button>
+          <Box>
+            <Button
+              sx={{ borderRadius: 0 }}
+              color="warning"
+              onClick={() => setnotification((n) => !n)}
+              disabled={!optimizationTarget}
+            >
+              {notification ? (
+                <NotificationsActiveIcon />
+              ) : (
+                <NotificationsOffIcon />
+              )}
+            </Button>
+          </Box>
         </BootstrapTooltip>
         <BootstrapTooltip
           placement="top"
@@ -766,64 +769,68 @@ export default function TabBuild() {
           {...{ status: buildStatus, characterName, maxBuildsToShow }}
         />
       )}
-      <Box>
-        <ChartCard
-          disabled={generatingBuilds || !optimizationTarget}
-          plotBase={plotBase}
-          setPlotBase={setPlotBase}
-          showTooltip={!optimizationTarget}
-        />
-      </Box>
-      <CardThemed bgt="light">
-        <CardContent>
-          <Box display="flex" alignItems="center" gap={1} mb={1}>
-            <Typography sx={{ flexGrow: 1 }}>
-              {builds ? (
-                <span>
-                  Showing{' '}
-                  <strong>
-                    {builds.length + (graphBuilds ? graphBuilds.length : 0)}
-                  </strong>{' '}
-                  build generated for {characterName}.{' '}
-                  {!!buildDate && (
-                    <span>
-                      Build generated on:{' '}
-                      <strong>{new Date(buildDate).toLocaleString()}</strong>
-                    </span>
-                  )}
-                </span>
-              ) : (
-                <span>Select a character to generate builds.</span>
-              )}
-            </Typography>
-            <Button
-              disabled={!builds.length}
-              color="error"
-              onClick={() => {
-                setGraphBuilds(undefined)
-                database.optConfigs.set(optConfigId, {
-                  builds: [],
-                  buildDate: 0,
-                })
-              }}
-            >
-              Clear Builds
-            </Button>
-          </Box>
-          <Grid container display="flex" spacing={1}>
-            <Grid item>
-              <HitModeToggle size="small" />
+      {optimizationTarget && (
+        <Box>
+          <ChartCard
+            disabled={generatingBuilds || !optimizationTarget}
+            plotBase={plotBase}
+            setPlotBase={setPlotBase}
+            showTooltip={!optimizationTarget}
+          />
+        </Box>
+      )}
+      {optimizationTarget && (
+        <CardThemed bgt="light">
+          <CardContent>
+            <Box display="flex" alignItems="center" gap={1} mb={1}>
+              <Typography sx={{ flexGrow: 1 }}>
+                {builds ? (
+                  <span>
+                    Showing{' '}
+                    <strong>
+                      {builds.length + (graphBuilds ? graphBuilds.length : 0)}
+                    </strong>{' '}
+                    build generated for {characterName}.{' '}
+                    {!!buildDate && (
+                      <span>
+                        Build generated on:{' '}
+                        <strong>{new Date(buildDate).toLocaleString()}</strong>
+                      </span>
+                    )}
+                  </span>
+                ) : (
+                  <span>Select a character to generate builds.</span>
+                )}
+              </Typography>
+              <Button
+                disabled={!builds.length}
+                color="error"
+                onClick={() => {
+                  setGraphBuilds(undefined)
+                  database.optConfigs.set(optConfigId, {
+                    builds: [],
+                    buildDate: 0,
+                  })
+                }}
+              >
+                Clear Builds
+              </Button>
+            </Box>
+            <Grid container display="flex" spacing={1}>
+              <Grid item>
+                <HitModeToggle size="small" />
+              </Grid>
+              <Grid item>
+                <ReactionToggle size="small" />
+              </Grid>
+              <Grid item flexGrow={1} />
+              <Grid item>
+                <CompareBtn />
+              </Grid>
             </Grid>
-            <Grid item>
-              <ReactionToggle size="small" />
-            </Grid>
-            <Grid item flexGrow={1} />
-            <Grid item>
-              <CompareBtn />
-            </Grid>
-          </Grid>
-        </CardContent>
-      </CardThemed>
+          </CardContent>
+        </CardThemed>
+      )}
 
       <OptimizationTargetContext.Provider value={optimizationTarget}>
         {graphBuilds && (
@@ -888,44 +895,6 @@ const LevelFilter = memo(function LevelFilter({
         disabled={disabled}
       />
     </CardThemed>
-  )
-})
-
-const CharacterCard = memo(function CharacterCard({
-  characterKey,
-}: {
-  characterKey: CharacterKey
-}) {
-  return (
-    <>
-      {/* character card */}
-      <Box>
-        <Suspense
-          fallback={
-            <Skeleton variant="rectangular" width="100%" height={600} />
-          }
-        >
-          <CardThemed bgt="light">
-            <CharacterCardHeader characterKey={characterKey}>
-              <CharacterCardHeaderContent characterKey={characterKey} />
-            </CharacterCardHeader>
-            <Box
-              sx={{
-                p: 1,
-                width: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 1,
-              }}
-            >
-              <CharacterCardEquipmentRow />
-              <CharacterCardStats />
-            </Box>
-          </CardThemed>
-        </Suspense>
-      </Box>
-      <BonusStatsCard />
-    </>
   )
 })
 

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -23,10 +23,6 @@ import {
   AddArtInfo,
   ArtifactEditor,
   ArtifactLevelSlider,
-  CharacterCardEquipmentRow,
-  CharacterCardHeader,
-  CharacterCardHeaderContent,
-  CharacterCardStats,
   DataContext,
   HitModeToggle,
   NoArtWarning,
@@ -62,6 +58,7 @@ import { Trans } from 'react-i18next'
 import ArtifactSetConfig from '../TabOptimize/Components/ArtifactSetConfig'
 import BonusStatsCard from '../TabOptimize/Components/BonusStatsCard'
 import MainStatSelectionCard from '../TabOptimize/Components/MainStatSelectionCard'
+import { OptCharacterCard } from '../TabOptimize/Components/OptCharacterCard'
 import OptimizationTargetSelector from '../TabOptimize/Components/OptimizationTargetSelector'
 import StatFilterCard from '../TabOptimize/Components/StatFilterCard'
 import UpgradeOptChartCard from './UpgradeOptChartCard'
@@ -379,37 +376,7 @@ export default function TabUpopt() {
                   gap={1}
                 >
                   {/* character card */}
-                  <Box>
-                    <Suspense
-                      fallback={
-                        <Skeleton
-                          variant="rectangular"
-                          width="100%"
-                          height={600}
-                        />
-                      }
-                    >
-                      <CardThemed bgt="light">
-                        <CharacterCardHeader characterKey={characterKey}>
-                          <CharacterCardHeaderContent
-                            characterKey={characterKey}
-                          />
-                        </CharacterCardHeader>
-                        <Box
-                          sx={{
-                            p: 1,
-                            width: '100%',
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 1,
-                          }}
-                        >
-                          <CharacterCardEquipmentRow />
-                          <CharacterCardStats />
-                        </Box>
-                      </CardThemed>
-                    </Suspense>
-                  </Box>
+                  <OptCharacterCard characterKey={characterKey} />
                   <BonusStatsCard />
                 </Grid>
 

--- a/libs/gi/ui/src/components/LocationIcon.tsx
+++ b/libs/gi/ui/src/components/LocationIcon.tsx
@@ -1,7 +1,7 @@
 import { BootstrapTooltip } from '@genshin-optimizer/common/ui'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import { useDBMeta } from '@genshin-optimizer/gi/db-ui'
-import { Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { CharIconSide, CharacterName } from './character'
 
 export function LocationIcon({
@@ -20,7 +20,9 @@ export function LocationIcon({
         </Typography>
       }
     >
-      <CharIconSide characterKey={characterKey} sideMargin />
+      <Box>
+        <CharIconSide characterKey={characterKey} sideMargin />
+      </Box>
     </BootstrapTooltip>
   )
 }

--- a/libs/gi/ui/src/components/artifact/ArtifactCardNano.tsx
+++ b/libs/gi/ui/src/components/artifact/ArtifactCardNano.tsx
@@ -25,8 +25,8 @@ import {
 } from '@mui/material'
 import type { ReactNode } from 'react'
 import { useCallback } from 'react'
-import { LocationIcon } from '../LocationIcon'
 import { StatColoredWithUnit } from '../StatDisplay'
+import { CharIconSide } from '../character'
 import { ArtifactTooltip } from './ArtifactTooltip'
 import { artifactLevelVariant } from './util'
 
@@ -128,11 +128,11 @@ export function ArtifactCardNano({
                 size="small"
                 label={
                   location ? (
-                    <LocationIcon
-                      characterKey={
-                        location &&
-                        database.chars.LocationToCharacterKey(location)
-                      }
+                    <CharIconSide
+                      characterKey={database.chars.LocationToCharacterKey(
+                        location
+                      )}
+                      sideMargin
                     />
                   ) : (
                     <BusinessCenterIcon />

--- a/libs/gi/ui/src/components/artifact/ArtifactTooltip.tsx
+++ b/libs/gi/ui/src/components/artifact/ArtifactTooltip.tsx
@@ -25,13 +25,14 @@ export function ArtifactTooltip({
   art: ICachedArtifact
   children: JSX.Element
 }) {
-  const fallback = (
-    <Box>
-      <Skeleton variant="rectangular" width={100} height={100} />
-    </Box>
-  )
   const title = (
-    <Suspense fallback={fallback}>
+    <Suspense
+      fallback={
+        <Box>
+          <Skeleton variant="rectangular" width={100} height={100} />
+        </Box>
+      }
+    >
       <ArtifactData art={art} />
     </Suspense>
   )

--- a/libs/gi/ui/src/components/character/card/CharacterCardStats.tsx
+++ b/libs/gi/ui/src/components/character/card/CharacterCardStats.tsx
@@ -1,28 +1,29 @@
+import type { CardBackgroundColor } from '@genshin-optimizer/common/ui'
 import { input } from '@genshin-optimizer/gi/wr'
-import { Box, Typography } from '@mui/material'
+import { ListItem, Typography } from '@mui/material'
 import { useContext } from 'react'
 import { DataContext } from '../../../context'
 import { resolveInfo } from '../../../util'
-import { NodeFieldDisplay } from '../../FieldDisplay'
+import { FieldDisplayList, NodeFieldDisplay } from '../../FieldDisplay'
 
-export function CharacterCardStats() {
+export function CharacterCardStats({ bgt }: { bgt?: CardBackgroundColor }) {
   const { data } = useContext(DataContext)
   const specialNode = data.get(input.special)
   const { name, icon } = resolveInfo(specialNode.info)
   return (
-    <Box sx={{ width: '100%' }}>
+    <FieldDisplayList bgt={bgt} sx={{ width: '100%', borderRadius: 0 }}>
       {Object.values(data.getDisplay()['basic']).map((n) => (
         <NodeFieldDisplay key={JSON.stringify(n.info)} node={n} />
       ))}
       {name && (
-        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <ListItem sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
           <Typography flexGrow={1}>
             <strong>Specialized:</strong>
           </Typography>
           {icon}
           <Typography>{name}</Typography>
-        </Box>
+        </ListItem>
       )}
-    </Box>
+    </FieldDisplayList>
   )
 }

--- a/libs/gi/ui/src/components/weapon/WeaponCardNano.tsx
+++ b/libs/gi/ui/src/components/weapon/WeaponCardNano.tsx
@@ -18,7 +18,7 @@ import { Box, CardActionArea, Chip, Typography } from '@mui/material'
 import type { ReactNode } from 'react'
 import { useCallback, useMemo } from 'react'
 import { getCalcDisplay, resolveInfo } from '../../util'
-import { LocationIcon } from '../LocationIcon'
+import { CharIconSide } from '../character'
 import { WeaponNameTooltip } from './WeaponNameTooltip'
 
 type Data = {
@@ -140,10 +140,11 @@ export function WeaponCardNanoObj({
                 size="small"
                 label={
                   location ? (
-                    <LocationIcon
+                    <CharIconSide
                       characterKey={database.chars.LocationToCharacterKey(
                         location
                       )}
+                      sideMargin
                     />
                   ) : (
                     <BusinessCenterIcon />

--- a/libs/gi/ui/src/components/weapon/WeaponNameTooltip.tsx
+++ b/libs/gi/ui/src/components/weapon/WeaponNameTooltip.tsx
@@ -2,7 +2,7 @@ import { BootstrapTooltip, ImgIcon } from '@genshin-optimizer/common/ui'
 import { imgAssets } from '@genshin-optimizer/gi/assets'
 import type { WeaponKey } from '@genshin-optimizer/gi/consts'
 import { getWeaponStat } from '@genshin-optimizer/gi/stats'
-import { Skeleton, Typography } from '@mui/material'
+import { Box, Skeleton, Typography } from '@mui/material'
 import type { ReactElement, ReactNode } from 'react'
 import { Suspense } from 'react'
 import { WeaponName } from './WeaponTrans'
@@ -15,14 +15,16 @@ type Data = {
 export function WeaponNameTooltip({ weaponKey, addlText, children }: Data) {
   const title = (
     <Suspense fallback={<Skeleton variant="text" width={100} />}>
-      <Typography>
-        <ImgIcon
-          src={imgAssets.weaponTypes[getWeaponStat(weaponKey).weaponType]}
-          size={1.5}
-        />{' '}
-        <WeaponName weaponKey={weaponKey} />
-      </Typography>
-      {addlText}
+      <Box>
+        <Typography>
+          <ImgIcon
+            src={imgAssets.weaponTypes[getWeaponStat(weaponKey).weaponType]}
+            size={1.5}
+          />{' '}
+          <WeaponName weaponKey={weaponKey} />
+        </Typography>
+        {addlText}
+      </Box>
     </Suspense>
   )
   return (


### PR DESCRIPTION
## Describe your changes

- Standardized stat display across opt tab and upopt tab
  - Refactor character card's stat display to use `FieldDisplayList`
  - Refactor Bonus Stat stat display to use `FieldDisplayList`
- Add a above-the-fold in-content Ad
- Hide/disable elements when opt target is not selected
  - Disable build/threads/notification icon 
  - Hide Graph/Display UI

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
### Before
<img width="1146" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/33944fc1-d02b-44b5-8b07-9f659abe4ad7">

### After

![Screenshot 2024-05-04 135409](https://github.com/frzyc/genshin-optimizer/assets/1754901/03a95a2a-f655-4a67-8b0e-275af7114931)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
