### PR TITLE
Reduce rail ad width for GO ads

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -36,6 +36,9 @@ import Footer from './Footer'
 import Header from './Header'
 import Snow from './Snow'
 
+const AD_RAIL_MAXWIDTH = 300
+const AD_RAIL_HEIGHT = 600
+
 const PageHome = lazy(() => import('@genshin-optimizer/gi/page-home'))
 const PageArtifacts = lazy(() => import('@genshin-optimizer/gi/page-artifacts'))
 const PageTools = lazy(() => import('@genshin-optimizer/gi/page-tools'))
@@ -150,9 +153,11 @@ function Content() {
               dataAdSlot="2411728037"
               sx={{
                 minWidth: 160,
-                maxWidth:
+                maxWidth: Math.min(
                   adWidth >= 160 && adWidth <= 320 ? adWidth : adWidth * 0.5,
-                height: 600,
+                  AD_RAIL_MAXWIDTH
+                ),
+                height: AD_RAIL_HEIGHT,
                 width: '100%',
               }}
             />
@@ -196,8 +201,8 @@ function Content() {
               dataAdSlot="2411728037"
               sx={{
                 minWidth: 160,
-                maxWidth: adWidth * 0.5,
-                height: 600,
+                maxWidth: Math.min(adWidth * 0.5, AD_RAIL_MAXWIDTH),
+                height: AD_RAIL_HEIGHT,
                 width: '100%',
               }}
             />

--- a/libs/gi/ui/src/components/ad/AdWrapper.tsx
+++ b/libs/gi/ui/src/components/ad/AdWrapper.tsx
@@ -48,16 +48,17 @@ function GOAdWrapper({
   children: ReactNode
 }) {
   const maxHeight = (sx as any)?.['maxHeight'] || (sx as any)?.['height']
+  const maxWidth = (sx as any)?.['maxWidth'] || (sx as any)?.['width']
   const Comp = useMemo(() => {
     const components: Array<FunctionComponent<{ children: ReactNode }>> = [GOAd]
     if (maxHeight === undefined || canshowGoDevAd(maxHeight))
       components.push(GODevAd)
     if (maxHeight === undefined || canshowSroDevAd(maxHeight))
       components.push(SRODevAd)
-    if (maxHeight === undefined || canShowDrakeAd(maxHeight))
+    if (maxHeight === undefined || canShowDrakeAd(maxHeight, maxWidth))
       components.push(DrakeAd)
     return getRandomElementFromArray(components)
-  }, [maxHeight])
+  }, [maxHeight, maxWidth])
   return (
     <Box className="go-ad-wrapper" sx={{ margin: 'auto', ...sx }}>
       <Comp>{children}</Comp>

--- a/libs/gi/ui/src/components/ad/GoAd/DrakeAd.tsx
+++ b/libs/gi/ui/src/components/ad/GoAd/DrakeAd.tsx
@@ -32,7 +32,8 @@ export function DrakeAd({ children }: { children: ReactNode }) {
     </Box>
   )
 }
-export function canShowDrakeAd(height: number) {
+export function canShowDrakeAd(height: number, width: number) {
   if (height < 120) return false
+  if (width < 300) return false
   return true
 }


### PR DESCRIPTION
## Describe your changes

- Set a sensible max width for Go ads in the side banner space. Now they are capped to 300, to accommodate the largest [common banner ad size](https://support.google.com/google-ads/answer/7031480) of 300x600
- Minor refactoring to hoist global consts. 
- May consider decreasing the cap to 160, since I have not seen a 300x600 ad being displayed (need more time to experiment)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/1754901/56df7187-8d91-430a-ab85-7def2d6501e1)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
