### PR TITLE
Update Team removal modal to selectable loadouts

### DIFF
--- a/libs/gi/page-team/src/TeamSetting/TeamDelModal.tsx
+++ b/libs/gi/page-team/src/TeamSetting/TeamDelModal.tsx
@@ -1,0 +1,175 @@
+import {
+  BootstrapTooltip,
+  CardThemed,
+  ColorText,
+  ModalWrapper,
+} from '@genshin-optimizer/common/ui'
+import { notEmpty, toggleArr } from '@genshin-optimizer/common/util'
+import type { Team } from '@genshin-optimizer/gi/db'
+import { useDatabase, useTeam, useTeamChar } from '@genshin-optimizer/gi/db-ui'
+import type { dataContextObj } from '@genshin-optimizer/gi/ui'
+import {
+  DataContext,
+  LoadoutHeaderContent,
+  useCharData,
+} from '@genshin-optimizer/gi/ui'
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import InfoIcon from '@mui/icons-material/Info'
+import {
+  Alert,
+  Box,
+  Button,
+  CardActionArea,
+  CardContent,
+  CardHeader,
+  Divider,
+  IconButton,
+  Typography,
+} from '@mui/material'
+import { useMemo, useState } from 'react'
+export default function TeamDelModal({
+  teamId,
+  show,
+  onHide,
+  onDel,
+}: {
+  teamId: string
+  show: boolean
+  onHide: () => void
+  onDel: () => void
+}) {
+  const database = useDatabase()
+  const team = useTeam(teamId)!
+  const { name, description, loadoutData } = team
+
+  const inTeamsData = useMemo(
+    () =>
+      loadoutData.map((loadoutDatum) => {
+        if (!loadoutDatum) return []
+        const { teamCharId } = loadoutDatum
+        return database.teams.values.filter(({ loadoutData: data }) =>
+          data.find((datum) => datum?.teamCharId === teamCharId)
+        )
+      }),
+    [database, loadoutData]
+  )
+  const [delArr, setDelArry] = useState(() =>
+    inTeamsData
+      .map((teams, i) => (teams.length === 1 ? i : undefined))
+      .filter(notEmpty)
+  )
+  const onDelete = () => {
+    database.teams.remove(teamId)
+    loadoutData.forEach((loadoutDatum, i) => {
+      if (!loadoutDatum || !delArr.includes(i)) return
+      database.teamChars.remove(loadoutDatum.teamCharId)
+    })
+    onDel()
+  }
+  return (
+    <ModalWrapper open={show} onClose={onHide}>
+      <CardThemed>
+        <CardHeader
+          title={
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 1,
+                alignItems: 'center',
+              }}
+            >
+              <Box>Delete Team:</Box>
+              <strong>{name}</strong>
+              {description && (
+                <BootstrapTooltip title={description}>
+                  <InfoIcon />
+                </BootstrapTooltip>
+              )}
+            </Box>
+          }
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Alert severity="info">
+            Removing the team will remove: resonance buffs, and enemy configs
+            stored in the team. Loadouts that are only in this team are also
+            selected by default for deletion.
+          </Alert>
+          {loadoutData.map((loadoutDatum, i) =>
+            loadoutDatum ? (
+              <LoadoutDisplay
+                key={i}
+                teamCharId={loadoutDatum.teamCharId}
+                selected={delArr.includes(i)}
+                onClick={() => setDelArry((arr) => toggleArr(arr, i))}
+                inTeams={inTeamsData[i]}
+              />
+            ) : null
+          )}
+        </CardContent>
+        <Divider />
+        <CardContent sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button
+            color="error"
+            startIcon={<DeleteForeverIcon />}
+            onClick={onDelete}
+          >
+            Delete
+          </Button>
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}
+function LoadoutDisplay({
+  teamCharId,
+  selected,
+  onClick,
+  inTeams,
+}: {
+  teamCharId: string
+  selected: boolean
+  onClick: () => void
+  inTeams: Team[]
+}) {
+  const teamChar = useTeamChar(teamCharId)!
+  const { key: characterKey } = teamChar
+  const teamData = useCharData(characterKey)
+  const { target: charUIData } = teamData?.[characterKey] ?? {}
+
+  const dataContextValue: dataContextObj | undefined = useMemo(() => {
+    if (!teamData || !charUIData) return undefined
+    return {
+      data: charUIData,
+      teamData,
+      compareData: undefined,
+    }
+  }, [charUIData, teamData])
+  if (!dataContextValue) return
+  return (
+    <DataContext.Provider value={dataContextValue}>
+      <CardThemed
+        bgt="light"
+        sx={{ border: selected ? '2px red solid' : undefined }}
+      >
+        <CardActionArea onClick={onClick}>
+          <LoadoutHeaderContent teamCharId={teamCharId}>
+            <ColorText color={inTeams.length === 1 ? 'success' : 'warning'}>
+              <Typography>
+                {inTeams.length === 1
+                  ? 'Only in current team'
+                  : `In ${inTeams.length} teams`}
+              </Typography>
+            </ColorText>
+          </LoadoutHeaderContent>
+        </CardActionArea>
+      </CardThemed>
+    </DataContext.Provider>
+  )
+}

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -25,6 +25,7 @@ import BuildDropdown from '../BuildDropdown'
 import { LoadoutDropdown } from '../LoadoutDropdown'
 import { ResonanceDisplay } from './ResonanceDisplay'
 import { TeammateDisplay } from './TeamComponents'
+import TeamDelModal from './TeamDelModal'
 import TeamExportModal from './TeamExportModal'
 
 // TODO: Translation
@@ -43,13 +44,7 @@ export default function TeamSetting({
   const noChars = team.loadoutData.every((id) => !id)
   const { name, description } = team
 
-  const onDel = () => {
-    if (
-      !window.confirm(
-        'Removing the team will not remove the loadouts, but will remove select builds, resonance buffs, and enemy config.'
-      )
-    )
-      return
+  const onDelNoChars = () => {
     database.teams.remove(teamId)
     navigate(`/teams`)
   }
@@ -58,7 +53,7 @@ export default function TeamSetting({
     const newTeamId = database.teams.duplicate(teamId)
     navigate(`/teams/${newTeamId}`)
   }
-
+  const [showDel, onShowDel, onHideDel] = useBoolState()
   return (
     <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <TeamInfoAlert />
@@ -97,10 +92,16 @@ export default function TeamSetting({
         >
           Duplicate Team
         </Button>
+        <TeamDelModal
+          teamId={teamId}
+          show={showDel}
+          onHide={onHideDel}
+          onDel={() => navigate(`/teams`)}
+        />
         <Button
           color="error"
           sx={{ flexGrow: 1 }}
-          onClick={onDel}
+          onClick={noChars ? onDelNoChars : onShowDel}
           startIcon={<DeleteForeverIcon />}
         >
           Delete Team

--- a/libs/gi/ui/src/components/character/editor/LoadoutHeaderContent.tsx
+++ b/libs/gi/ui/src/components/character/editor/LoadoutHeaderContent.tsx
@@ -6,14 +6,17 @@ import InfoIcon from '@mui/icons-material/Info'
 import PersonIcon from '@mui/icons-material/Person'
 import SettingsIcon from '@mui/icons-material/Settings'
 import { Box, CardContent, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
 import { OptimizationIcon } from '../../../consts'
 import { OptimizationTargetDisplay } from './OptimizationTargetDisplay'
 export function LoadoutHeaderContent({
   teamCharId,
   showSetting = false,
+  children,
 }: {
   teamCharId: string
   showSetting?: boolean
+  children?: ReactNode
 }) {
   const database = useDatabase()
   const {
@@ -69,6 +72,7 @@ export function LoadoutHeaderContent({
           />
         </Typography>
       )}
+      {children}
     </CardContent>
   )
 }


### PR DESCRIPTION
## Describe your changes

I noticed that people would delete the team caused by the v10 migration(but the loadouts would still remain).
and if people adopt importing of teams, they would have 4 new loadouts from importing that team. deleting this "Team" would mean deleting the 4 loadouts separately, then the team.

Add a modal so user can select loadouts to delete when deleting a team.

Depends on changes from #2108 

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![Screenshot 2024-05-14 132939](https://github.com/frzyc/genshin-optimizer/assets/1754901/dc731f0f-e8eb-487f-83ea-0fcc94ed2ec3)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
