### PR TITLE
Hide AdCard when closing AdWrapper

### DIFF
--- a/libs/gi/ui/src/components/ad/AdCard.tsx
+++ b/libs/gi/ui/src/components/ad/AdCard.tsx
@@ -1,3 +1,4 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
 import type { CardBackgroundColor } from '@genshin-optimizer/common/ui'
 import { CardThemed, useRefSize } from '@genshin-optimizer/common/ui'
 import { Box } from '@mui/material'
@@ -13,11 +14,18 @@ export function AdCard({
   maxHeight?: number
 }) {
   const { width, height, ref } = useRefSize()
+  const [show, _, onHide] = useBoolState(true)
+
+  if (!show) return null
   return (
     <CardThemed bgt={bgt} sx={{ height: '100%', maxHeight }}>
       <Box ref={ref} sx={{ height: '100%', width: '100%' }}>
         {width && (
           <AdWrapper
+            onClose={(e) => {
+              e.stopPropagation()
+              onHide()
+            }}
             dataAdSlot={dataAdSlot}
             sx={{ width, height: Math.max(height, maxHeight) }}
           />

--- a/libs/gi/ui/src/components/ad/AdWrapper.tsx
+++ b/libs/gi/ui/src/components/ad/AdWrapper.tsx
@@ -3,7 +3,7 @@ import { AdSenseUnit, IsAdBlockedContext } from '@genshin-optimizer/common/ui'
 import { getRandomElementFromArray } from '@genshin-optimizer/common/util'
 import type { BoxProps } from '@mui/material'
 import { Box } from '@mui/material'
-import type { FunctionComponent } from 'react'
+import type { FunctionComponent, MouseEventHandler } from 'react'
 import { useContext, useMemo, type ReactNode } from 'react'
 import { AdButtons } from './AdButtons'
 import { DrakeAd, canShowDrakeAd } from './GoAd/DrakeAd'
@@ -15,12 +15,14 @@ export function AdWrapper({
   dataAdSlot,
   fullWidth = false,
   sx,
+  onClose,
 }: {
   dataAdSlot: string
   height?: number
   width?: number
   sx?: BoxProps['sx']
   fullWidth?: boolean
+  onClose?: MouseEventHandler
 }) {
   const [show, _, onHide] = useBoolState(true)
   const adblockEnabled = useContext(IsAdBlockedContext)
@@ -32,10 +34,13 @@ export function AdWrapper({
   return (
     <GOAdWrapper sx={sx}>
       <AdButtons
-        onClose={(e) => {
-          e.stopPropagation()
-          onHide()
-        }}
+        onClose={
+          onClose ??
+          ((e) => {
+            e.stopPropagation()
+            onHide()
+          })
+        }
       />
     </GOAdWrapper>
   )


### PR DESCRIPTION
## Describe your changes

Prevent cut off the Set Config when closing the ad on the Artifact Upgrader

## Issue or discord link

- Resolves #2092

## Testing/validation

https://github.com/frzyc/genshin-optimizer/assets/70012600/40f7389a-86e7-4bd2-9ec1-d7e1befe6ac2

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
