### PR TITLE
Tallies added for teams and loadouts

### DIFF
--- a/libs/gi/localization/assets/locales/en/settings.json
+++ b/libs/gi/localization/assets/locales/en/settings.json
@@ -15,6 +15,8 @@
     "chars": "Characters:",
     "arts": "Artifacts:",
     "weapons": "Weapons:",
+    "teams": "Teams:",
+    "loadouts": "Loadouts:",
     "total": "Total:",
     "new": "New:",
     "updated": "Updated:",

--- a/libs/gi/localization/assets/locales/en/settings.json
+++ b/libs/gi/localization/assets/locales/en/settings.json
@@ -17,6 +17,7 @@
     "weapons": "Weapons:",
     "teams": "Teams:",
     "loadouts": "Loadouts:",
+    "builds": "Builds: ",
     "total": "Total:",
     "new": "New:",
     "updated": "Updated:",

--- a/libs/gi/ui/src/components/database/DatabaseCard.tsx
+++ b/libs/gi/ui/src/components/database/DatabaseCard.tsx
@@ -174,16 +174,12 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
               <strong>{numWeapon}</strong>
             </Typography>
             <Typography noWrap>
-              <Trans t={t} i18nKey="Teams" /> <strong>{numTeams}</strong>
+              <Trans t={t} i18nKey="count.teams" /> <strong>{numTeams}</strong>
             </Typography>
             <Typography noWrap>
-              <Trans t={t} i18nKey="Loadouts" /> <strong>{numLoadouts}</strong>
+              <Trans t={t} i18nKey="count.loadouts" /> <strong>{numLoadouts}</strong>
             </Typography>
-            {!!lastEdit && (
-              <Typography noWrap>
-                <strong>{new Date(lastEdit).toLocaleString()}</strong>
-              </Typography>
-            )}
+
           </Box>
           <Box>
             <Grid container spacing={1} columns={{ xs: 2 }}>
@@ -235,6 +231,11 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
                 </Button>
               </Grid>
             </Grid>
+            {!!lastEdit && (
+              <Typography noWrap align="center" style={{ paddingTop: '1em' }}>
+                <strong>{new Date(lastEdit).toLocaleString()}</strong>
+              </Typography>
+            )}
           </Box>
         </Box>
       </CardContent>

--- a/libs/gi/ui/src/components/database/DatabaseCard.tsx
+++ b/libs/gi/ui/src/components/database/DatabaseCard.tsx
@@ -63,7 +63,17 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
   const numChar = database.chars.keys.length
   const numArt = database.arts.values.length
   const numWeapon = database.weapons.values.length
-  const hasData = Boolean(numChar || numArt || numWeapon)
+  const numTeams = database.teams.values.length
+  let numLoadouts = 0;
+  const loadoutTeamMap: Record<string, string[]> = {};
+  database.teamChars.entries.forEach(([id]) => loadoutTeamMap[id] = loadoutTeamMap[id] || []);
+  database.teams.entries.forEach(([teamId, { loadoutData }]) => {
+    const teamCharId = loadoutData.find(Boolean)?.teamCharId;
+    if (teamCharId) loadoutTeamMap[teamCharId].push(teamId);
+  });
+  Object.entries(loadoutTeamMap).forEach(() => numLoadouts += 1);
+
+  const hasData = Boolean(numChar || numArt || numWeapon || numTeams || numLoadouts)
   const copyToClipboard = useCallback(
     () =>
       navigator.clipboard
@@ -162,6 +172,12 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
             <Typography noWrap>
               <Trans t={t} i18nKey="count.weapons" />{' '}
               <strong>{numWeapon}</strong>
+            </Typography>
+            <Typography noWrap>
+              <Trans t={t} i18nKey="Teams" /> <strong>{numTeams}</strong>
+            </Typography>
+            <Typography noWrap>
+              <Trans t={t} i18nKey="Loadouts" /> <strong>{numLoadouts}</strong>
             </Typography>
             {!!lastEdit && (
               <Typography noWrap>

--- a/libs/gi/ui/src/components/database/DatabaseCard.tsx
+++ b/libs/gi/ui/src/components/database/DatabaseCard.tsx
@@ -17,7 +17,7 @@ import {
   Grid,
   Typography,
 } from '@mui/material'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { UploadCard } from './UploadCard'
 
@@ -63,22 +63,7 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
   const numChar = database.chars.keys.length
   const numArt = database.arts.values.length
   const numWeapon = database.weapons.values.length
-  const numTeams = database.teams.values.length
-
-
-
-  let numLoadouts = 0;
-  const loadoutTeamMap: Record<string, string[]> = {};
-
-  database.teamChars.entries.forEach(([id]) => loadoutTeamMap[id] = loadoutTeamMap[id] || []);
-  database.teams.entries.forEach(([teamId, { loadoutData }]) => {
-    const teamCharId = loadoutData.find(Boolean)?.teamCharId;
-    if (teamCharId) loadoutTeamMap[teamCharId].push(teamId);
-  });
-
-  Object.entries(loadoutTeamMap).forEach(() => numLoadouts += 1);
-
-  const hasData = Boolean(numChar || numArt || numWeapon || numTeams || numLoadouts)
+  const hasData = Boolean(numChar || numArt || numWeapon)
   const copyToClipboard = useCallback(
     () =>
       navigator.clipboard
@@ -177,12 +162,6 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
             <Typography noWrap>
               <Trans t={t} i18nKey="count.weapons" />{' '}
               <strong>{numWeapon}</strong>
-            </Typography>
-            <Typography noWrap>
-              <Trans t={t} i18nKey="Teams" /> <strong>{numTeams}</strong>
-            </Typography>
-            <Typography noWrap>
-              <Trans t={t} i18nKey="Active Loadouts" /> <strong>{numLoadouts}</strong>
             </Typography>
             {!!lastEdit && (
               <Typography noWrap>

--- a/libs/gi/ui/src/components/database/DatabaseCard.tsx
+++ b/libs/gi/ui/src/components/database/DatabaseCard.tsx
@@ -64,16 +64,11 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
   const numArt = database.arts.values.length
   const numWeapon = database.weapons.values.length
   const numTeams = database.teams.values.length
-  let numLoadouts = 0;
-  const loadoutTeamMap: Record<string, string[]> = {};
-  database.teamChars.entries.forEach(([id]) => loadoutTeamMap[id] = loadoutTeamMap[id] || []);
-  database.teams.entries.forEach(([teamId, { loadoutData }]) => {
-    const teamCharId = loadoutData.find(Boolean)?.teamCharId;
-    if (teamCharId) loadoutTeamMap[teamCharId].push(teamId);
-  });
-  Object.entries(loadoutTeamMap).forEach(() => numLoadouts += 1);
-
-  const hasData = Boolean(numChar || numArt || numWeapon || numTeams || numLoadouts)
+  const numLoadouts = database.teamChars.values.length
+  const numBuilds = database.builds.values.length
+  const hasData = Boolean(
+    numChar || numArt || numWeapon || numTeams || numLoadouts || numBuilds
+  )
   const copyToClipboard = useCallback(
     () =>
       navigator.clipboard
@@ -177,9 +172,13 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
               <Trans t={t} i18nKey="count.teams" /> <strong>{numTeams}</strong>
             </Typography>
             <Typography noWrap>
-              <Trans t={t} i18nKey="count.loadouts" /> <strong>{numLoadouts}</strong>
+              <Trans t={t} i18nKey="count.loadouts" />{' '}
+              <strong>{numLoadouts}</strong>
             </Typography>
-
+            <Typography noWrap>
+              <Trans t={t} i18nKey="count.builds" />{' '}
+              <strong>{numBuilds}</strong>
+            </Typography>
           </Box>
           <Box>
             <Grid container spacing={1} columns={{ xs: 2 }}>
@@ -232,7 +231,7 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
               </Grid>
             </Grid>
             {!!lastEdit && (
-              <Typography noWrap align="center" style={{ paddingTop: '1em' }}>
+              <Typography noWrap align="center" style={{ paddingTop: '1.5em' }}>
                 <strong>{new Date(lastEdit).toLocaleString()}</strong>
               </Typography>
             )}

--- a/libs/gi/ui/src/components/database/DatabaseCard.tsx
+++ b/libs/gi/ui/src/components/database/DatabaseCard.tsx
@@ -17,7 +17,7 @@ import {
   Grid,
   Typography,
 } from '@mui/material'
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { UploadCard } from './UploadCard'
 
@@ -63,7 +63,22 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
   const numChar = database.chars.keys.length
   const numArt = database.arts.values.length
   const numWeapon = database.weapons.values.length
-  const hasData = Boolean(numChar || numArt || numWeapon)
+  const numTeams = database.teams.values.length
+
+
+
+  let numLoadouts = 0;
+  const loadoutTeamMap: Record<string, string[]> = {};
+
+  database.teamChars.entries.forEach(([id]) => loadoutTeamMap[id] = loadoutTeamMap[id] || []);
+  database.teams.entries.forEach(([teamId, { loadoutData }]) => {
+    const teamCharId = loadoutData.find(Boolean)?.teamCharId;
+    if (teamCharId) loadoutTeamMap[teamCharId].push(teamId);
+  });
+
+  Object.entries(loadoutTeamMap).forEach(() => numLoadouts += 1);
+
+  const hasData = Boolean(numChar || numArt || numWeapon || numTeams || numLoadouts)
   const copyToClipboard = useCallback(
     () =>
       navigator.clipboard
@@ -162,6 +177,12 @@ function DataCard({ index, readOnly }: { index: number; readOnly: boolean }) {
             <Typography noWrap>
               <Trans t={t} i18nKey="count.weapons" />{' '}
               <strong>{numWeapon}</strong>
+            </Typography>
+            <Typography noWrap>
+              <Trans t={t} i18nKey="Teams" /> <strong>{numTeams}</strong>
+            </Typography>
+            <Typography noWrap>
+              <Trans t={t} i18nKey="Active Loadouts" /> <strong>{numLoadouts}</strong>
             </Typography>
             {!!lastEdit && (
               <Typography noWrap>


### PR DESCRIPTION
## Describe your changes

Added a tally when looking at databases for the number of teams and loadouts.

## Issue or discord link

https://github.com/frzyc/genshin-optimizer/issues/2040

## Testing/validation

BEFORE
![image](https://github.com/frzyc/genshin-optimizer/assets/111794367/b2fcfdf2-3082-4c54-bd9e-1bb2a2858530)
AFTER
![image](https://github.com/frzyc/genshin-optimizer/assets/111794367/2df8ddf4-0413-4692-a20c-c439ee3ae648)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ x ] I have commented my code in hard-to understand areas.
- [  ] I have made corresponding changes to README or wiki.
- [  ] For front-end changes, I have updated the corresponding English translations.
- [ x ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ x ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
