### PR TITLE
Validate 1*/2* Weapon for TC Build

### DIFF
--- a/libs/gi/consts/src/weapon.ts
+++ b/libs/gi/consts/src/weapon.ts
@@ -1,4 +1,4 @@
-import { AscensionKey } from './character'
+import type { AscensionKey } from './character'
 import type { RarityKey } from './common'
 
 export const allWeaponTypeKeys = [

--- a/libs/gi/consts/src/weapon.ts
+++ b/libs/gi/consts/src/weapon.ts
@@ -1,3 +1,4 @@
+import { AscensionKey } from './character'
 import type { RarityKey } from './common'
 
 export const allWeaponTypeKeys = [
@@ -232,6 +233,14 @@ export const weaponMaxLevel: Record<RarityKey, number> = {
   3: 90,
   4: 90,
   5: 90,
+} as const
+
+export const weaponMaxAscension: Record<RarityKey, AscensionKey> = {
+  1: 4,
+  2: 4,
+  3: 6,
+  4: 6,
+  5: 6,
 } as const
 
 export const allRefinementKeys = [1, 2, 3, 4, 5] as const

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -17,7 +17,7 @@ import {
   weaponMaxAscension,
   weaponMaxLevel,
 } from '@genshin-optimizer/gi/consts'
-import { allStats } from '@genshin-optimizer/gi/stats'
+import { allStats, getWeaponStat } from '@genshin-optimizer/gi/stats'
 import { validateLevelAsc } from '@genshin-optimizer/gi/util'
 import type { ICachedArtifact, ICachedWeapon } from '../../Interfaces'
 import type { BuildTc } from '../../Interfaces/BuildTc'
@@ -157,7 +157,7 @@ function validateCharTCWeapon(weapon: unknown): BuildTc['weapon'] | undefined {
   let { level, ascension, refinement } = weapon as BuildTc['weapon']
 
   if (!allWeaponKeys.includes(key)) return undefined
-  const { rarity } = allStats.weapon.data[key]
+  const { rarity } = getWeaponStat(key)
   if (level > weaponMaxLevel[rarity]) {
     level = weaponMaxLevel[rarity]
     ascension = weaponMaxAscension[rarity]

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -14,8 +14,11 @@ import {
   allWeaponKeys,
   artMaxLevel,
   substatTypeKeys,
+  weaponMaxLevel,
+  weaponMaxAscension,
 } from '@genshin-optimizer/gi/consts'
 import { validateLevelAsc } from '@genshin-optimizer/gi/util'
+import { allStats } from '@genshin-optimizer/gi/stats'
 import type { ICachedArtifact, ICachedWeapon } from '../../Interfaces'
 import type { BuildTc } from '../../Interfaces/BuildTc'
 import type { ArtCharDatabase } from '../ArtCharDatabase'
@@ -152,7 +155,13 @@ function validateCharTCWeapon(weapon: unknown): BuildTc['weapon'] | undefined {
   if (typeof weapon !== 'object') return undefined
   const { key } = weapon as BuildTc['weapon']
   let { level, ascension, refinement } = weapon as BuildTc['weapon']
+
   if (!allWeaponKeys.includes(key)) return undefined
+  const { rarity } = allStats.weapon.data[key]
+  if (level > weaponMaxLevel[rarity]) {
+    level = weaponMaxLevel[rarity]
+    ascension = weaponMaxAscension[rarity]
+  }
   if (typeof refinement !== 'number' || refinement < 1 || refinement > 5)
     refinement = 1
   const { level: _level, ascension: _ascension } = validateLevelAsc(

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -17,7 +17,7 @@ import {
   weaponMaxAscension,
   weaponMaxLevel,
 } from '@genshin-optimizer/gi/consts'
-import { allStats, getWeaponStat } from '@genshin-optimizer/gi/stats'
+import { getWeaponStat } from '@genshin-optimizer/gi/stats'
 import { validateLevelAsc } from '@genshin-optimizer/gi/util'
 import type { ICachedArtifact, ICachedWeapon } from '../../Interfaces'
 import type { BuildTc } from '../../Interfaces/BuildTc'

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -14,11 +14,11 @@ import {
   allWeaponKeys,
   artMaxLevel,
   substatTypeKeys,
-  weaponMaxLevel,
   weaponMaxAscension,
+  weaponMaxLevel,
 } from '@genshin-optimizer/gi/consts'
-import { validateLevelAsc } from '@genshin-optimizer/gi/util'
 import { allStats } from '@genshin-optimizer/gi/stats'
+import { validateLevelAsc } from '@genshin-optimizer/gi/util'
 import type { ICachedArtifact, ICachedWeapon } from '../../Interfaces'
 import type { BuildTc } from '../../Interfaces/BuildTc'
 import type { ArtCharDatabase } from '../ArtCharDatabase'


### PR DESCRIPTION
## Describe your changes

When swapping a 3/4/5* weapon to 1/2* for level 70+ in TC build, set level and ascension level to max level and ascension for 1/2* weapons. 

## Issue or discord link

Resolves [https://github.com/frzyc/genshin-optimizer/issues/2036](https://github.com/frzyc/genshin-optimizer/issues/2036
)
## Testing/validation

https://github.com/frzyc/genshin-optimizer/assets/23622319/7c228310-1aae-4165-8980-cf4c7378dbf1

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
