### PR TITLE
Add -10 and -30 values to resin counter

### DIFF
--- a/libs/gi/page-tools/src/ResinCounter.tsx
+++ b/libs/gi/page-tools/src/ResinCounter.tsx
@@ -75,6 +75,14 @@ export default function ResinCounter() {
 
   const nextDeltaString = timeString(Math.abs(nextResinDateNum - Date.now()))
 
+  const handleResinChange = (val: string) => {
+    const MAX_ORIGINAL_RESIN = 2000
+    const newResin = parseInt(val)
+    if (newResin >= 0 && newResin <= MAX_ORIGINAL_RESIN) {
+      setResin(newResin)
+    }
+  }
+
   return (
     <CardThemed>
       <Grid container sx={{ px: 2, py: 1 }} spacing={2}>
@@ -93,10 +101,10 @@ export default function ResinCounter() {
               <ImgIcon src={imgAssets.resin.fragile} />
               <InputBase
                 type="number"
-                sx={{ width: '2em', fontSize: '4rem' }}
+                sx={{ width: '2.5em', fontSize: '4rem' }}
                 value={resin}
                 inputProps={{ min: 0, max: 999, sx: { textAlign: 'right' } }}
-                onChange={(e) => setResin(parseInt(e.target.value))}
+                onChange={(e) => handleResinChange(e.target.value)}
               />
               <span>/{RESIN_MAX}</span>
             </Typography>

--- a/libs/gi/page-tools/src/ResinCounter.tsx
+++ b/libs/gi/page-tools/src/ResinCounter.tsx
@@ -15,6 +15,8 @@ import {
 } from '@mui/material'
 import { useEffect, useRef, useState } from 'react'
 
+const RESIN_COUNTER_VALUES = [0, -1, -10, -20, -30, -40, -60, 1, 60, RESIN_MAX]
+
 export default function ResinCounter() {
   const database = useDatabase()
   const [{ resin, resinDate }, setState] = useState(() =>
@@ -101,41 +103,47 @@ export default function ResinCounter() {
           </Grid>
           <Grid item flexGrow={1}>
             <ButtonGroup fullWidth>
-              <Button onClick={() => setResin(0)} disabled={resin === 0}>
-                0
-              </Button>
-              <Button
-                onClick={() => setResin(resin - 1)}
-                disabled={resin === 0}
-              >
-                -1
-              </Button>
-              <Button
-                onClick={() => setResin(resin - 20)}
-                disabled={resin < 20}
-              >
-                -20
-              </Button>
-              <Button
-                onClick={() => setResin(resin - 40)}
-                disabled={resin < 40}
-              >
-                -40
-              </Button>
-              <Button
-                onClick={() => setResin(resin - 60)}
-                disabled={resin < 60}
-              >
-                -60
-              </Button>
-              <Button onClick={() => setResin(resin + 1)}>+1</Button>
-              <Button onClick={() => setResin(resin + 60)}>+60</Button>
-              <Button
-                onClick={() => setResin(RESIN_MAX)}
-                disabled={resin === RESIN_MAX}
-              >
-                MAX {RESIN_MAX}
-              </Button>
+              {RESIN_COUNTER_VALUES.map((rcv) => {
+                if (rcv === 0) {
+                  return (
+                    <Button
+                      onClick={() => setResin(rcv)}
+                      disabled={resin === 0}
+                    >
+                      {rcv}
+                    </Button>
+                  )
+                }
+                if (rcv === RESIN_MAX) {
+                  return (
+                    <Button
+                      onClick={() => setResin(RESIN_MAX)}
+                      disabled={resin >= RESIN_MAX}
+                    >
+                      MAX {rcv}
+                    </Button>
+                  )
+                }
+                if (rcv > 0) {
+                  return (
+                    <Button
+                      onClick={() => setResin(resin + rcv)}
+                      disabled={resin >= RESIN_MAX}
+                    >
+                      {rcv}
+                    </Button>
+                  )
+                }
+
+                return (
+                  <Button
+                    onClick={() => setResin(resin + rcv)}
+                    disabled={resin < Math.abs(rcv)}
+                  >
+                    {rcv}
+                  </Button>
+                )
+              })}
             </ButtonGroup>
             <Typography variant="subtitle1" sx={{ mt: 2 }}>
               {resin < RESIN_MAX ? (


### PR DESCRIPTION
## Describe your changes

Added more options to the resin counter. Moved the buttons to a constant at the top to allow for more values later down the line easily.

## Issue or discord link

- Resolves #2148 
- Resolves https://github.com/frzyc/genshin-optimizer/issues/2150

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/25755821/210f8061-4c07-4ce7-bad5-e4ff21273f99)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
