### PR TITLE
Archive keep filter

### DIFF
--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -3,6 +3,7 @@ import { Database, SandboxStorage } from '@genshin-optimizer/common/database'
 import type { GenderKey } from '@genshin-optimizer/gi/consts'
 import type { IGOOD } from '@genshin-optimizer/gi/good'
 import { DBMetaEntry } from './DataEntries/DBMetaEntry'
+import { DisplayArchiveEntry } from './DataEntries/DisplayArchiveEntry'
 import { DisplayArtifactEntry } from './DataEntries/DisplayArtifactEntry'
 import { DisplayCharacterEntry } from './DataEntries/DisplayCharacterEntry'
 import { DisplayTeamEntry } from './DataEntries/DisplayTeamEntry'
@@ -35,6 +36,7 @@ export class ArtCharDatabase extends Database {
   displayWeapon: DisplayWeaponEntry
   displayArtifact: DisplayArtifactEntry
   displayCharacter: DisplayCharacterEntry
+  displayArchive: DisplayArchiveEntry
   displayTool: DisplayToolEntry
   displayTeam: DisplayTeamEntry
   dbIndex: 1 | 2 | 3 | 4
@@ -81,6 +83,7 @@ export class ArtCharDatabase extends Database {
     this.displayCharacter = new DisplayCharacterEntry(this)
     this.displayTool = new DisplayToolEntry(this)
     this.displayTeam = new DisplayTeamEntry(this)
+    this.displayArchive = new DisplayArchiveEntry(this)
 
     // invalidates character when things change.
     this.chars.followAny(() => {

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -118,7 +118,7 @@ export class ArtCharDatabase extends Database {
       this.displayCharacter,
       this.displayTool,
       this.displayTeam,
-      this.displayArchive
+      this.displayArchive,
     ] as const
   }
 

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -118,6 +118,7 @@ export class ArtCharDatabase extends Database {
       this.displayCharacter,
       this.displayTool,
       this.displayTeam,
+      this.displayArchive
     ] as const
   }
 

--- a/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
+++ b/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
@@ -1,0 +1,108 @@
+import { validateArr } from '@genshin-optimizer/common/util'
+import type {
+  ArtifactRarity,
+  CharacterRarityKey,
+  RarityKey,
+  WeaponTypeKey,
+} from '@genshin-optimizer/gi/consts'
+import {
+  allArtifactRarityKeys,
+  allCharacterRarityKeys,
+  allRarityKeys,
+  allWeaponTypeKeys,
+} from '@genshin-optimizer/gi/consts'
+import type { ArtCharDatabase } from '../ArtCharDatabase'
+import { DataEntry } from '../DataEntry'
+
+export interface IArtifactOption {
+  rarity: ArtifactRarity[]
+}
+
+export interface ICharacterOption {
+  rarity: CharacterRarityKey[]
+  weaponType: WeaponTypeKey[]
+}
+
+export interface IWeaponOption {
+  rarity: RarityKey[]
+  weaponType: WeaponTypeKey[]
+}
+
+export interface IDisplayArchiveEntry {
+  artifact: IArtifactOption
+  character: ICharacterOption
+  weapon: IWeaponOption
+}
+
+const initialArtifactOption = (): IArtifactOption => ({
+  rarity: [...allArtifactRarityKeys],
+})
+
+const initialCharacterOption = (): ICharacterOption => ({
+  rarity: [...allCharacterRarityKeys],
+  weaponType: [...allWeaponTypeKeys],
+})
+
+const initialWeaponOption = (): IWeaponOption => ({
+  rarity: [...allRarityKeys],
+  weaponType: [...allWeaponTypeKeys],
+})
+
+const initialState = (): IDisplayArchiveEntry => ({
+  artifact: initialArtifactOption(),
+  character: initialCharacterOption(),
+  weapon: initialWeaponOption(),
+})
+
+export class DisplayArchiveEntry extends DataEntry<
+  'display_archive',
+  'display_archive',
+  IDisplayArchiveEntry,
+  IDisplayArchiveEntry
+> {
+  constructor(database: ArtCharDatabase) {
+    super(database, 'display_archive', initialState, 'display_archive')
+  }
+  override validate(obj: any): IDisplayArchiveEntry | undefined {
+    if (typeof obj !== 'object') return undefined
+    let { artifact, character, weapon } = obj
+
+    if (typeof artifact !== 'object') artifact = initialArtifactOption()
+    else {
+      let { rarity } = artifact
+      rarity = validateArr(rarity, allArtifactRarityKeys)
+
+      artifact = {
+        rarity,
+      }
+
+      if (typeof character !== 'object') character = initialCharacterOption()
+      else {
+        let { rarity, weaponType } = character
+        rarity = validateArr(rarity, allCharacterRarityKeys)
+        weaponType = validateArr(weaponType, allWeaponTypeKeys)
+
+        character = {
+          rarity,
+          weaponType,
+        }
+      }
+
+      if (typeof weapon !== 'object') weapon = initialWeaponOption()
+      else {
+        let { rarity } = weapon
+        rarity = validateArr(rarity, allRarityKeys)
+
+        weapon = {
+          rarity,
+        }
+      }
+    }
+
+    return {
+      artifact,
+      character,
+      weapon,
+    }
+  }
+}

--- a/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
+++ b/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
@@ -14,36 +14,36 @@ import {
 import type { ArtCharDatabase } from '../ArtCharDatabase'
 import { DataEntry } from '../DataEntry'
 
-export interface IArtifactOption {
+export interface ArchiveArtifactOption {
   rarity: ArtifactRarity[]
 }
 
-export interface ICharacterOption {
+export interface ArchiveCharacterOption {
   rarity: CharacterRarityKey[]
   weaponType: WeaponTypeKey[]
 }
 
-export interface IWeaponOption {
+export interface ArchiveWeaponOption {
   rarity: RarityKey[]
   weaponType: WeaponTypeKey[]
 }
 
 export interface IDisplayArchiveEntry {
-  artifact: IArtifactOption
-  character: ICharacterOption
-  weapon: IWeaponOption
+  artifact: ArchiveArtifactOption
+  character: ArchiveCharacterOption
+  weapon: ArchiveWeaponOption
 }
 
-const initialArtifactOption = (): IArtifactOption => ({
+const initialArtifactOption = (): ArchiveArtifactOption => ({
   rarity: [...allArtifactRarityKeys],
 })
 
-const initialCharacterOption = (): ICharacterOption => ({
+const initialCharacterOption = (): ArchiveCharacterOption => ({
   rarity: [...allCharacterRarityKeys],
   weaponType: [...allWeaponTypeKeys],
 })
 
-const initialWeaponOption = (): IWeaponOption => ({
+const initialWeaponOption = (): ArchiveWeaponOption => ({
   rarity: [...allRarityKeys],
   weaponType: [...allWeaponTypeKeys],
 })

--- a/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
+++ b/libs/gi/db/src/Database/DataEntries/DisplayArchiveEntry.ts
@@ -90,11 +90,13 @@ export class DisplayArchiveEntry extends DataEntry<
 
       if (typeof weapon !== 'object') weapon = initialWeaponOption()
       else {
-        let { rarity } = weapon
+        let { rarity, weaponType } = weapon
         rarity = validateArr(rarity, allRarityKeys)
+        weaponType = validateArr(weaponType, allWeaponTypeKeys)
 
         weapon = {
           rarity,
+          weaponType,
         }
       }
     }

--- a/libs/gi/db/src/Database/DataEntries/index.ts
+++ b/libs/gi/db/src/Database/DataEntries/index.ts
@@ -1,3 +1,8 @@
+import type {
+  ArchiveArtifactOption,
+  ArchiveCharacterOption,
+  ArchiveWeaponOption,
+} from './DisplayArchiveEntry'
 import {
   characterSortKeys,
   type CharacterSortKey,
@@ -7,4 +12,12 @@ import type { TimeZoneKey } from './DisplayTool'
 import { RESIN_MAX, timeZones } from './DisplayTool'
 import type { WeaponSortKey } from './DisplayWeaponEntry'
 export { RESIN_MAX, characterSortKeys, teamSortKeys, timeZones }
-export type { CharacterSortKey, TeamSortKey, TimeZoneKey, WeaponSortKey }
+export type {
+  ArchiveArtifactOption,
+  ArchiveCharacterOption,
+  ArchiveWeaponOption,
+  CharacterSortKey,
+  TeamSortKey,
+  TimeZoneKey,
+  WeaponSortKey,
+}

--- a/libs/gi/page-archive/src/TabArtifact.tsx
+++ b/libs/gi/page-archive/src/TabArtifact.tsx
@@ -55,36 +55,33 @@ export default function TabArtifact() {
   )
 
   const artSetKeys = useMemo(() => {
-    return allArtifactSetKeys.filter(
-      (setKey) => {
-        const { rarities } = getArtSetStat(setKey)
-        if (
-          !artifact.rarity.includes(
-            Math.max(...rarities) as (typeof maxRarities)[number]
-          )
+    return allArtifactSetKeys.filter((setKey) => {
+      const { rarities } = getArtSetStat(setKey)
+      if (
+        !artifact.rarity.includes(
+          Math.max(...rarities) as (typeof maxRarities)[number]
         )
-          return false
+      )
+        return false
 
-        const setKeyStr = i18n
-          .t(`artifactNames_gen:${setKey}`)
-          .toLocaleLowerCase()
-        const set4KeyDesc = t('setEffects.4', {
-          ns: `artifact_${setKey}_gen`,
-        }).toLocaleLowerCase()
-        const set2KeyDesc = t('setEffects.2', {
-          ns: `artifact_${setKey}_gen`,
-        }).toLocaleLowerCase()
-        if (
-          searchTermDeferred &&
-          !setKeyStr.includes(searchTermDeferred.toLocaleLowerCase()) &&
-          !set2KeyDesc.includes(searchTermDeferred.toLocaleLowerCase()) &&
-          !set4KeyDesc.includes(searchTermDeferred.toLocaleLowerCase())
-        )
-          return false
-        return true
-      },
-      [artifact]
-    )
+      const setKeyStr = i18n
+        .t(`artifactNames_gen:${setKey}`)
+        .toLocaleLowerCase()
+      const set4KeyDesc = t('setEffects.4', {
+        ns: `artifact_${setKey}_gen`,
+      }).toLocaleLowerCase()
+      const set2KeyDesc = t('setEffects.2', {
+        ns: `artifact_${setKey}_gen`,
+      }).toLocaleLowerCase()
+      if (
+        searchTermDeferred &&
+        !setKeyStr.includes(searchTermDeferred.toLocaleLowerCase()) &&
+        !set2KeyDesc.includes(searchTermDeferred.toLocaleLowerCase()) &&
+        !set4KeyDesc.includes(searchTermDeferred.toLocaleLowerCase())
+      )
+        return false
+      return true
+    })
   }, [artifact, searchTermDeferred, t])
   const artSetKeysWithoutPrayer = useMemo(
     () => artSetKeys.filter((sk) => !sk.startsWith('Prayers')),

--- a/libs/gi/page-archive/src/TabArtifact.tsx
+++ b/libs/gi/page-archive/src/TabArtifact.tsx
@@ -1,3 +1,4 @@
+import { useDataEntryBase } from '@genshin-optimizer/common/database-ui'
 import { ColorText, ImgIcon, useInfScroll } from '@genshin-optimizer/common/ui'
 import { handleMultiSelect } from '@genshin-optimizer/common/util'
 import { artifactDefIcon } from '@genshin-optimizer/gi/assets'
@@ -28,7 +29,6 @@ import {
   Suspense,
   useCallback,
   useDeferredValue,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -36,12 +36,7 @@ import { useTranslation } from 'react-i18next'
 const maxRarities = [5, 4, 3] as const
 export default function TabArtifact() {
   const database = useDatabase()
-  const [state, setState] = useState(database.displayArchive.get())
-  useEffect(
-    () => database.displayArchive.follow((r, dbMeta) => setState(dbMeta)),
-    [database]
-  )
-
+  const archive = useDataEntryBase(database.displayArchive)
   const [searchTerm, setSearchTerm] = useState('')
   const searchTermDeferred = useDeferredValue(searchTerm)
   const handleRarity = handleMultiSelect([...maxRarities])
@@ -52,7 +47,7 @@ export default function TabArtifact() {
     })
   )
 
-  const { artifact } = state
+  const { artifact } = archive
   const artifactOptionDispatch = useCallback(
     (option: Partial<ArchiveArtifactOption>) =>
       database.displayArchive.set({ artifact: { ...artifact, ...option } }),

--- a/libs/gi/page-archive/src/TabCharacter.tsx
+++ b/libs/gi/page-archive/src/TabCharacter.tsx
@@ -1,3 +1,4 @@
+import { useDataEntryBase } from '@genshin-optimizer/common/database-ui'
 import { useBoolState } from '@genshin-optimizer/common/react-util'
 import { ColorText, ImgIcon, useInfScroll } from '@genshin-optimizer/common/ui'
 import { handleMultiSelect } from '@genshin-optimizer/common/util'
@@ -43,7 +44,6 @@ import {
   useCallback,
   useContext,
   useDeferredValue,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -52,17 +52,13 @@ const rarties = [5, 4] as const
 export default function TabCharacter() {
   const { silly } = useContext(SillyContext)
   const database = useDatabase()
-  const [state, setState] = useState(database.displayArchive.get())
-  useEffect(
-    () => database.displayArchive.follow((r, dbMeta) => setState(dbMeta)),
-    [database]
-  )
+  const archive = useDataEntryBase(database.displayArchive)
   const handleRarity = handleMultiSelect([...rarties])
   const handleType = handleMultiSelect([...allWeaponTypeKeys])
   const [searchTerm, setSearchTerm] = useState('')
   const searchTermDeferred = useDeferredValue(searchTerm)
 
-  const { character } = state
+  const { character } = archive
   const characterOptionDispatch = useCallback(
     (option: Partial<ArchiveCharacterOption>) =>
       database.displayArchive.set({ character: { ...character, ...option } }),

--- a/libs/gi/page-archive/src/TabCharacter.tsx
+++ b/libs/gi/page-archive/src/TabCharacter.tsx
@@ -65,32 +65,29 @@ export default function TabCharacter() {
     [database, character]
   )
   const charKeys = useMemo(() => {
-    return allCharacterKeys.filter(
-      (cKey) => {
-        const { rarity, weaponType } = getCharStat(cKey)
-        if (!character.rarity.includes(rarity as (typeof rarties)[number]))
-          return false
-        if (!character.weaponType.includes(weaponType)) return false
+    return allCharacterKeys.filter((cKey) => {
+      const { rarity, weaponType } = getCharStat(cKey)
+      if (!character.rarity.includes(rarity as (typeof rarties)[number]))
+        return false
+      if (!character.weaponType.includes(weaponType)) return false
 
-        const nameStr = i18n.t(`charNames_gen:${cKey}`)
-        const sillyStr =
-          silly && i18n.exists(`sillyWisher_charNames:${cKey}`)
-            ? i18n.t(`sillyWisher_charNames:${cKey}`)
-            : ''
-        if (
-          searchTermDeferred &&
-          !nameStr
-            .toLocaleLowerCase()
-            .includes(searchTermDeferred.toLocaleLowerCase()) &&
-          !sillyStr
-            .toLocaleLowerCase()
-            .includes(searchTermDeferred.toLocaleLowerCase())
-        )
-          return false
-        return true
-      },
-      [character]
-    )
+      const nameStr = i18n.t(`charNames_gen:${cKey}`)
+      const sillyStr =
+        silly && i18n.exists(`sillyWisher_charNames:${cKey}`)
+          ? i18n.t(`sillyWisher_charNames:${cKey}`)
+          : ''
+      if (
+        searchTermDeferred &&
+        !nameStr
+          .toLocaleLowerCase()
+          .includes(searchTermDeferred.toLocaleLowerCase()) &&
+        !sillyStr
+          .toLocaleLowerCase()
+          .includes(searchTermDeferred.toLocaleLowerCase())
+      )
+        return false
+      return true
+    })
   }, [character, searchTermDeferred, silly])
 
   const { numShow, setTriggerElement } = useInfScroll(10, charKeys.length)

--- a/libs/gi/page-archive/src/TabWeapon.tsx
+++ b/libs/gi/page-archive/src/TabWeapon.tsx
@@ -63,23 +63,20 @@ export default function TabWeapon() {
     [database, weapon]
   )
   const weaponKeys = useMemo(() => {
-    return allWeaponKeys.filter(
-      (wKey) => {
-        const { rarity, weaponType } = getWeaponStat(wKey)
-        if (!weapon.rarity.includes(rarity)) return false
-        if (!weapon.weaponType.includes(weaponType)) return false
-        const setKeyStr = i18n.t(`weaponNames_gen:${wKey}`)
-        if (
-          searchTermDeferred &&
-          !setKeyStr
-            .toLocaleLowerCase()
-            .includes(searchTermDeferred.toLocaleLowerCase())
-        )
-          return false
-        return true
-      },
-      [weapon]
-    )
+    return allWeaponKeys.filter((wKey) => {
+      const { rarity, weaponType } = getWeaponStat(wKey)
+      if (!weapon.rarity.includes(rarity)) return false
+      if (!weapon.weaponType.includes(weaponType)) return false
+      const setKeyStr = i18n.t(`weaponNames_gen:${wKey}`)
+      if (
+        searchTermDeferred &&
+        !setKeyStr
+          .toLocaleLowerCase()
+          .includes(searchTermDeferred.toLocaleLowerCase())
+      )
+        return false
+      return true
+    })
   }, [weapon, searchTermDeferred])
   const { numShow, setTriggerElement } = useInfScroll(10, weaponKeys.length)
   const weaponKeysToShow = useMemo(

--- a/libs/gi/page-archive/src/TabWeapon.tsx
+++ b/libs/gi/page-archive/src/TabWeapon.tsx
@@ -1,3 +1,4 @@
+import { useDataEntryBase } from '@genshin-optimizer/common/database-ui'
 import { useBoolState } from '@genshin-optimizer/common/react-util'
 import { ColorText, ImgIcon, useInfScroll } from '@genshin-optimizer/common/ui'
 import { handleMultiSelect } from '@genshin-optimizer/common/util'
@@ -43,7 +44,6 @@ import {
   memo,
   useCallback,
   useDeferredValue,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -51,15 +51,12 @@ import { WeaponView } from './WeaponView'
 const rarities = [5, 4, 3, 2, 1] as const
 export default function TabWeapon() {
   const database = useDatabase()
-  const [state, setState] = useState(database.displayArchive.get())
-  useEffect(() =>
-    database.displayArchive.follow((r, dbMeta) => setState(dbMeta))
-  )
+  const archive = useDataEntryBase(database.displayArchive)
   const handleRarity = handleMultiSelect([...rarities])
   const handleType = handleMultiSelect([...allWeaponTypeKeys])
   const [searchTerm, setSearchTerm] = useState('')
   const searchTermDeferred = useDeferredValue(searchTerm)
-  const { weapon } = state
+  const { weapon } = archive
   const weaponOptionDispatch = useCallback(
     (option: Partial<ArchiveWeaponOption>) =>
       database.displayArchive.set({ weapon: { ...weapon, ...option } }),


### PR DESCRIPTION
## Describe your changes

Keep filters on archive pages.

The line https://github.com/CordonZeus22/genshin-optimizer/blob/c97bc402d6b0ecb55d5e19535ae17f7315097b72/libs/gi/page-archive/src/TabArtifact.tsx#L86 is really usefull ? The second argument of the filter method is a `thisArg` but `this` is not used in the function, what is the purpose of this line, is it safe to remove ?

Same for lines
- https://github.com/CordonZeus22/genshin-optimizer/blob/c97bc402d6b0ecb55d5e19535ae17f7315097b72/libs/gi/page-archive/src/TabCharacter.tsx#L92
- https://github.com/CordonZeus22/genshin-optimizer/blob/c97bc402d6b0ecb55d5e19535ae17f7315097b72/libs/gi/page-archive/src/TabWeapon.tsx#L81

## Issue or discord link

- Close #2000

## Testing/validation

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed