### PR TITLE
Granular team exports

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
@@ -255,7 +255,7 @@ export class OptConfigDataManager extends DataManager<
     if (!optConfig) return ''
     return this.new(structuredClone(optConfig))
   }
-  export(optConfigId: string): object {
+  export(optConfigId: string, overrideOptTarget?: string[]): object {
     const optConfig = this.database.optConfigs.get(optConfigId)
     if (!optConfig) return {}
     const {
@@ -267,7 +267,11 @@ export class OptConfigDataManager extends DataManager<
       builds,
       ...rest
     } = optConfig
-    return rest
+    if (!overrideOptTarget) return rest
+    return {
+      ...rest,
+      optimizationTarget: overrideOptTarget,
+    }
   }
   import(data: object): string {
     const id = this.generateKey()

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -306,6 +306,7 @@ export class TeamCharacterDataManager extends DataManager<
     if (!teamChar) return {}
     const { buildIds, buildTcIds, optConfigId, customMultiTargets, ...rest } =
       teamChar
+    const { optimizationTarget } = this.database.optConfigs.get(optConfigId)!
     const { weaponType } = getCharStat(teamChar.key)
     const {
       convertEquipped,
@@ -353,6 +354,19 @@ export class TeamCharacterDataManager extends DataManager<
     const convertedTcBuilds = convertTcBuilds
       .filter((id) => buildTcIds.includes(id))
       .map((buildTcId) => this.database.buildTcs.export(buildTcId))
+
+    let overrideOptTarget = undefined
+    if (optimizationTarget?.[0] === 'custom') {
+      const ind = parseInt(optimizationTarget[1])
+      if (!isNaN(ind)) {
+        const newInd = exportCustomMultiTarget.findIndex((i) => i === ind)
+        if (newInd !== -1) {
+          overrideOptTarget = structuredClone(optimizationTarget)
+          overrideOptTarget[1] = newInd.toString()
+        }
+      }
+    }
+
     return {
       ...rest,
       buildTcs: [
@@ -363,7 +377,10 @@ export class TeamCharacterDataManager extends DataManager<
       customMultiTargets: customMultiTargets.filter((_, i) =>
         exportCustomMultiTarget.includes(i)
       ),
-      optConfig: this.database.optConfigs.export(optConfigId),
+      optConfig: this.database.optConfigs.export(
+        optConfigId,
+        overrideOptTarget
+      ),
     }
   }
   import(data: object): string {

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -355,7 +355,7 @@ export class TeamCharacterDataManager extends DataManager<
       .filter((id) => buildTcIds.includes(id))
       .map((buildTcId) => this.database.buildTcs.export(buildTcId))
 
-    let overrideOptTarget = undefined
+    let overrideOptTarget: string[] | undefined = undefined
     if (optimizationTarget?.[0] === 'custom') {
       const ind = parseInt(optimizationTarget[1])
       if (!isNaN(ind)) {

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -313,52 +313,52 @@ export class TeamCharacterDataManager extends DataManager<
       convertTcBuilds,
       exportCustomMultiTarget,
     } = settings
+
+    const equippedBuildToTCBuild = () => {
+      const char = this.database.chars.get(teamChar.key)
+      if (!char) return
+      const { equippedArtifacts, equippedWeapon } = char
+      const weapon = this.database.weapons.get(equippedWeapon)
+      const arts = Object.values(equippedArtifacts).map((id) =>
+        this.database.arts.get(id)
+      )
+      const buildTC = toBuildTc(
+        initCharTC(defaultInitialWeaponKey(weaponType)),
+        weapon,
+        arts
+      )
+      buildTC.name = 'Equipped(Converted)'
+      buildTC.description = 'Converted from Equipped'
+      return buildTC
+    }
+    const convertedBuilds = convertbuilds
+      .filter((id) => buildIds.includes(id))
+      .map((buildId) => {
+        const build = this.database.builds.get(buildId)
+        if (!build) return
+        const { name, description, weaponId, artifactIds } = build
+        const weapon = this.database.weapons.get(weaponId)
+        const arts = Object.values(artifactIds).map((id) =>
+          this.database.arts.get(id)
+        )
+        const buildTC = toBuildTc(
+          initCharTC(defaultInitialWeaponKey(weaponType)),
+          weapon,
+          arts
+        )
+        buildTC.name = name
+        buildTC.description = description
+        return buildTC
+      })
+    const convertedTcBuilds = convertTcBuilds
+      .filter((id) => buildTcIds.includes(id))
+      .map((buildTcId) => this.database.buildTcs.export(buildTcId))
     return {
       ...rest,
       buildTcs: [
-        ...(convertEquipped
-          ? [
-              (() => {
-                const char = this.database.chars.get(teamChar.key)
-                if (!char) return
-                const { equippedArtifacts, equippedWeapon } = char
-                const weapon = this.database.weapons.get(equippedWeapon)
-                const arts = Object.values(equippedArtifacts).map((id) =>
-                  this.database.arts.get(id)
-                )
-                const buildTC = toBuildTc(
-                  initCharTC(defaultInitialWeaponKey(weaponType)),
-                  weapon,
-                  arts
-                )
-                buildTC.name = 'Equipped(Converted)'
-                buildTC.description = 'Converted from Equipped'
-                return buildTC
-              })(),
-            ]
-          : []),
-        ...convertbuilds
-          .filter((id) => buildIds.includes(id))
-          .map((buildId) => {
-            const build = this.database.builds.get(buildId)
-            if (!build) return
-            const { name, description, weaponId, artifactIds } = build
-            const weapon = this.database.weapons.get(weaponId)
-            const arts = Object.values(artifactIds).map((id) =>
-              this.database.arts.get(id)
-            )
-            const buildTC = toBuildTc(
-              initCharTC(defaultInitialWeaponKey(weaponType)),
-              weapon,
-              arts
-            )
-            buildTC.name = name
-            buildTC.description = description
-            return buildTC
-          }),
-        ...convertTcBuilds
-          .filter((id) => buildTcIds.includes(id))
-          .map((buildTcId) => this.database.buildTcs.export(buildTcId)),
+        ...(convertEquipped ? [equippedBuildToTCBuild()] : []),
+        ...convertedBuilds,
+        ...convertedTcBuilds,
       ].filter(notEmpty),
       customMultiTargets: customMultiTargets.filter((_, i) =>
         exportCustomMultiTarget.includes(i)

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.test.ts
@@ -54,6 +54,12 @@ describe('export and import test', () => {
         convertTcBuilds: [],
         exportCustomMultiTarget: [],
       },
+      {
+        convertbuilds: [],
+        convertEquipped: true,
+        convertTcBuilds: [],
+        exportCustomMultiTarget: [],
+      },
     ])
     expect(exp).toBeTruthy()
     expect((exp as any).loadoutData[0].key).toEqual('RaidenShogun')

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.test.ts
@@ -41,7 +41,20 @@ describe('export and import test', () => {
     expect(dbTeam.loadoutData[0]?.teamCharId).toEqual(raidenId)
     expect(dbTeam.loadoutData[2]?.teamCharId).toEqual(bennettId)
 
-    const exp = database.teams.export(teamId)
+    const exp = database.teams.export(teamId, [
+      {
+        convertbuilds: [],
+        convertEquipped: true,
+        convertTcBuilds: [],
+        exportCustomMultiTarget: [],
+      },
+      {
+        convertbuilds: [],
+        convertEquipped: true,
+        convertTcBuilds: [],
+        exportCustomMultiTarget: [],
+      },
+    ])
     expect(exp).toBeTruthy()
     expect((exp as any).loadoutData[0].key).toEqual('RaidenShogun')
     expect((exp as any).loadoutData[0].optConfig.optimizationTarget).toEqual([

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -50,7 +50,7 @@ export type LoadoutExportSetting = {
   convertTcBuilds: string[]
   exportCustomMultiTarget: number[]
 }
-export const defLoadoutExportSetting = ():LoadoutExportSetting => ({
+export const defLoadoutExportSetting = (): LoadoutExportSetting => ({
   convertEquipped: false,
   convertbuilds: [],
   convertTcBuilds: [],

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -198,11 +198,17 @@ export class TeamDataManager extends DataManager<
     const rem = super.remove(teamId, notify)
     if (!rem) return
     // handle removal of loadouts that are only in this team.
-    rem.loadoutData.forEach(loadoutDatum=>{
-      if(!loadoutDatum) return
-      const {teamCharId} = loadoutDatum
+    rem.loadoutData.forEach((loadoutDatum) => {
+      if (!loadoutDatum) return
+      const { teamCharId } = loadoutDatum
       // check if there is another team that has this loadout, if so, do not remove it
-      if(this.database.teams.values.some(({loadoutData})=>loadoutData.some(loadoutDatum=>loadoutDatum?.teamCharId===teamCharId)))
+      if (
+        this.database.teams.values.some(({ loadoutData }) =>
+          loadoutData.some(
+            (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
+          )
+        )
+      )
         return
       this.database.teamChars.remove(teamCharId)
     })

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -50,7 +50,7 @@ export type LoadoutExportSetting = {
   convertTcBuilds: string[]
   exportCustomMultiTarget: number[]
 }
-export const defLoadoutExportSetting = () => ({
+export const defLoadoutExportSetting = ():LoadoutExportSetting => ({
   convertEquipped: false,
   convertbuilds: [],
   convertTcBuilds: [],

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -200,26 +200,6 @@ export class TeamDataManager extends DataManager<
       lastEdit,
     }
   }
-  override remove(teamId: string, notify?: boolean): Team | undefined {
-    const rem = super.remove(teamId, notify)
-    if (!rem) return
-    // handle removal of loadouts that are only in this team.
-    rem.loadoutData.forEach((loadoutDatum) => {
-      if (!loadoutDatum) return
-      const { teamCharId } = loadoutDatum
-      // check if there is another team that has this loadout, if so, do not remove it
-      if (
-        this.database.teams.values.some(({ loadoutData }) =>
-          loadoutData.some(
-            (loadoutDatum) => loadoutDatum?.teamCharId === teamCharId
-          )
-        )
-      )
-        return
-      this.database.teamChars.remove(teamCharId)
-    })
-    return rem
-  }
   new(value: Partial<Team> = {}): string {
     const id = this.generateKey()
     this.set(id, value)

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -50,6 +50,12 @@ export type LoadoutExportSetting = {
   convertTcBuilds: string[]
   exportCustomMultiTarget: number[]
 }
+export const defLoadoutExportSetting = () => ({
+  convertEquipped: false,
+  convertbuilds: [],
+  convertTcBuilds: [],
+  exportCustomMultiTarget: [],
+})
 export type LoadoutDataExportSetting = Array<LoadoutExportSetting>
 export class TeamDataManager extends DataManager<
   string,

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -21,7 +21,12 @@ import {
   maxBuildsToShowList,
 } from './OptConfigDataManager'
 import type { TeamCharacter } from './TeamCharacterDataManager'
-import type { LoadoutDatum, Team } from './TeamDataManager'
+import type {
+  LoadoutDataExportSetting,
+  LoadoutDatum,
+  LoadoutExportSetting,
+  Team,
+} from './TeamDataManager'
 import {
   defaultInitialWeapon,
   defaultInitialWeaponKey,
@@ -49,7 +54,9 @@ export type {
   ArtSetExclusion,
   ArtSetExclusionKey,
   GeneratedBuild,
+  LoadoutDataExportSetting,
   LoadoutDatum,
+  LoadoutExportSetting,
   MinTotalStatKey,
   StatFilterSetting,
   StatFilters,

--- a/libs/gi/db/src/Database/DataManagers/index.ts
+++ b/libs/gi/db/src/Database/DataManagers/index.ts
@@ -27,6 +27,7 @@ import type {
   LoadoutExportSetting,
   Team,
 } from './TeamDataManager'
+import { defLoadoutExportSetting } from './TeamDataManager'
 import {
   defaultInitialWeapon,
   defaultInitialWeaponKey,
@@ -37,6 +38,7 @@ export {
   MAX_NAME_LENGTH,
   allArtifactSetExclusionKeys,
   cachedArtifact,
+  defLoadoutExportSetting,
   defaultInitialWeapon,
   defaultInitialWeaponKey,
   handleArtSetExclusion,

--- a/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
@@ -96,10 +96,10 @@ export default function TeamExportModal({
       .then(() => alert('Copied team data to clipboard.'))
       .catch(console.error)
   }
-  const [selEverything, setSelEverything] = useState(true)
+  const [selAll, setSelAll] = useState(true)
 
-  const unselectEverything = () => {
-    setSelEverything(true)
+  const onUnselAll = () => {
+    setSelAll(true)
     setLoadoutDataExportSetting(
       loadoutData.map((loadoutDatum) =>
         loadoutDatum
@@ -109,8 +109,8 @@ export default function TeamExportModal({
     )
   }
 
-  const selectEverything = () => {
-    setSelEverything(false)
+  const onSelAll = () => {
+    setSelAll(false)
     setLoadoutDataExportSetting(
       loadoutData.map((loadoutDatum) => {
         if (!loadoutDatum) return defLoadoutExportSetting()
@@ -155,11 +155,8 @@ export default function TeamExportModal({
               and loadout data (bonus stats, enemy config, optimize config) are
               exported. All exported non-TC builds are converted to TC builds.
             </Alert>
-            <Button
-              color="info"
-              onClick={selEverything ? selectEverything : unselectEverything}
-            >
-              {selEverything ? 'Select Everything' : 'Unselect Everything'}
+            <Button color="info" onClick={selAll ? onSelAll : onUnselAll}>
+              {selAll ? 'Select All' : 'Unselect All'}
             </Button>
           </Box>
 

--- a/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
@@ -18,6 +18,8 @@ import {
   CustomMultiTargetIcon,
   FieldDisplayList,
 } from '@genshin-optimizer/gi/ui'
+import CheckBoxIcon from '@mui/icons-material/CheckBox'
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CloseIcon from '@mui/icons-material/Close'
 import InfoIcon from '@mui/icons-material/Info'
 import {
@@ -103,11 +105,23 @@ export default function TeamExportModal({
         />
         <Divider />
         <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-          <Alert severity="info">
-            Export the team data to be imported by another user. All the team
-            and loadout data (bonus stats, enemy config, optimize config) are
-            exported. All exported non-TC builds are converted to TC builds.
-          </Alert>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Alert severity="info">
+              Export the team data to be imported by another user. All the team
+              and loadout data (bonus stats, enemy config, optimize config) are
+              exported. All exported non-TC builds are converted to TC builds.
+            </Alert>
+            <Button
+              color="info"
+              onClick={selEverything ? selectEverything : unselectEverything}
+              startIcon={
+                selEverything ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />
+              }
+            >
+              {selEverything ? 'Select Everything' : 'Unselect Everything'}
+            </Button>
+          </Box>
+
           <Grid container columns={{ xs: 2, md: 4 }} spacing={1}>
             {loadoutData.map(
               (loadout, i) =>
@@ -136,12 +150,6 @@ export default function TeamExportModal({
         <CardContent
           sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}
         >
-          <Button
-            color="info"
-            onClick={selEverything ? selectEverything : unselectEverything}
-          >
-            {selEverything ? 'Select Everything' : 'Unselect Everything'}
-          </Button>
           <Button color="success" onClick={onExport}>
             Export
           </Button>

--- a/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
@@ -1,0 +1,282 @@
+import {
+  BootstrapTooltip,
+  CardThemed,
+  ModalWrapper,
+  SqBadge,
+} from '@genshin-optimizer/common/ui'
+import { toggleInArr } from '@genshin-optimizer/common/util'
+import type {
+  LoadoutDataExportSetting,
+  LoadoutDatum,
+  LoadoutExportSetting,
+} from '@genshin-optimizer/gi/db'
+import { useDatabase, useTeam, useTeamChar } from '@genshin-optimizer/gi/db-ui'
+import {
+  BuildIcon,
+  CharIconSide,
+  CustomMultiTargetIcon,
+  FieldDisplayList,
+} from '@genshin-optimizer/gi/ui'
+import CloseIcon from '@mui/icons-material/Close'
+import InfoIcon from '@mui/icons-material/Info'
+import {
+  Alert,
+  Box,
+  Button,
+  CardContent,
+  CardHeader,
+  Checkbox,
+  Divider,
+  Grid,
+  IconButton,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material'
+import { useState } from 'react'
+
+// TODO: Translation
+export default function TeamExportModal({
+  show,
+  onHide,
+  teamId,
+}: {
+  show: boolean
+  onHide: () => void
+  teamId: string
+}) {
+  const database = useDatabase()
+  const team = useTeam(teamId)!
+  const { loadoutData } = team
+
+  const [loadoutDataExportSetting, setLoadoutDataExportSetting] =
+    useState<LoadoutDataExportSetting>(() =>
+      loadoutData.map(() => ({
+        convertEquipped: false,
+        convertbuilds: [],
+        convertTcBuilds: [],
+        exportCustomMultiTarget: [],
+      }))
+    )
+  const onExport = () => {
+    const data = database.teams.export(teamId, loadoutDataExportSetting)
+    const dataStr = JSON.stringify(data)
+    navigator.clipboard
+      .writeText(dataStr)
+      .then(() => alert('Copied team data to clipboard.'))
+      .catch(console.error)
+  }
+  return (
+    <ModalWrapper open={show} onClose={onHide}>
+      <CardThemed>
+        <CardHeader
+          title="Team Export"
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Alert severity="info">
+            Export the team data to be imported by another user. All the team
+            and loadout data (bonus stats, enemy config, optimize config) are
+            exported. All exported non-TC builds are converted to TC builds.
+          </Alert>
+          <Grid container columns={{ xs: 2, md: 4 }} spacing={1}>
+            {loadoutData.map(
+              (loadout, i) =>
+                !!loadout && (
+                  <Grid item xs={1} key={i}>
+                    <LoadoutSetting
+                      loadout={loadout}
+                      setting={loadoutDataExportSetting[i]}
+                      setSetting={(loadoutExportSetting) =>
+                        setLoadoutDataExportSetting((settings) => {
+                          const data = structuredClone(settings)
+                          data[i] = {
+                            ...data[i],
+                            ...loadoutExportSetting,
+                          }
+                          return data
+                        })
+                      }
+                    />
+                  </Grid>
+                )
+            )}
+          </Grid>
+        </CardContent>
+        <Divider />
+        <CardContent>
+          <Button onClick={onExport}>Export</Button>
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}
+function LoadoutSetting({
+  loadout,
+  setting,
+  setSetting,
+}: {
+  loadout: LoadoutDatum
+  setting: LoadoutExportSetting
+  setSetting: (loadoutExportSetting: Partial<LoadoutExportSetting>) => void
+}) {
+  const database = useDatabase()
+  const teamChar = useTeamChar(loadout.teamCharId)!
+  const {
+    key: characterKey,
+    name,
+    description,
+    buildIds,
+    buildTcIds,
+    customMultiTargets,
+  } = teamChar
+  return (
+    <CardThemed bgt="light">
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <CharIconSide characterKey={characterKey} />
+        <Typography>{name}</Typography>
+        {!!description && (
+          <BootstrapTooltip title={description}>
+            <InfoIcon />
+          </BootstrapTooltip>
+        )}
+      </CardContent>
+      <Divider />
+      {!!customMultiTargets.length && (
+        <>
+          <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CustomMultiTargetIcon />
+            <Typography>
+              <strong>Mtargets to Export</strong>
+            </Typography>
+          </CardContent>
+          <FieldDisplayList bgt="light">
+            {customMultiTargets.map((mtarget, i) => {
+              const { name, description } = mtarget
+              return (
+                <ListItem key={i} sx={{ p: 0 }}>
+                  <ListItemButton
+                    onClick={() =>
+                      setSetting({
+                        exportCustomMultiTarget: toggleInArr(
+                          setting.exportCustomMultiTarget,
+                          i
+                        ),
+                      })
+                    }
+                  >
+                    <Checkbox
+                      edge="start"
+                      checked={setting.exportCustomMultiTarget.includes(i)}
+                      tabIndex={-1}
+                      disableRipple
+                    />
+                    <ListItemText primary={name} />
+                    {!!description && (
+                      <BootstrapTooltip title={description}>
+                        <InfoIcon />
+                      </BootstrapTooltip>
+                    )}
+                  </ListItemButton>
+                </ListItem>
+              )
+            })}
+          </FieldDisplayList>
+          <Divider />
+        </>
+      )}
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <BuildIcon />
+        <Typography>
+          <strong>Builds to Export</strong>
+        </Typography>
+      </CardContent>
+      <FieldDisplayList bgt="light">
+        <ListItem sx={{ p: 0 }}>
+          <ListItemButton
+            onClick={() =>
+              setSetting({ convertEquipped: !setting.convertEquipped })
+            }
+          >
+            <Checkbox
+              edge="start"
+              checked={setting.convertEquipped}
+              tabIndex={-1}
+              disableRipple
+            />
+            <ListItemText primary={`Equipped Build`} />
+          </ListItemButton>
+        </ListItem>
+        {buildIds.map((buildId) => {
+          const build = database.builds.get(buildId)!
+          return (
+            <ListItem key={buildId} sx={{ p: 0 }}>
+              <ListItemButton
+                onClick={() =>
+                  setSetting({
+                    convertbuilds: toggleInArr(setting.convertbuilds, buildId),
+                  })
+                }
+              >
+                <Checkbox
+                  edge="start"
+                  checked={setting.convertbuilds.includes(buildId)}
+                  tabIndex={-1}
+                  disableRipple
+                />
+                <ListItemText primary={build.name} />
+                {!!build.description && (
+                  <BootstrapTooltip title={build.description}>
+                    <InfoIcon />
+                  </BootstrapTooltip>
+                )}
+              </ListItemButton>
+            </ListItem>
+          )
+        })}
+        {buildTcIds.map((buildTcId) => {
+          const buildTc = database.buildTcs.get(buildTcId)!
+          return (
+            <ListItem key={buildTcId} sx={{ p: 0 }}>
+              <ListItemButton
+                onClick={() =>
+                  setSetting({
+                    convertTcBuilds: toggleInArr(
+                      setting.convertTcBuilds,
+                      buildTcId
+                    ),
+                  })
+                }
+              >
+                <Checkbox
+                  edge="start"
+                  checked={setting.convertTcBuilds.includes(buildTcId)}
+                  tabIndex={-1}
+                  disableRipple
+                />
+                <ListItemText
+                  primary={
+                    <Box>
+                      {buildTc.name} <SqBadge>TC Build</SqBadge>
+                    </Box>
+                  }
+                />
+                {!!buildTc.description && (
+                  <BootstrapTooltip title={buildTc.description}>
+                    <InfoIcon />
+                  </BootstrapTooltip>
+                )}
+              </ListItemButton>
+            </ListItem>
+          )
+        })}
+      </FieldDisplayList>
+    </CardThemed>
+  )
+}

--- a/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamExportModal.tsx
@@ -36,6 +36,8 @@ import {
   ListItemButton,
   ListItemText,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 import { useState } from 'react'
 
@@ -92,6 +94,8 @@ export default function TeamExportModal({
     )
   }
 
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   return (
     <ModalWrapper open={show} onClose={onHide}>
       <CardThemed>
@@ -105,7 +109,13 @@ export default function TeamExportModal({
         />
         <Divider />
         <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              flexDirection: isMobile ? 'column' : 'row',
+            }}
+          >
             <Alert severity="info">
               Export the team data to be imported by another user. All the team
               and loadout data (bonus stats, enemy config, optimize config) are
@@ -122,7 +132,7 @@ export default function TeamExportModal({
             </Button>
           </Box>
 
-          <Grid container columns={{ xs: 2, md: 4 }} spacing={1}>
+          <Grid container columns={{ xs: 1, sm: 2, md: 4 }} spacing={1}>
             {loadoutData.map(
               (loadout, i) =>
                 !!loadout && (

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -46,7 +46,7 @@ export default function TeamSetting({
   const onDel = () => {
     if (
       !window.confirm(
-        'Removing the team will remove select builds, resonance buffs, enemy config, and loadouts. Loadouts that are used in another team will not be removed.'
+        'Removing the team will not remove the loadouts, but will remove select builds, resonance buffs, and enemy config.'
       )
     )
       return

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -1,14 +1,34 @@
-import { TextFieldLazy } from '@genshin-optimizer/common/ui'
+import { useBoolState } from '@genshin-optimizer/common/react-util'
+import {
+  BootstrapTooltip,
+  CardThemed,
+  ModalWrapper,
+  SqBadge,
+  TextFieldLazy,
+} from '@genshin-optimizer/common/ui'
+import { toggleInArr } from '@genshin-optimizer/common/util'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
-import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
-import { useDBMeta, useDatabase } from '@genshin-optimizer/gi/db-ui'
+import type {
+  LoadoutDataExportSetting,
+  LoadoutDatum,
+  LoadoutExportSetting,
+} from '@genshin-optimizer/gi/db'
+import {
+  useDBMeta,
+  useDatabase,
+  useTeam,
+  useTeamChar,
+} from '@genshin-optimizer/gi/db-ui'
 import type { TeamData, dataContextObj } from '@genshin-optimizer/gi/ui'
 import {
   AdResponsive,
+  BuildIcon,
   CharIconSide,
   CharacterName,
   CharacterSelectionModal,
+  CustomMultiTargetIcon,
   EnemyExpandCard,
+  FieldDisplayList,
   TeamInfoAlert,
 } from '@genshin-optimizer/gi/ui'
 import AddIcon from '@mui/icons-material/Add'
@@ -16,8 +36,23 @@ import CloseIcon from '@mui/icons-material/Close'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import InfoIcon from '@mui/icons-material/Info'
 import type { ButtonProps } from '@mui/material'
-import { Alert, Box, Button, CardContent, Grid } from '@mui/material'
+import {
+  Alert,
+  Box,
+  Button,
+  CardContent,
+  CardHeader,
+  Checkbox,
+  Divider,
+  Grid,
+  IconButton,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material'
 import { Suspense, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import BuildDropdown from '../BuildDropdown'
@@ -36,6 +71,7 @@ export default function TeamSetting({
 }) {
   const navigate = useNavigate()
   const database = useDatabase()
+  const [show, onShow, onHide] = useBoolState()
   const team = database.teams.get(teamId)!
   const noChars = team.loadoutData.every((id) => !id)
   const { name, description } = team
@@ -43,21 +79,14 @@ export default function TeamSetting({
   const onDel = () => {
     if (
       !window.confirm(
-        'Removing the team will not remove the loadouts, but will remove select builds, resonance buffs, and enemy config.'
+        'Removing the team will remove select builds, resonance buffs, enemy config, and loadouts. Loadouts that are used in another team will not be removed.'
       )
     )
       return
     database.teams.remove(teamId)
     navigate(`/teams`)
   }
-  const onExport = () => {
-    const data = database.teams.export(teamId)
-    const dataStr = JSON.stringify(data)
-    navigator.clipboard
-      .writeText(dataStr)
-      .then(() => alert('Copied team data to clipboard.'))
-      .catch(console.error)
-  }
+
   const onDup = () => {
     const newTeamId = database.teams.duplicate(teamId)
     navigate(`/teams/${newTeamId}`)
@@ -82,12 +111,13 @@ export default function TeamSetting({
         minRows={2}
       />
       <Box sx={{ display: 'flex', gap: 1 }}>
+        <TeamExportModal show={show} teamId={teamId} onHide={onHide} />
         <Button
           color="info"
           sx={{ flexGrow: 1 }}
           startIcon={<ContentPasteIcon />}
           disabled={noChars}
-          onClick={onExport}
+          onClick={onShow}
         >
           Export Team
         </Button>
@@ -325,5 +355,229 @@ function CharSelButton({
         />
       )}
     </Box>
+  )
+}
+function TeamExportModal({
+  show,
+  onHide,
+  teamId,
+}: {
+  show: boolean
+  onHide: () => void
+  teamId: string
+}) {
+  const database = useDatabase()
+  const team = useTeam(teamId)!
+  const { loadoutData } = team
+
+  const [loadoutDataExportSetting, setLoadoutDataExportSetting] =
+    useState<LoadoutDataExportSetting>(() =>
+      loadoutData.map(() => ({
+        convertEquipped: false,
+        convertbuilds: [],
+        convertTcBuilds: [],
+        exportCustomMultiTarget: [],
+      }))
+    )
+  const onExport = () => {
+    const data = database.teams.export(teamId, loadoutDataExportSetting)
+    const dataStr = JSON.stringify(data)
+    navigator.clipboard
+      .writeText(dataStr)
+      .then(() => alert('Copied team data to clipboard.'))
+      .catch(console.error)
+  }
+  return (
+    <ModalWrapper open={show} onClose={onHide}>
+      <CardThemed>
+        <CardHeader
+          title="Team Export"
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Alert severity="info">
+            Export the team data to be imported by another user. All the team
+            and loadout data (bonus stats, enemy config, optimize config) are
+            exported. All exported non-TC builds are converted to TC builds.
+          </Alert>
+          <Grid container columns={{ xs: 2, md: 4 }} spacing={1}>
+            {loadoutData.map(
+              (loadout, i) =>
+                !!loadout && (
+                  <Grid item xs={1} key={i}>
+                    <LoadoutSetting
+                      loadout={loadout}
+                      setting={loadoutDataExportSetting[i]}
+                      setSetting={(loadoutExportSetting) =>
+                        setLoadoutDataExportSetting((settings) => {
+                          const data = structuredClone(settings)
+                          data[i] = {
+                            ...data[i],
+                            ...loadoutExportSetting,
+                          }
+                          return data
+                        })
+                      }
+                    />
+                  </Grid>
+                )
+            )}
+          </Grid>
+        </CardContent>
+        <Divider />
+        <CardContent>
+          <Button onClick={onExport}>Export</Button>
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}
+function LoadoutSetting({
+  loadout,
+  setting,
+  setSetting,
+}: {
+  loadout: LoadoutDatum
+  setting: LoadoutExportSetting
+  setSetting: (loadoutExportSetting: Partial<LoadoutExportSetting>) => void
+}) {
+  const database = useDatabase()
+  const teamChar = useTeamChar(loadout.teamCharId)!
+  const {
+    key: characterKey,
+    name,
+    description,
+    buildIds,
+    buildTcIds,
+    customMultiTargets,
+  } = teamChar
+  return (
+    <CardThemed bgt="light">
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <CharIconSide characterKey={characterKey} />
+        <Typography>{name}</Typography>
+        {!!description && (
+          <BootstrapTooltip title={description}>
+            <InfoIcon />
+          </BootstrapTooltip>
+        )}
+      </CardContent>
+      <Divider />
+      {!!customMultiTargets.length && (
+        <>
+          <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CustomMultiTargetIcon />
+            <Typography>Mtargets to Export</Typography>
+          </CardContent>
+          <FieldDisplayList bgt="light">
+            {customMultiTargets.map((mtarget, i) => {
+              const { name } = mtarget
+              return (
+                <ListItem key={i} sx={{ p: 0 }}>
+                  <ListItemButton
+                    onClick={() =>
+                      setSetting({
+                        exportCustomMultiTarget: toggleInArr(
+                          setting.exportCustomMultiTarget,
+                          i
+                        ),
+                      })
+                    }
+                  >
+                    <Checkbox
+                      edge="start"
+                      checked={setting.exportCustomMultiTarget.includes(i)}
+                      tabIndex={-1}
+                      disableRipple
+                    />
+                    <ListItemText primary={name} />
+                  </ListItemButton>
+                </ListItem>
+              )
+            })}
+          </FieldDisplayList>
+          <Divider />
+        </>
+      )}
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <BuildIcon />
+        <Typography>Builds to Export</Typography>
+      </CardContent>
+      <FieldDisplayList bgt="light">
+        <ListItem sx={{ p: 0 }}>
+          <ListItemButton
+            onClick={() =>
+              setSetting({ convertEquipped: !setting.convertEquipped })
+            }
+          >
+            <Checkbox
+              edge="start"
+              checked={setting.convertEquipped}
+              tabIndex={-1}
+              disableRipple
+            />
+            <ListItemText primary={`Equipped Build`} />
+          </ListItemButton>
+        </ListItem>
+        {buildIds.map((buildId) => {
+          const build = database.builds.get(buildId)!
+          return (
+            <ListItem key={buildId} sx={{ p: 0 }}>
+              <ListItemButton
+                onClick={() =>
+                  setSetting({
+                    convertbuilds: toggleInArr(setting.convertbuilds, buildId),
+                  })
+                }
+              >
+                <Checkbox
+                  edge="start"
+                  checked={setting.convertbuilds.includes(buildId)}
+                  tabIndex={-1}
+                  disableRipple
+                />
+                <ListItemText primary={build.name} />
+              </ListItemButton>
+            </ListItem>
+          )
+        })}
+        {buildTcIds.map((buildTcId) => {
+          const buildTc = database.buildTcs.get(buildTcId)!
+          return (
+            <ListItem key={buildTcId} sx={{ p: 0 }}>
+              <ListItemButton
+                onClick={() =>
+                  setSetting({
+                    convertTcBuilds: toggleInArr(
+                      setting.convertTcBuilds,
+                      buildTcId
+                    ),
+                  })
+                }
+              >
+                <Checkbox
+                  edge="start"
+                  checked={setting.convertTcBuilds.includes(buildTcId)}
+                  tabIndex={-1}
+                  disableRipple
+                />
+                <ListItemText
+                  primary={
+                    <Box>
+                      {buildTc.name} <SqBadge>TC Build</SqBadge>
+                    </Box>
+                  }
+                />
+              </ListItemButton>
+            </ListItem>
+          )
+        })}
+      </FieldDisplayList>
+    </CardThemed>
   )
 }

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -472,7 +472,9 @@ function LoadoutSetting({
         <>
           <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <CustomMultiTargetIcon />
-            <Typography>Mtargets to Export</Typography>
+            <Typography>
+              <strong>Mtargets to Export</strong>
+            </Typography>
           </CardContent>
           <FieldDisplayList bgt="light">
             {customMultiTargets.map((mtarget, i) => {
@@ -506,7 +508,9 @@ function LoadoutSetting({
       )}
       <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <BuildIcon />
-        <Typography>Builds to Export</Typography>
+        <Typography>
+          <strong>Builds to Export</strong>
+        </Typography>
       </CardContent>
       <FieldDisplayList bgt="light">
         <ListItem sx={{ p: 0 }}>

--- a/libs/gi/ui/src/components/character/editor/LoadoutCard.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutCard.tsx
@@ -1,35 +1,19 @@
 import { useBoolState } from '@genshin-optimizer/common/react-util'
-import {
-  BootstrapTooltip,
-  CardThemed,
-  SqBadge,
-} from '@genshin-optimizer/common/ui'
-import { objPathValue } from '@genshin-optimizer/common/util'
-import type { CustomMultiTarget, LoadoutDatum } from '@genshin-optimizer/gi/db'
-import { useDatabase, useOptConfig } from '@genshin-optimizer/gi/db-ui'
-import type { CalcResult } from '@genshin-optimizer/gi/uidata'
+import { CardThemed } from '@genshin-optimizer/common/ui'
+import type { LoadoutDatum } from '@genshin-optimizer/gi/db'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import AddIcon from '@mui/icons-material/Add'
-import CheckroomIcon from '@mui/icons-material/Checkroom'
-import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
-import InfoIcon from '@mui/icons-material/Info'
-import PersonIcon from '@mui/icons-material/Person'
-import SettingsIcon from '@mui/icons-material/Settings'
-import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import {
-  Box,
   Button,
   CardActionArea,
   CardContent,
   Divider,
   Grid,
-  Typography,
 } from '@mui/material'
-import { useContext, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { DataContext } from '../../../context'
-import { getDisplayHeader, resolveInfo } from '../../../util'
 import { TeamCard } from '../../team'
 import { LoadoutEditor } from './LoadoutEditor'
+import { LoadoutHeaderContent } from './LoadoutHeaderContent'
 const columns = {
   xs: 1,
   md: 2,
@@ -45,15 +29,6 @@ export function LoadoutCard({
 }) {
   const navigate = useNavigate()
   const database = useDatabase()
-  const {
-    name,
-    description,
-    buildIds,
-    buildTcIds,
-    optConfigId,
-    customMultiTargets,
-  } = database.teamChars.get(teamCharId)!
-  const { optimizationTarget } = useOptConfig(optConfigId)!
   const onAddTeam = (teamCharId: string) => {
     const teamId = database.teams.new()
     database.teams.set(teamId, (team) => {
@@ -72,52 +47,7 @@ export function LoadoutCard({
       />
       <CardThemed key={teamCharId} bgt="light">
         <CardActionArea onClick={onShow}>
-          <CardContent
-            sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
-          >
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              <PersonIcon />
-              <Typography variant="h6">{name}</Typography>
-              {!!description && (
-                <BootstrapTooltip
-                  title={<Typography>{description}</Typography>}
-                >
-                  <InfoIcon />
-                </BootstrapTooltip>
-              )}
-
-              <SettingsIcon sx={{ ml: 'auto' }} />
-            </Box>
-            <Box
-              sx={{ display: 'flex', gap: 1, justifyContent: 'space-between' }}
-            >
-              <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
-                <CheckroomIcon />
-                <Typography>
-                  Builds: <strong>{buildIds.length}</strong>
-                </Typography>
-              </Box>
-              <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
-                <CheckroomIcon />
-                <Typography>
-                  TC Builds: <strong>{buildTcIds.length}</strong>
-                </Typography>
-              </Box>
-              <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
-                <DashboardCustomizeIcon />
-                <Typography>
-                  Custom multi-targets:{' '}
-                  <strong>{customMultiTargets.length}</strong>
-                </Typography>
-              </Box>
-            </Box>
-            {optimizationTarget && (
-              <OptimizationTargetDisplay
-                customMultiTargets={customMultiTargets}
-                optimizationTarget={optimizationTarget}
-              />
-            )}
-          </CardContent>
+          <LoadoutHeaderContent teamCharId={teamCharId} showSetting />
         </CardActionArea>
         <Divider />
         <CardContent sx={{ p: 1 }}>
@@ -148,58 +78,5 @@ export function LoadoutCard({
         </CardContent>
       </CardThemed>
     </>
-  )
-}
-function OptimizationTargetDisplay({
-  optimizationTarget,
-  customMultiTargets,
-}: {
-  optimizationTarget: string[]
-  customMultiTargets: CustomMultiTarget[]
-}) {
-  const { data } = useContext(DataContext)
-  const database = useDatabase()
-  const displayHeader = useMemo(
-    () => getDisplayHeader(data, optimizationTarget[0], database),
-    [data, optimizationTarget, database]
-  )
-
-  const { title, icon, action } = displayHeader ?? {}
-  const node: CalcResult | undefined = objPathValue(
-    data.getDisplay(),
-    optimizationTarget
-  ) as any
-
-  const {
-    textSuffix,
-    icon: infoIcon,
-    // Since mtargets are not passed in the character UIData, retrieve the name manually.
-    name = optimizationTarget[0] === 'custom'
-      ? customMultiTargets[parseInt(optimizationTarget[1] ?? '')]?.name
-      : undefined,
-  } = (node && resolveInfo(node.info)) ?? {}
-
-  const suffixDisplay = textSuffix && <span> {textSuffix}</span>
-  const iconDisplay = icon ? icon : infoIcon
-  return (
-    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-      <TrendingUpIcon />
-      <Typography>Optimization Target:</Typography>
-      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-        {iconDisplay}
-        <span>{title}</span>
-        {!!action && (
-          <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
-            {action}
-          </SqBadge>
-        )}
-      </Box>
-      <Typography sx={{ display: 'flex', alignItems: 'center' }}>
-        <SqBadge sx={{ whiteSpace: 'normal' }}>
-          <strong>{name}</strong>
-          {suffixDisplay}
-        </SqBadge>
-      </Typography>
-    </Box>
   )
 }

--- a/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutEditor.tsx
@@ -29,11 +29,13 @@ import {
   Divider,
   Grid,
   IconButton,
+  Stack,
   Tooltip,
   Typography,
 } from '@mui/material'
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { OptimizationIcon } from '../../../consts'
 import { DocumentDisplay } from '../../DocumentDisplay'
 import { BuildInfoAlert, TCBuildInfoAlert } from '../../build'
 import { LoadoutInfoAlert } from '../../loadout'
@@ -177,10 +179,34 @@ export function LoadoutEditor({
               )}
               {!!optimizationTarget && (
                 <Grid item xs={1}>
-                  <OptimizationTargetDisplay
-                    optimizationTarget={optimizationTarget}
-                    customMultiTargets={customMultiTargets}
-                  />
+                  <CardThemed bgt="light">
+                    <CardHeader
+                      title={
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                          }}
+                        >
+                          <OptimizationIcon />
+                          <span>Optimization Target</span>
+                        </Box>
+                      }
+                    />
+                    <Divider />
+                    <CardContent>
+                      <Stack
+                        divider={<Divider orientation="vertical" flexItem />}
+                        spacing={1}
+                      >
+                        <OptimizationTargetDisplay
+                          optimizationTarget={optimizationTarget}
+                          customMultiTargets={customMultiTargets}
+                        />
+                      </Stack>
+                    </CardContent>
+                  </CardThemed>
                 </Grid>
               )}
               {!!customMultiTargets.length && (

--- a/libs/gi/ui/src/components/character/editor/LoadoutHeaderContent.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutHeaderContent.tsx
@@ -1,0 +1,74 @@
+import { BootstrapTooltip } from '@genshin-optimizer/common/ui'
+import { useDatabase, useOptConfig } from '@genshin-optimizer/gi/db-ui'
+import CheckroomIcon from '@mui/icons-material/Checkroom'
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
+import InfoIcon from '@mui/icons-material/Info'
+import PersonIcon from '@mui/icons-material/Person'
+import SettingsIcon from '@mui/icons-material/Settings'
+import { Box, CardContent, Typography } from '@mui/material'
+import { OptimizationIcon } from '../../../consts'
+import { OptimizationTargetDisplay } from './OptimizationTargetDisplay'
+export function LoadoutHeaderContent({
+  teamCharId,
+  showSetting = false,
+}: {
+  teamCharId: string
+  showSetting?: boolean
+}) {
+  const database = useDatabase()
+  const {
+    name,
+    description,
+    buildIds,
+    buildTcIds,
+    optConfigId,
+    customMultiTargets,
+  } = database.teamChars.get(teamCharId)!
+  const { optimizationTarget } = useOptConfig(optConfigId)!
+
+  return (
+    <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <PersonIcon />
+        <Typography variant="h6">{name}</Typography>
+        {!!description && (
+          <BootstrapTooltip title={<Typography>{description}</Typography>}>
+            <InfoIcon />
+          </BootstrapTooltip>
+        )}
+
+        {showSetting && <SettingsIcon sx={{ ml: 'auto' }} />}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'space-between' }}>
+        <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
+          <CheckroomIcon />
+          <Typography>
+            Builds: <strong>{buildIds.length}</strong>
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
+          <CheckroomIcon />
+          <Typography>
+            TC Builds: <strong>{buildTcIds.length}</strong>
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', justifyItems: 'center', gap: 1 }}>
+          <DashboardCustomizeIcon />
+          <Typography>
+            Custom multi-targets: <strong>{customMultiTargets.length}</strong>
+          </Typography>
+        </Box>
+      </Box>
+      {optimizationTarget && (
+        <Typography sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          <OptimizationIcon />
+          <Box>Optimization Target:</Box>
+          <OptimizationTargetDisplay
+            customMultiTargets={customMultiTargets}
+            optimizationTarget={optimizationTarget}
+          />
+        </Typography>
+      )}
+    </CardContent>
+  )
+}

--- a/libs/gi/ui/src/components/character/editor/OptimizationTargetDisplay.tsx
+++ b/libs/gi/ui/src/components/character/editor/OptimizationTargetDisplay.tsx
@@ -1,17 +1,9 @@
-import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
+import { SqBadge } from '@genshin-optimizer/common/ui'
 import { objPathValue } from '@genshin-optimizer/common/util'
 import type { CustomMultiTarget } from '@genshin-optimizer/gi/db'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
-import TrackChangesIcon from '@mui/icons-material/TrackChanges'
-import {
-  Box,
-  CardContent,
-  CardHeader,
-  Divider,
-  Stack,
-  Typography,
-} from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { useContext, useMemo } from 'react'
 import { DataContext } from '../../../context'
 import { getDisplayHeader, resolveInfo } from '../../../util'
@@ -47,47 +39,22 @@ export function OptimizationTargetDisplay({
   const suffixDisplay = textSuffix && <span> {textSuffix}</span>
   const iconDisplay = icon ? icon : infoIcon
   return (
-    <CardThemed bgt="light">
-      <CardHeader
-        title={
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-            }}
-          >
-            <TrackChangesIcon />
-            <span>Optimization Target</span>
-          </Box>
-        }
-      />
-      <Divider />
-      <CardContent>
-        <Stack
-          divider={<Divider orientation="vertical" flexItem />}
-          spacing={1}
-        >
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            {iconDisplay}
-            <span>{title}</span>
-            {!!action && (
-              <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
-                {action}
-              </SqBadge>
-            )}
-          </Box>
-          <Typography
-            variant="h6"
-            sx={{ display: 'flex', alignItems: 'center' }}
-          >
-            <SqBadge sx={{ whiteSpace: 'normal' }}>
-              <strong>{name}</strong>
-              {suffixDisplay}
-            </SqBadge>
-          </Typography>
-        </Stack>
-      </CardContent>
-    </CardThemed>
+    <>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        {iconDisplay}
+        <span>{title}</span>
+        {!!action && (
+          <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
+            {action}
+          </SqBadge>
+        )}
+      </Box>
+      <Typography sx={{ display: 'flex', alignItems: 'center' }}>
+        <SqBadge sx={{ whiteSpace: 'normal' }}>
+          <strong>{name}</strong>
+          {suffixDisplay}
+        </SqBadge>
+      </Typography>
+    </>
   )
 }

--- a/libs/gi/ui/src/components/character/editor/index.ts
+++ b/libs/gi/ui/src/components/character/editor/index.ts
@@ -1,1 +1,3 @@
 export * from './CharacterEditor'
+export * from './LoadoutHeaderContent'
+export * from './OptimizationTargetDisplay'

--- a/libs/gi/ui/src/consts.tsx
+++ b/libs/gi/ui/src/consts.tsx
@@ -1,4 +1,7 @@
 import CheckroomIcon from '@mui/icons-material/Checkroom'
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+
 export const BuildIcon = CheckroomIcon
 export const CustomMultiTargetIcon = DashboardCustomizeIcon
+export const OptimizationIcon = TrendingUpIcon

--- a/libs/gi/ui/src/consts.tsx
+++ b/libs/gi/ui/src/consts.tsx
@@ -1,0 +1,4 @@
+import CheckroomIcon from '@mui/icons-material/Checkroom'
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
+export const BuildIcon = CheckroomIcon
+export const CustomMultiTargetIcon = DashboardCustomizeIcon

--- a/libs/gi/ui/src/index.ts
+++ b/libs/gi/ui/src/index.ts
@@ -1,6 +1,7 @@
 import '@genshin-optimizer/gi/theme'
 import './App.scss'
 export * from './components'
+export * from './consts'
 export * from './context'
 export * from './hooks'
 export type * from './type'


### PR DESCRIPTION
## Describe your changes

Add more granular options to exporting team, So the exporter can choose what they want to be exported.
- selectable equipped build
- selectable builds
- selectable tc builds
- selectable mtargets

Special handling for selected mtarget as opt target

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Should handling exporting a mtarget, and the imported team still links to that mtarget

![Screenshot 2024-05-14 054613](https://github.com/frzyc/genshin-optimizer/assets/1754901/1dfcfa03-c80e-4882-9848-e67a57d8b5fe)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
