### PR TITLE
Port DB UI entries for characters, relics, and lightcones to SRO

### DIFF
--- a/libs/sr/db/src/Database/DataEntries/DisplayCharacterEntry.ts
+++ b/libs/sr/db/src/Database/DataEntries/DisplayCharacterEntry.ts
@@ -1,0 +1,70 @@
+import { validateArr } from '@genshin-optimizer/common/util'
+import type {
+  ElementalTypeKey,
+  PathKey,
+  RarityKey,
+} from '@genshin-optimizer/sr/consts'
+import {
+  allElementalTypeKeys,
+  allPathKeys,
+  allRarityKeys,
+} from '@genshin-optimizer/sr/consts'
+import { DataEntry } from '../DataEntry'
+import type { SroDatabase } from '../Database'
+
+export const characterSortKeys = [
+  'new',
+  'level',
+  'rarity',
+  'name',
+  'favorite',
+] as const
+export type CharacterSortKey = (typeof characterSortKeys)[number]
+
+export interface IDisplayCharacterEntry {
+  sortType: CharacterSortKey
+  ascending: boolean
+  path: PathKey[]
+  elementalType: ElementalTypeKey[]
+  rarity: RarityKey[]
+}
+
+const initialState = (): IDisplayCharacterEntry => ({
+  sortType: 'level',
+  ascending: false,
+  path: [...allPathKeys],
+  elementalType: [...allElementalTypeKeys],
+  rarity: [...allRarityKeys],
+})
+
+export class DisplayCharacterEntry extends DataEntry<
+  'display_character',
+  'display_character',
+  IDisplayCharacterEntry,
+  IDisplayCharacterEntry
+> {
+  constructor(database: SroDatabase) {
+    super(database, 'display_character', initialState, 'display_character')
+  }
+  override validate(obj: any): IDisplayCharacterEntry | undefined {
+    if (typeof obj !== 'object') return undefined
+    let { sortType, ascending, path, elementalType, rarity } = obj
+
+    //Disallow sorting by "new" explicitly.
+    if (sortType === 'new' || !characterSortKeys.includes(sortType))
+      sortType = 'level'
+    if (typeof ascending !== 'boolean') ascending = false
+    path = validateArr(path, allPathKeys)
+    elementalType = validateArr(elementalType, allElementalTypeKeys)
+    rarity = validateArr(rarity, allRarityKeys)
+
+    const data: IDisplayCharacterEntry = {
+      sortType,
+      ascending,
+      path,
+      elementalType,
+      rarity,
+    }
+    return data
+  }
+}

--- a/libs/sr/db/src/Database/DataEntries/DisplayLightConeEntry.ts
+++ b/libs/sr/db/src/Database/DataEntries/DisplayLightConeEntry.ts
@@ -6,7 +6,6 @@ import type { SroDatabase } from '../Database'
 export const lightConeSortKeys = ['level', 'rarity', 'name'] as const
 export type LightConeSortKey = (typeof lightConeSortKeys)[number]
 export interface IDisplayLightCone {
-  editLightConeId: string
   sortType: LightConeSortKey
   ascending: boolean
   rarity: RarityKey[]
@@ -14,7 +13,6 @@ export interface IDisplayLightCone {
 }
 
 const initialState = () => ({
-  editLightConeId: '',
   sortType: lightConeSortKeys[0],
   ascending: false,
   rarity: [...allRarityKeys],
@@ -33,8 +31,6 @@ export class DisplayLightConeEntry extends DataEntry<
   override validate(obj: any): IDisplayLightCone | undefined {
     if (typeof obj !== 'object') return undefined
     let { sortType, ascending, rarity, path } = obj
-    const { editLightConeId } = obj
-    if (typeof editLightConeId !== 'string') return editLightConeId
     if (
       typeof sortType !== 'string' ||
       !lightConeSortKeys.includes(sortType as any)
@@ -46,7 +42,6 @@ export class DisplayLightConeEntry extends DataEntry<
     if (!Array.isArray(path)) path = [...allPathKeys]
     else path = path.filter((r) => allPathKeys.includes(r))
     const data: IDisplayLightCone = {
-      editLightConeId,
       sortType,
       ascending,
       rarity,

--- a/libs/sr/db/src/Database/DataEntries/DisplayLightConeEntry.ts
+++ b/libs/sr/db/src/Database/DataEntries/DisplayLightConeEntry.ts
@@ -1,0 +1,57 @@
+import type { PathKey, RarityKey } from '@genshin-optimizer/sr/consts'
+import { allPathKeys, allRarityKeys } from '@genshin-optimizer/sr/consts'
+import { DataEntry } from '../DataEntry'
+import type { SroDatabase } from '../Database'
+
+export const lightConeSortKeys = ['level', 'rarity', 'name'] as const
+export type LightConeSortKey = (typeof lightConeSortKeys)[number]
+export interface IDisplayLightCone {
+  editLightConeId: string
+  sortType: LightConeSortKey
+  ascending: boolean
+  rarity: RarityKey[]
+  path: PathKey[]
+}
+
+const initialState = () => ({
+  editLightConeId: '',
+  sortType: lightConeSortKeys[0],
+  ascending: false,
+  rarity: [...allRarityKeys],
+  path: [...allPathKeys],
+})
+
+export class DisplayLightConeEntry extends DataEntry<
+  'display_lightcone',
+  'display_lightcone',
+  IDisplayLightCone,
+  IDisplayLightCone
+> {
+  constructor(database: SroDatabase) {
+    super(database, 'display_lightcone', initialState, 'display_lightcone')
+  }
+  override validate(obj: any): IDisplayLightCone | undefined {
+    if (typeof obj !== 'object') return undefined
+    let { sortType, ascending, rarity, path } = obj
+    const { editLightConeId } = obj
+    if (typeof editLightConeId !== 'string') return editLightConeId
+    if (
+      typeof sortType !== 'string' ||
+      !lightConeSortKeys.includes(sortType as any)
+    )
+      sortType = lightConeSortKeys[0]
+    if (typeof ascending !== 'boolean') ascending = false
+    if (!Array.isArray(rarity)) rarity = [...allRarityKeys]
+    else rarity = rarity.filter((r) => allRarityKeys.includes(r))
+    if (!Array.isArray(path)) path = [...allPathKeys]
+    else path = path.filter((r) => allPathKeys.includes(r))
+    const data: IDisplayLightCone = {
+      editLightConeId,
+      sortType,
+      ascending,
+      rarity,
+      path,
+    }
+    return data
+  }
+}

--- a/libs/sr/db/src/Database/DataEntries/DisplayRelicEntry.ts
+++ b/libs/sr/db/src/Database/DataEntries/DisplayRelicEntry.ts
@@ -72,7 +72,7 @@ export function initialFilterOption(): FilterOption {
     showInventory: true,
     locked: ['locked', 'unlocked'],
     rvLow: 0,
-    rvHigh: 900,
+    rvHigh: 900, // TODO: Figure out RVs for SRO
     useMaxRV: false,
     lines: [1, 2, 3, 4],
   }
@@ -138,7 +138,7 @@ export class DisplayRelicEntry extends DataEntry<
       locked = validateArr(locked, ['locked', 'unlocked'])
 
       if (typeof rvLow !== 'number') rvLow = 0
-      if (typeof rvHigh !== 'number') rvHigh = 900
+      if (typeof rvHigh !== 'number') rvHigh = 900 // TODO: Figure out RVs for SRO
 
       if (typeof useMaxRV !== 'boolean') useMaxRV = false
 

--- a/libs/sr/db/src/Database/DataEntries/DisplayRelicEntry.ts
+++ b/libs/sr/db/src/Database/DataEntries/DisplayRelicEntry.ts
@@ -1,0 +1,197 @@
+import {
+  clamp,
+  validateArr,
+  validateObject,
+} from '@genshin-optimizer/common/util'
+import type {
+  LocationKey,
+  RelicMainStatKey,
+  RelicRarityKey,
+  RelicSetKey,
+  RelicSlotKey,
+  RelicSubStatKey,
+} from '@genshin-optimizer/sr/consts'
+import {
+  allLocationKeys,
+  allRelicRarityKeys,
+  allRelicSetKeys,
+  allRelicSlotKeys,
+  allRelicSubStatKeys,
+} from '@genshin-optimizer/sr/consts'
+
+import { DataEntry } from '../DataEntry'
+import type { SroDatabase } from '../Database'
+
+export const relicSortKeys = [
+  'rarity',
+  'level',
+  'relicsetkey',
+  'efficiency',
+  'mefficiency',
+  'probability',
+] as const
+export type RelicSortKey = (typeof relicSortKeys)[number]
+
+export type FilterOption = {
+  relicSetKeys: RelicSetKey[]
+  rarity: RelicRarityKey[]
+  levelLow: number
+  levelHigh: number
+  slotKeys: RelicSlotKey[]
+  mainStatKeys: RelicMainStatKey[]
+  substats: RelicSubStatKey[]
+  locations: LocationKey[]
+  showEquipped: boolean
+  showInventory: boolean
+  locked: Array<'locked' | 'unlocked'>
+  rvLow: number
+  rvHigh: number
+  useMaxRV: boolean
+  lines: Array<1 | 2 | 3 | 4>
+}
+
+export type IDisplayRelic = {
+  filterOption: FilterOption
+  ascending: boolean
+  sortType: RelicSortKey
+  effFilter: RelicSubStatKey[]
+  probabilityFilter: Partial<Record<RelicSubStatKey, number>>
+}
+
+export function initialFilterOption(): FilterOption {
+  return {
+    relicSetKeys: [],
+    rarity: [...allRelicRarityKeys],
+    levelLow: 0,
+    levelHigh: 15,
+    slotKeys: [...allRelicSlotKeys],
+    mainStatKeys: [],
+    substats: [],
+    locations: [],
+    showEquipped: true,
+    showInventory: true,
+    locked: ['locked', 'unlocked'],
+    rvLow: 0,
+    rvHigh: 900,
+    useMaxRV: false,
+    lines: [1, 2, 3, 4],
+  }
+}
+
+function initialState(): IDisplayRelic {
+  return {
+    filterOption: initialFilterOption(),
+    ascending: false,
+    sortType: relicSortKeys[0],
+    effFilter: [...allRelicSubStatKeys],
+    probabilityFilter: {},
+  }
+}
+
+export class DisplayRelicEntry extends DataEntry<
+  'display_relic',
+  'display_relic',
+  IDisplayRelic,
+  IDisplayRelic
+> {
+  constructor(database: SroDatabase) {
+    super(database, 'display_relic', initialState, 'display_relic')
+  }
+  override validate(obj: unknown): IDisplayRelic | undefined {
+    if (typeof obj !== 'object') return undefined
+    let { filterOption, ascending, sortType, effFilter, probabilityFilter } =
+      obj as IDisplayRelic
+
+    if (typeof filterOption !== 'object') filterOption = initialFilterOption()
+    else {
+      let {
+        relicSetKeys,
+        rarity,
+        levelLow,
+        levelHigh,
+        slotKeys,
+        mainStatKeys,
+        substats,
+        locations,
+        showEquipped,
+        showInventory,
+        locked,
+        rvLow,
+        rvHigh,
+        useMaxRV,
+        lines,
+      } = filterOption
+      relicSetKeys = validateArr(relicSetKeys, allRelicSetKeys, [])
+      rarity = validateArr(rarity, allRelicRarityKeys)
+
+      if (typeof levelLow !== 'number') levelLow = 0
+      else levelLow = clamp(levelLow, 0, 15)
+      if (typeof levelHigh !== 'number') levelHigh = 0
+      else levelHigh = clamp(levelHigh, 0, 15)
+
+      slotKeys = validateArr(slotKeys, allRelicSlotKeys)
+      mainStatKeys = validateArr(mainStatKeys, mainStatKeys, [])
+      substats = validateArr(substats, allRelicSubStatKeys, [])
+      locations = validateArr(locations, allLocationKeys, [])
+      if (typeof showEquipped !== 'boolean') showEquipped = true
+      if (typeof showInventory !== 'boolean') showInventory = true
+      locked = validateArr(locked, ['locked', 'unlocked'])
+
+      if (typeof rvLow !== 'number') rvLow = 0
+      if (typeof rvHigh !== 'number') rvHigh = 900
+
+      if (typeof useMaxRV !== 'boolean') useMaxRV = false
+
+      lines = validateArr(lines, [1, 2, 3, 4])
+
+      filterOption = {
+        relicSetKeys,
+        rarity,
+        levelLow,
+        levelHigh,
+        slotKeys,
+        mainStatKeys,
+        substats,
+        locations,
+        showEquipped,
+        showInventory,
+        locked,
+        rvLow,
+        rvHigh,
+        useMaxRV,
+        lines,
+      } as FilterOption
+    }
+
+    if (typeof ascending !== 'boolean') ascending = false
+    if (!relicSortKeys.includes(sortType)) sortType = relicSortKeys[0]
+
+    effFilter = validateArr(effFilter, allRelicSubStatKeys)
+
+    probabilityFilter = validateObject(
+      probabilityFilter,
+      (k) => allRelicSubStatKeys.includes(k as RelicSubStatKey),
+      (e) => typeof e === 'number'
+    )
+
+    return {
+      filterOption,
+      ascending,
+      sortType,
+      effFilter,
+      probabilityFilter,
+    } as IDisplayRelic
+  }
+  override set(
+    value:
+      | Partial<IDisplayRelic>
+      | ((v: IDisplayRelic) => Partial<IDisplayRelic> | void)
+      | { action: 'reset' }
+  ): boolean {
+    if ('action' in value) {
+      if (value.action === 'reset')
+        return super.set({ filterOption: initialFilterOption() })
+      return false
+    } else return super.set(value)
+  }
+}

--- a/libs/sr/db/src/Database/DataEntries/index.ts
+++ b/libs/sr/db/src/Database/DataEntries/index.ts
@@ -1,0 +1,7 @@
+import {
+  characterSortKeys,
+  type CharacterSortKey,
+} from './DisplayCharacterEntry'
+import type { LightConeSortKey } from './DisplayLightConeEntry'
+export { characterSortKeys }
+export type { CharacterSortKey, LightConeSortKey }

--- a/libs/sr/db/src/Database/Database.ts
+++ b/libs/sr/db/src/Database/Database.ts
@@ -5,6 +5,9 @@ import type { ISrObjectDescription } from '@genshin-optimizer/sr/srod'
 import type { ISroDatabase } from '../Interfaces'
 import { SroSource } from '../Interfaces'
 import { DBMetaEntry } from './DataEntries/DBMetaEntry'
+import { DisplayCharacterEntry } from './DataEntries/DisplayCharacterEntry'
+import { DisplayLightConeEntry } from './DataEntries/DisplayLightConeEntry'
+import { DisplayRelicEntry } from './DataEntries/DisplayRelicEntry'
 import { BuildDataManager } from './DataManagers/BuildDataManager'
 import { BuildTcDataManager } from './DataManagers/BuildTcDataManager'
 import { CharMetaDataManager } from './DataManagers/CharMetaDataManager'
@@ -33,6 +36,9 @@ export class SroDatabase extends Database {
   teams: TeamDataManager
 
   dbMeta: DBMetaEntry
+  displayCharacter: DisplayCharacterEntry
+  displayLightCone: DisplayLightConeEntry
+  displayRelic: DisplayRelicEntry
   dbIndex: 1 | 2 | 3 | 4
   dbVer: number
 
@@ -72,6 +78,9 @@ export class SroDatabase extends Database {
 
     // Handle DataEntries
     this.dbMeta = new DBMetaEntry(this)
+    this.displayCharacter = new DisplayCharacterEntry(this)
+    this.displayLightCone = new DisplayLightConeEntry(this)
+    this.displayRelic = new DisplayRelicEntry(this)
 
     this.chars.followAny(() => {
       this.dbMeta.set({ lastEdit: Date.now() })
@@ -98,7 +107,12 @@ export class SroDatabase extends Database {
     ] as const
   }
   get dataEntries() {
-    return [this.dbMeta] as const
+    return [
+      this.dbMeta,
+      this.displayCharacter,
+      this.displayLightCone,
+      this.displayRelic,
+    ] as const
   }
 
   clear() {


### PR DESCRIPTION
## Describe your changes
- add `Display<Item>Entry` files for Characters, Relics, and LightCones to save any UI settings to the DB like in GO
- modify `SroDatabase` to initialize new DB entries

Notable nit: I have no idea what `rvHigh` is supposed to be for measuring relics, which is listed in `DisplayRelicEntry.ts`. I kept GO's number for now, but any information on what it should be would be appreciated, and/or I can add a TODO for someone to go back and fix this later if this data has not been finalized yet.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
