### PR TITLE
Condense mtarget UI, add editor

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/CustomMultiTarget.ts
+++ b/libs/gi/db/src/Database/DataManagers/CustomMultiTarget.ts
@@ -27,6 +27,7 @@ export function initCustomTarget(path: string[], multi = 1): CustomTarget {
     path,
     hitMode: 'avgHit',
     bonusStats: {},
+    description: '',
   }
 }
 function validateOptTarget(path: string[]): string[] {
@@ -35,8 +36,15 @@ function validateOptTarget(path: string[]): string[] {
 }
 function validateCustomTarget(ct: unknown): CustomTarget | undefined {
   if (typeof ct !== 'object') return undefined
-  let { weight, path, hitMode, reaction, infusionAura, bonusStats } =
-    ct as CustomTarget
+  let {
+    weight,
+    path,
+    hitMode,
+    reaction,
+    infusionAura,
+    bonusStats,
+    description,
+  } = ct as CustomTarget
 
   if (typeof weight !== 'number' || weight <= 0) weight = 1
 
@@ -63,6 +71,8 @@ function validateCustomTarget(ct: unknown): CustomTarget | undefined {
 
   if (!bonusStats) bonusStats = {}
 
+  if (typeof description !== 'string') description = ''
+
   bonusStats = Object.fromEntries(
     Object.entries(bonusStats).filter(
       ([key, value]) =>
@@ -71,7 +81,15 @@ function validateCustomTarget(ct: unknown): CustomTarget | undefined {
     )
   )
 
-  return { weight, path, hitMode, reaction, infusionAura, bonusStats }
+  return {
+    weight,
+    path,
+    hitMode,
+    reaction,
+    infusionAura,
+    bonusStats,
+    description,
+  }
 }
 export function validateCustomMultiTarget(
   cmt: unknown

--- a/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamCharacterDataManager.ts
@@ -16,10 +16,14 @@ import {
   type AmpReactionKey,
   type CharacterKey,
   type InfusionAuraElementKey,
-  type MultiOptHitModeKey,
 } from '@genshin-optimizer/gi/consts'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
-import type { BuildTc, ICachedArtifact, ICachedWeapon } from '../../Interfaces'
+import type {
+  BuildTc,
+  CustomMultiTarget,
+  ICachedArtifact,
+  ICachedWeapon,
+} from '../../Interfaces'
 import type { InputPremodKey } from '../../legacy/keys'
 import type { ArtCharDatabase } from '../ArtCharDatabase'
 import { DataManager } from '../DataManager'
@@ -55,20 +59,6 @@ export interface TeamCharacter {
 
   buildTcIds: string[]
   optConfigId: string
-}
-
-export interface CustomTarget {
-  weight: number
-  path: string[]
-  hitMode: MultiOptHitModeKey
-  reaction?: AmpReactionKey | AdditiveReactionKey
-  infusionAura?: InfusionAuraElementKey
-  bonusStats: Partial<Record<InputPremodKey, number>>
-}
-export interface CustomMultiTarget {
-  name: string
-  description?: string
-  targets: CustomTarget[]
 }
 
 export class TeamCharacterDataManager extends DataManager<

--- a/libs/gi/db/src/Interfaces/CustomMultiTarget.ts
+++ b/libs/gi/db/src/Interfaces/CustomMultiTarget.ts
@@ -12,6 +12,7 @@ export interface CustomTarget {
   infusionAura?: InfusionAuraElementKey
   // TODO: Partial<Record<InputPremodKey, number>>
   bonusStats: Record<string, number>
+  description: string
 }
 export interface CustomMultiTarget {
   name: string

--- a/libs/gi/db/src/Interfaces/CustomMultiTarget.ts
+++ b/libs/gi/db/src/Interfaces/CustomMultiTarget.ts
@@ -4,14 +4,16 @@ import type {
   InfusionAuraElementKey,
   MultiOptHitModeKey,
 } from '@genshin-optimizer/gi/consts'
+import type { InputPremodKey } from '../legacy/keys'
+
+export type BonusStats = Partial<Record<InputPremodKey, number>>
 export interface CustomTarget {
   weight: number
   path: string[]
   hitMode: MultiOptHitModeKey
   reaction?: AmpReactionKey | AdditiveReactionKey
   infusionAura?: InfusionAuraElementKey
-  // TODO: Partial<Record<InputPremodKey, number>>
-  bonusStats: Record<string, number>
+  bonusStats: BonusStats
   description: string
 }
 export interface CustomMultiTarget {

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
@@ -96,7 +96,7 @@ export default function CustomMultiTargetCard({
     [target, setTarget]
   )
 
-  const [selectedTarget, setSelectedTarget] = useState(0)
+  const [selectedTarget, setSelectedTarget] = useState(-1)
   const setTargetIndex = useCallback(
     (oldInd: number) => (newRank?: number) => {
       if (newRank === undefined || newRank === 0) return
@@ -131,7 +131,9 @@ export default function CustomMultiTargetCard({
         <CustomTargetDisplay
           key={t.path.join() + i}
           selected={selectedTarget === i}
-          setSelect={() => setSelectedTarget(i)}
+          setSelect={() =>
+            selectedTarget === i ? setSelectedTarget(-1) : setSelectedTarget(i)
+          }
           customTarget={t}
           rank={i + 1}
         />
@@ -140,7 +142,7 @@ export default function CustomMultiTargetCard({
   )
   const selectedTargetValid = clamp(
     selectedTarget,
-    0,
+    -1,
     target.targets.length - 1
   )
   return (

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
@@ -244,15 +244,17 @@ export default function CustomMultiTargetCard({
           >
             {customTargetDisplays}
             <AddCustomTargetBtn setTarget={addTarget} />
-            <MTargetEditor
-              customTarget={target.targets[selectedTargetValid]}
-              setCustomTarget={setCustomTarget(selectedTargetValid)}
-              deleteCustomTarget={deleteCustomTarget(selectedTargetValid)}
-              rank={selectedTargetValid + 1}
-              maxRank={target.targets.length}
-              setTargetIndex={setTargetIndex(selectedTargetValid)}
-              onDup={dupCustomTarget(selectedTargetValid)}
-            />
+            {target.targets[selectedTargetValid] && (
+              <MTargetEditor
+                customTarget={target.targets[selectedTargetValid]}
+                setCustomTarget={setCustomTarget(selectedTargetValid)}
+                deleteCustomTarget={deleteCustomTarget(selectedTargetValid)}
+                rank={selectedTargetValid + 1}
+                maxRank={target.targets.length}
+                setTargetIndex={setTargetIndex(selectedTargetValid)}
+                onDup={dupCustomTarget(selectedTargetValid)}
+              />
+            )}
           </CardContent>
         </CardThemed>
       </ModalWrapper>

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
@@ -1,218 +1,93 @@
-import {
-  CardThemed,
-  CustomNumberInput,
-  CustomNumberInputButtonGroupWrapper,
-  DropdownButton,
-} from '@genshin-optimizer/common/ui'
+import { CardThemed } from '@genshin-optimizer/common/ui'
 import { objPathValue } from '@genshin-optimizer/common/util'
 import type {
   AdditiveReactionKey,
   AmpReactionKey,
   InfusionAuraElementKey,
 } from '@genshin-optimizer/gi/consts'
-import {
-  allAmpReactionKeys,
-  allMultiOptHitModeKeys,
-  allowedAdditiveReactions,
-  allowedAmpReactions,
-} from '@genshin-optimizer/gi/consts'
+import { allAmpReactionKeys } from '@genshin-optimizer/gi/consts'
 import type { CustomTarget } from '@genshin-optimizer/gi/db'
-import { CharacterContext } from '@genshin-optimizer/gi/db-ui'
-import { isCharMelee } from '@genshin-optimizer/gi/stats'
 import {
   AdditiveReactionModeText,
   AmpReactionModeText,
   DataContext,
-  StatEditorList,
-  infusionVals,
 } from '@genshin-optimizer/gi/ui'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
-import { allInputPremodKeys } from '@genshin-optimizer/gi/wr'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
-import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
-import { Box, Button, ButtonGroup, Grid, MenuItem } from '@mui/material'
-import { useCallback, useContext, useMemo } from 'react'
+import BarChartIcon from '@mui/icons-material/BarChart'
+import { Box, CardActionArea, Chip, Typography } from '@mui/material'
+import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import OptimizationTargetSelector from '../Tabs/TabOptimize/Components/OptimizationTargetSelector'
+import OptimizationTargetDisplay from '../Tabs/TabOptimize/Components/OptimizationTargetDisplay'
 
-const keys = [...allInputPremodKeys]
-const wrapperFunc = (e: JSX.Element, key?: string) => (
-  <Grid item key={key} xs={1}>
-    {e}
-  </Grid>
-)
 export default function CustomTargetDisplay({
+  selected,
+  setSelect,
   customTarget,
-  setCustomTarget,
-  deleteCustomTarget,
   rank,
-  maxRank,
-  setTargetIndex,
-  onDup,
 }: {
+  selected: boolean
+  setSelect: () => void
   customTarget: CustomTarget
-  setCustomTarget: (t: CustomTarget) => void
-  deleteCustomTarget: () => void
   rank: number
-  maxRank: number
-  setTargetIndex: (ind?: number) => void
-  onDup: () => void
 }) {
   const { t } = useTranslation('page_character')
-  const {
-    character: { key: characterKey },
-  } = useContext(CharacterContext)
   const { data } = useContext(DataContext)
   const { path, weight, hitMode, reaction, infusionAura, bonusStats } =
     customTarget
-  const setWeight = useCallback(
-    (weight) => setCustomTarget({ ...customTarget, weight }),
-    [customTarget, setCustomTarget]
-  )
+
   const node = objPathValue(data.getDisplay(), path) as CalcResult | undefined
-  const setFilter = useCallback(
-    (bonusStats) => setCustomTarget({ ...customTarget, bonusStats }),
-    [customTarget, setCustomTarget]
-  )
 
-  const statEditorList = useMemo(
-    () => (
-      <StatEditorList
-        statKeys={keys}
-        statFilters={bonusStats}
-        setStatFilters={setFilter}
-        wrapperFunc={wrapperFunc}
-        label={t('addStats.label')}
-      />
-    ),
-    [bonusStats, setFilter, t]
-  )
-
-  const isMeleeAuto =
-    isCharMelee(characterKey) &&
-    (path[0] === 'normal' || path[0] === 'charged' || path[0] === 'plunging')
-  const isTransformativeReaction = path[0] === 'reaction'
   return (
-    <CardThemed bgt="light" sx={{ display: 'flex' }}>
-      <Box sx={{ p: 1, flexGrow: 1 }}>
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          <CustomNumberInput
-            float
-            startAdornment="x"
-            value={weight}
-            onChange={setWeight}
-            sx={{ borderRadius: 1, pl: 1 }}
-            inputProps={{ sx: { pl: 0.5, width: '2em' }, min: 0 }}
-          />
-          <OptimizationTargetSelector
+    <CardThemed
+      bgt="light"
+      sx={{ display: 'flex', border: selected ? '2px solid green' : undefined }}
+    >
+      <CardActionArea sx={{ p: 1, flexGrow: 1 }} onClick={setSelect}>
+        <Typography
+          sx={{
+            display: 'flex',
+            gap: 1,
+            flexWrap: 'wrap',
+            alignItems: 'center',
+          }}
+        >
+          <Chip label={`#${rank}`} sx={{ minWidth: '4em' }} />
+          <Chip label={`x${weight}`} sx={{ minWidth: '5em' }} />
+
+          <OptimizationTargetDisplay
             optimizationTarget={path}
-            setTarget={(path) =>
-              setCustomTarget({
-                ...customTarget,
-                path,
-                reaction: undefined,
-                infusionAura: undefined,
-              })
-            }
             showEmptyTargets
-            targetSelectorModalProps={{
-              flatOnly: true,
-              excludeSections: ['basic', 'custom'],
-            }}
           />
           <Box sx={{ flexGrow: 1 }} />
           {node && (
-            <ReactionDropdown
+            <ReactionChip
               reaction={reaction}
-              setReactionMode={(rm) =>
-                setCustomTarget({ ...customTarget, reaction: rm })
-              }
               node={node}
               infusionAura={infusionAura}
             />
           )}
-          <DropdownButton title={t(`hitmode.${hitMode}`)}>
-            {allMultiOptHitModeKeys.map((hm) => (
-              <MenuItem
-                key={hm}
-                value={hm}
-                disabled={hitMode === hm}
-                onClick={() =>
-                  setCustomTarget({ ...customTarget, hitMode: hm })
-                }
-              >
-                {t(`hitmode.${hm}`)}
-              </MenuItem>
-            ))}
-          </DropdownButton>
-        </Box>
-        <Grid container columns={{ xs: 1, lg: 2 }} sx={{ pt: 1 }} spacing={1}>
-          {(isMeleeAuto || isTransformativeReaction) && (
-            <Grid item xs={1}>
-              <DropdownButton
-                title={infusionVals[infusionAura ?? '']}
-                color={infusionAura || 'secondary'}
-                disableElevation
-                fullWidth
-              >
-                {Object.entries(infusionVals).map(([key, text]) => (
-                  <MenuItem
-                    key={key}
-                    sx={key ? { color: `${key}.main` } : undefined}
-                    selected={key === infusionAura}
-                    disabled={key === infusionAura}
-                    onClick={() =>
-                      setCustomTarget({
-                        ...customTarget,
-                        infusionAura: key ? key : undefined,
-                        reaction: undefined,
-                      })
-                    }
-                  >
-                    {text}
-                  </MenuItem>
-                ))}
-              </DropdownButton>
-            </Grid>
+          {!!Object.values(bonusStats).length && (
+            <Chip
+              avatar={<BarChartIcon />}
+              label={<strong>{Object.values(bonusStats).length}</strong>}
+            />
           )}
-          {statEditorList}
-        </Grid>
-      </Box>
-      <ButtonGroup
-        orientation="vertical"
-        sx={{ borderTopLeftRadius: 0, '*': { flexGrow: 1 } }}
-      >
-        <CustomNumberInputButtonGroupWrapper>
-          <CustomNumberInput
-            value={rank}
-            onChange={setTargetIndex}
-            sx={{ pl: 2 }}
-            inputProps={{ sx: { width: '1em' }, min: 1, max: maxRank }}
-          />
-        </CustomNumberInputButtonGroupWrapper>
-        <Button size="small" color="info" onClick={onDup}>
-          <ContentCopyIcon />
-        </Button>
-        <Button size="small" color="error" onClick={deleteCustomTarget}>
-          <DeleteForeverIcon />
-        </Button>
-      </ButtonGroup>
+          <Chip label={t(`hitmode.${hitMode}`)} />
+        </Typography>
+      </CardActionArea>
     </CardThemed>
   )
 }
-function ReactionDropdown({
+function ReactionChip({
   node,
   reaction,
-  setReactionMode,
   infusionAura,
 }: {
   node: CalcResult
   reaction?: AmpReactionKey | AdditiveReactionKey
-  setReactionMode: (r?: AmpReactionKey | AdditiveReactionKey) => void
   infusionAura?: InfusionAuraElementKey
 }) {
   const ele = node.info.variant ?? 'physical'
-  const { t } = useTranslation('page_character')
 
   if (
     !['pyro', 'hydro', 'cryo', 'electro', 'dendro'].some(
@@ -220,41 +95,14 @@ function ReactionDropdown({
     )
   )
     return null
-  const reactions = [
-    ...new Set([
-      ...(allowedAmpReactions[ele] ?? []),
-      ...(allowedAmpReactions[infusionAura ?? ''] ?? []),
-      ...(allowedAdditiveReactions[ele] ?? []),
-      ...(allowedAdditiveReactions[infusionAura ?? ''] ?? []),
-    ]),
-  ]
-  const title = reaction ? (
-    ([...allAmpReactionKeys] as string[]).includes(reaction) ? (
+  const title =
+    reaction &&
+    (([...allAmpReactionKeys] as string[]).includes(reaction) ? (
       <AmpReactionModeText reaction={reaction as AmpReactionKey} />
     ) : (
       <AdditiveReactionModeText reaction={reaction as AdditiveReactionKey} />
-    )
-  ) : (
-    t`noReaction`
-  )
-  return (
-    <DropdownButton title={title} sx={{ ml: 'auto' }}>
-      <MenuItem value="" disabled={!reaction} onClick={() => setReactionMode()}>
-        No Reactions
-      </MenuItem>
-      {reactions.map((rm) => (
-        <MenuItem
-          key={rm}
-          disabled={reaction === rm}
-          onClick={() => setReactionMode(rm)}
-        >
-          {([...allAmpReactionKeys] as string[]).includes(rm) ? (
-            <AmpReactionModeText reaction={rm} />
-          ) : (
-            <AdditiveReactionModeText reaction={rm} />
-          )}
-        </MenuItem>
-      ))}
-    </DropdownButton>
-  )
+    ))
+  if (!title) return null
+
+  return <Chip label={title} />
 }

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
@@ -44,6 +44,7 @@ export default function CustomTargetDisplay({
     >
       <CardActionArea sx={{ p: 1, flexGrow: 1 }} onClick={setSelect}>
         <Typography
+          component="div"
           sx={{
             display: 'flex',
             gap: 1,

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/MTargetEditor.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/MTargetEditor.tsx
@@ -1,0 +1,322 @@
+import {
+  CardThemed,
+  DropdownButton,
+  TextFieldLazy,
+} from '@genshin-optimizer/common/ui'
+import { objPathValue } from '@genshin-optimizer/common/util'
+import type {
+  AdditiveReactionKey,
+  AmpReactionKey,
+  InfusionAuraElementKey,
+} from '@genshin-optimizer/gi/consts'
+import {
+  allAmpReactionKeys,
+  allMultiOptHitModeKeys,
+  allowedAdditiveReactions,
+  allowedAmpReactions,
+} from '@genshin-optimizer/gi/consts'
+import type { CustomTarget } from '@genshin-optimizer/gi/db'
+import { CharacterContext } from '@genshin-optimizer/gi/db-ui'
+import { isCharMelee } from '@genshin-optimizer/gi/stats'
+import {
+  AdditiveReactionModeText,
+  AmpReactionModeText,
+  DataContext,
+  StatEditorList,
+  infusionVals,
+} from '@genshin-optimizer/gi/ui'
+import type { CalcResult } from '@genshin-optimizer/gi/uidata'
+import { allInputPremodKeys } from '@genshin-optimizer/gi/wr'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import {
+  Box,
+  CardContent,
+  Divider,
+  Grid,
+  IconButton,
+  InputAdornment,
+  MenuItem,
+  Typography,
+} from '@mui/material'
+import { useCallback, useContext, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import OptimizationTargetSelector from '../Tabs/TabOptimize/Components/OptimizationTargetSelector'
+
+const keys = [...allInputPremodKeys]
+const wrapperFunc = (e: JSX.Element, key?: string) => (
+  <Grid item key={key} xs={1}>
+    {e}
+  </Grid>
+)
+
+export default function MTargetEditor({
+  customTarget,
+  setCustomTarget,
+  deleteCustomTarget,
+  rank,
+  maxRank,
+  setTargetIndex,
+  onDup,
+}: {
+  customTarget: CustomTarget
+  setCustomTarget: (t: CustomTarget) => void
+  deleteCustomTarget: () => void
+  rank: number
+  maxRank: number
+  setTargetIndex: (ind?: number) => void
+  onDup: () => void
+}) {
+  const { t } = useTranslation('page_character')
+  const {
+    character: { key: characterKey },
+  } = useContext(CharacterContext)
+  const { data } = useContext(DataContext)
+  const {
+    path,
+    weight,
+    hitMode,
+    reaction,
+    infusionAura,
+    bonusStats,
+    description,
+  } = customTarget
+  const setWeight = useCallback(
+    (weight: number) => setCustomTarget({ ...customTarget, weight }),
+    [customTarget, setCustomTarget]
+  )
+  const node = objPathValue(data.getDisplay(), path) as CalcResult | undefined
+  const setFilter = useCallback(
+    (bonusStats: CustomTarget['bonusStats']) =>
+      setCustomTarget({ ...customTarget, bonusStats }),
+    [customTarget, setCustomTarget]
+  )
+
+  const statEditorList = useMemo(
+    () => (
+      <StatEditorList
+        statKeys={keys}
+        statFilters={bonusStats}
+        setStatFilters={setFilter}
+        wrapperFunc={wrapperFunc}
+        label={t('addStats.label')}
+      />
+    ),
+    [bonusStats, setFilter, t]
+  )
+
+  const isMeleeAuto =
+    isCharMelee(characterKey) &&
+    (path[0] === 'normal' || path[0] === 'charged' || path[0] === 'plunging')
+  const isTransformativeReaction = path[0] === 'reaction'
+  return (
+    <CardThemed
+      bgt="light"
+      sx={{
+        boxShadow: '0 0 10px black',
+        position: 'sticky',
+        bottom: `10px`,
+        zIndex: 1000,
+      }}
+    >
+      <CardContent sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <Typography sx={{ flexGrow: 1 }} variant="h6">
+          Target Editor
+        </Typography>
+        <TextFieldLazy
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">Rank #</InputAdornment>
+            ),
+          }}
+          inputProps={{
+            sx: { width: '2em' },
+            min: 1,
+            max: maxRank,
+          }}
+          type="number"
+          value={rank.toString()}
+          onChange={(v) => setTargetIndex(parseInt(v))}
+          size="small"
+        />
+
+        <IconButton color="info" onClick={onDup}>
+          <ContentCopyIcon />
+        </IconButton>
+        <IconButton color="error" onClick={deleteCustomTarget}>
+          <DeleteForeverIcon />
+        </IconButton>
+      </CardContent>
+      <Divider />
+      <Box display="flex">
+        <Box sx={{ p: 1, flexGrow: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <TextFieldLazy
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">x</InputAdornment>
+                ),
+              }}
+              inputProps={{
+                sx: { width: '2em' },
+              }}
+              type="number"
+              value={weight.toString()}
+              onChange={(v) => setWeight(parseFloat(v))}
+              size="small"
+            />
+            <OptimizationTargetSelector
+              optimizationTarget={path}
+              setTarget={(path) =>
+                setCustomTarget({
+                  ...customTarget,
+                  path,
+                  reaction: undefined,
+                  infusionAura: undefined,
+                })
+              }
+              showEmptyTargets
+              targetSelectorModalProps={{
+                flatOnly: true,
+                excludeSections: ['basic', 'custom'],
+              }}
+            />
+            {node && (
+              <ReactionDropdown
+                reaction={reaction}
+                setReactionMode={(rm) =>
+                  setCustomTarget({ ...customTarget, reaction: rm })
+                }
+                node={node}
+                infusionAura={infusionAura}
+              />
+            )}
+            <DropdownButton title={t(`hitmode.${hitMode}`)}>
+              {allMultiOptHitModeKeys.map((hm) => (
+                <MenuItem
+                  key={hm}
+                  value={hm}
+                  disabled={hitMode === hm}
+                  onClick={() =>
+                    setCustomTarget({ ...customTarget, hitMode: hm })
+                  }
+                >
+                  {t(`hitmode.${hm}`)}
+                </MenuItem>
+              ))}
+            </DropdownButton>
+          </Box>
+          <Grid container columns={{ xs: 1, md: 2 }} spacing={1}>
+            <Grid item xs={1}>
+              <Box>
+                <Grid container columns={{ xs: 1 }} sx={{ pt: 1 }} spacing={1}>
+                  {(isMeleeAuto || isTransformativeReaction) && (
+                    <Grid item xs={1}>
+                      <DropdownButton
+                        title={infusionVals[infusionAura ?? '']}
+                        color={infusionAura || 'secondary'}
+                        disableElevation
+                        fullWidth
+                      >
+                        {Object.entries(infusionVals).map(([key, text]) => (
+                          <MenuItem
+                            key={key}
+                            sx={key ? { color: `${key}.main` } : undefined}
+                            selected={key === infusionAura}
+                            disabled={key === infusionAura}
+                            onClick={() =>
+                              setCustomTarget({
+                                ...customTarget,
+                                infusionAura: key ? key : undefined,
+                                reaction: undefined,
+                              })
+                            }
+                          >
+                            {text}
+                          </MenuItem>
+                        ))}
+                      </DropdownButton>
+                    </Grid>
+                  )}
+                  {statEditorList}
+                </Grid>
+              </Box>
+            </Grid>
+            <Grid item xs={1}>
+              <TextFieldLazy
+                fullWidth
+                label="Target Description"
+                value={description}
+                onChange={(description) =>
+                  setCustomTarget({ ...customTarget, description })
+                }
+                multiline
+                minRows={2}
+                sx={{ mt: 1 }}
+              />
+            </Grid>
+          </Grid>
+        </Box>
+      </Box>
+    </CardThemed>
+  )
+}
+
+function ReactionDropdown({
+  node,
+  reaction,
+  setReactionMode,
+  infusionAura,
+}: {
+  node: CalcResult
+  reaction?: AmpReactionKey | AdditiveReactionKey
+  setReactionMode: (r?: AmpReactionKey | AdditiveReactionKey) => void
+  infusionAura?: InfusionAuraElementKey
+}) {
+  const ele = node.info.variant ?? 'physical'
+  const { t } = useTranslation('page_character')
+
+  if (
+    !['pyro', 'hydro', 'cryo', 'electro', 'dendro'].some(
+      (e) => e === ele || e === infusionAura
+    )
+  )
+    return null
+  const reactions = [
+    ...new Set([
+      ...(allowedAmpReactions[ele] ?? []),
+      ...(allowedAmpReactions[infusionAura ?? ''] ?? []),
+      ...(allowedAdditiveReactions[ele] ?? []),
+      ...(allowedAdditiveReactions[infusionAura ?? ''] ?? []),
+    ]),
+  ]
+  const title = reaction ? (
+    ([...allAmpReactionKeys] as string[]).includes(reaction) ? (
+      <AmpReactionModeText reaction={reaction as AmpReactionKey} />
+    ) : (
+      <AdditiveReactionModeText reaction={reaction as AdditiveReactionKey} />
+    )
+  ) : (
+    t`noReaction`
+  )
+  return (
+    <DropdownButton title={title} sx={{ ml: 'auto' }}>
+      <MenuItem value="" disabled={!reaction} onClick={() => setReactionMode()}>
+        No Reactions
+      </MenuItem>
+      {reactions.map((rm) => (
+        <MenuItem
+          key={rm}
+          disabled={reaction === rm}
+          onClick={() => setReactionMode(rm)}
+        >
+          {([...allAmpReactionKeys] as string[]).includes(rm) ? (
+            <AmpReactionModeText reaction={rm} />
+          ) : (
+            <AdditiveReactionModeText reaction={rm} />
+          )}
+        </MenuItem>
+      ))}
+    </DropdownButton>
+  )
+}

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/MTargetEditor.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/MTargetEditor.tsx
@@ -44,7 +44,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material'
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import OptimizationTargetSelector from '../Tabs/TabOptimize/Components/OptimizationTargetSelector'
 
@@ -99,6 +99,10 @@ export default function MTargetEditor({
       setCustomTarget({ ...customTarget, bonusStats }),
     [customTarget, setCustomTarget]
   )
+  // Expand editor on change of custom target
+  useEffect(() => {
+    setcollapse(false)
+  }, [customTarget])
 
   const statEditorList = useMemo(
     () => (

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetDisplay.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetDisplay.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react'
 import { SqBadge } from '@genshin-optimizer/common/ui'
 import { objPathValue } from '@genshin-optimizer/common/util'
 import { useDatabase } from '@genshin-optimizer/gi/db-ui'
@@ -8,7 +7,7 @@ import {
   resolveInfo,
 } from '@genshin-optimizer/gi/ui'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
-import { Box, Divider, Stack, useMediaQuery } from '@mui/material'
+import { Box, Divider, Stack, useMediaQuery, useTheme } from '@mui/material'
 import { useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetDisplay.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetDisplay.tsx
@@ -1,0 +1,91 @@
+import { useTheme } from '@emotion/react'
+import { SqBadge } from '@genshin-optimizer/common/ui'
+import { objPathValue } from '@genshin-optimizer/common/util'
+import { useDatabase } from '@genshin-optimizer/gi/db-ui'
+import {
+  DataContext,
+  getDisplayHeader,
+  resolveInfo,
+} from '@genshin-optimizer/gi/ui'
+import type { CalcResult } from '@genshin-optimizer/gi/uidata'
+import { Box, Divider, Stack, useMediaQuery } from '@mui/material'
+import { useContext, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export default function OptimizationTargetDisplay({
+  optimizationTarget,
+  // TODO: does this do anything here?
+  showEmptyTargets = false,
+  defaultText,
+}: {
+  optimizationTarget?: string[]
+  showEmptyTargets?: boolean
+  defaultText?: string
+}) {
+  const { t } = useTranslation('page_character_optimize')
+
+  const { data } = useContext(DataContext)
+  const database = useDatabase()
+  const displayHeader = useMemo(
+    () =>
+      optimizationTarget &&
+      getDisplayHeader(data, optimizationTarget[0], database),
+    [data, optimizationTarget, database]
+  )
+
+  if (!defaultText) defaultText = t('targetSelector.selectOptTarget')
+
+  const { title, icon, action } = displayHeader ?? {}
+  const node: CalcResult | undefined =
+    optimizationTarget &&
+    (objPathValue(data.getDisplay(), optimizationTarget) as any)
+
+  const invalidTarget =
+    !optimizationTarget ||
+    !displayHeader ||
+    !node ||
+    // Make sure the opt target is valid, if we are not in multi-target
+    (!showEmptyTargets && node.isEmpty)
+
+  const {
+    name,
+    textSuffix,
+    icon: nodeIcon,
+    variant = invalidTarget ? 'secondary' : undefined,
+  } = (node?.info && resolveInfo(node?.info)) ?? {}
+
+  const suffixDisplay = textSuffix && <span> {textSuffix}</span>
+  const iconDisplay = icon ? icon : nodeIcon
+
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  return invalidTarget ? (
+    <strong>{defaultText}</strong>
+  ) : (
+    <Stack
+      direction="row"
+      divider={<Divider orientation="vertical" flexItem />}
+      spacing={1}
+    >
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        {iconDisplay}
+        {!isMobile && <span>{title}</span>}
+        {!!action && (
+          <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
+            {action}
+          </SqBadge>
+        )}
+      </Box>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <SqBadge
+          color={variant === 'invalid' ? undefined : variant}
+          sx={{ whiteSpace: 'normal' }}
+        >
+          <strong>{name}</strong>
+          {suffixDisplay}
+        </SqBadge>
+      </Box>
+    </Stack>
+  )
+}

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/OptimizationTargetSelector.tsx
@@ -1,16 +1,8 @@
 import { useBoolState } from '@genshin-optimizer/common/react-util'
-import { SqBadge } from '@genshin-optimizer/common/ui'
-import { objPathValue } from '@genshin-optimizer/common/util'
-import { useDatabase } from '@genshin-optimizer/gi/db-ui'
-import {
-  DataContext,
-  getDisplayHeader,
-  resolveInfo,
-} from '@genshin-optimizer/gi/ui'
-import type { CalcResult } from '@genshin-optimizer/gi/uidata'
-import { Box, Button, Divider, Stack } from '@mui/material'
-import { useCallback, useContext, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
+import type { ButtonProps } from '@mui/material'
+import { Button } from '@mui/material'
+import { useCallback } from 'react'
+import OptimizationTargetDisplay from './OptimizationTargetDisplay'
 import type { TargetSelectorModalProps } from './TargetSelectorModal'
 import { TargetSelectorModal } from './TargetSelectorModal'
 
@@ -21,6 +13,7 @@ export default function OptimizationTargetSelector({
   showEmptyTargets = false,
   defaultText,
   targetSelectorModalProps = {},
+  buttonProps = {},
 }: {
   optimizationTarget?: string[]
   setTarget: (target: string[]) => void
@@ -28,8 +21,8 @@ export default function OptimizationTargetSelector({
   showEmptyTargets?: boolean
   defaultText?: string
   targetSelectorModalProps?: Partial<TargetSelectorModalProps>
+  buttonProps?: ButtonProps
 }) {
-  const { t } = useTranslation('page_character_optimize')
   const [show, onShow, onClose] = useBoolState(false)
 
   const setTargetHandler = useCallback(
@@ -39,38 +32,6 @@ export default function OptimizationTargetSelector({
     },
     [onClose, setTarget]
   )
-  const { data } = useContext(DataContext)
-  const database = useDatabase()
-  const displayHeader = useMemo(
-    () =>
-      optimizationTarget &&
-      getDisplayHeader(data, optimizationTarget[0], database),
-    [data, optimizationTarget, database]
-  )
-
-  if (!defaultText) defaultText = t('targetSelector.selectOptTarget')
-
-  const { title, icon, action } = displayHeader ?? {}
-  const node: CalcResult | undefined =
-    optimizationTarget &&
-    (objPathValue(data.getDisplay(), optimizationTarget) as any)
-
-  const invalidTarget =
-    !optimizationTarget ||
-    !displayHeader ||
-    !node ||
-    // Make sure the opt target is valid, if we are not in multi-target
-    (!showEmptyTargets && node.isEmpty)
-
-  const {
-    name,
-    textSuffix,
-    icon: nodeIcon,
-    variant = invalidTarget ? 'secondary' : undefined,
-  } = (node?.info && resolveInfo(node?.info)) ?? {}
-
-  const suffixDisplay = textSuffix && <span> {textSuffix}</span>
-  const iconDisplay = icon ? icon : nodeIcon
   return (
     <>
       <Button
@@ -78,35 +39,13 @@ export default function OptimizationTargetSelector({
         onClick={onShow}
         disabled={disabled}
         sx={{ flexGrow: 1 }}
+        {...buttonProps}
       >
-        {invalidTarget ? (
-          <strong>{defaultText}</strong>
-        ) : (
-          <Stack
-            direction="row"
-            divider={<Divider orientation="vertical" flexItem />}
-            spacing={1}
-          >
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              {iconDisplay}
-              <span>{title}</span>
-              {!!action && (
-                <SqBadge color="success" sx={{ whiteSpace: 'normal' }}>
-                  {action}
-                </SqBadge>
-              )}
-            </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <SqBadge
-                color={variant === 'invalid' ? undefined : variant}
-                sx={{ whiteSpace: 'normal' }}
-              >
-                <strong>{name}</strong>
-                {suffixDisplay}
-              </SqBadge>
-            </Box>
-          </Stack>
-        )}
+        <OptimizationTargetDisplay
+          optimizationTarget={optimizationTarget}
+          showEmptyTargets={showEmptyTargets}
+          defaultText={defaultText}
+        />
       </Button>
       <TargetSelectorModal
         show={show}


### PR DESCRIPTION
## Describe your changes

Condense mtarget UI
- Add a floating target editor
- Reduce the amount of UI element per target
- Convert some of the inputs to TextFields

## Issue or discord link

- Resolves #1726

## Testing/validation

<img width="1196" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/1754901/f1f561f3-a403-477a-a5b3-e6a3b9b9d740">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
