### PR TITLE
Quick link area refactor

### DIFF
--- a/libs/gi/localization/Translated/id.json
+++ b/libs/gi/localization/Translated/id.json
@@ -545,7 +545,7 @@
           "tooltip": "Dokumentasi Deskriptor Objek Terbuka Genshin"
         },
         "patchNotes": {
-          "title": "Genshin Optimizer Patch Notes",
+          "title": "Patch Notes",
           "tooltip": "Semua patch notes untuk GO"
         }
       }
@@ -865,7 +865,13 @@
     "c4": "Musuh terkena petir <strong>Sesshou Sakura</strong>"
   },
   "char_Yanfei": {
-    "seals": ["0 seals", "1 seal", "2 seals", "3 seals", "4 seals"],
+    "seals": [
+      "0 seals",
+      "1 seal",
+      "2 seals",
+      "3 seals",
+      "4 seals"
+    ],
     "perSeal": "(per seal)",
     "maxSeals": "Jumlah maksimum Scarlet Seals",
     "charged": {

--- a/libs/gi/localization/assets/locales/en/page_home.json
+++ b/libs/gi/localization/assets/locales/en/page_home.json
@@ -24,7 +24,7 @@
         "tooltip": "Genshin Open Object Descriptor Documentation"
       },
       "patchNotes": {
-        "title": "Genshin Optimizer Patch Notes",
+        "title": "Patch Notes",
         "tooltip": "All of GO's patch notes"
       }
     }

--- a/libs/gi/page-home/src/QuickLinksCard.tsx
+++ b/libs/gi/page-home/src/QuickLinksCard.tsx
@@ -116,7 +116,9 @@ export default function QuickLinksCard() {
             return (
               <Box sx={{ display: 'flex', gap: 2 }}>
                 {icon}
-                <Link href={url}>{title(t)}</Link>
+                <Link target="_blank" rel="noopener" href={url}>
+                  {title(t)}
+                </Link>
               </Box>
             )
           })}
@@ -130,7 +132,9 @@ export default function QuickLinksCard() {
             return (
               <Box sx={{ display: 'flex', gap: 2 }}>
                 {icon}
-                <Link href={url}>{title()}</Link>
+                <Link target="_blank" rel="noopener" href={url}>
+                  {title()}
+                </Link>
               </Box>
             )
           })}
@@ -144,7 +148,9 @@ export default function QuickLinksCard() {
             return (
               <Box sx={{ display: 'flex', gap: 2 }}>
                 {icon}
-                <Link href={url}>{title(t)}</Link>
+                <Link target="_blank" rel="noopener" href={url}>
+                  {title(t)}
+                </Link>
               </Box>
             )
           })}

--- a/libs/gi/page-home/src/QuickLinksCard.tsx
+++ b/libs/gi/page-home/src/QuickLinksCard.tsx
@@ -16,104 +16,84 @@ import {
   YouTube,
 } from '@mui/icons-material'
 import {
-  Button,
+  Box,
   CardContent,
   CardHeader,
   Divider,
   Link,
-  Tooltip,
   Typography,
 } from '@mui/material'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
-import { Link as RouterLink } from 'react-router-dom'
 
-const buttons = [
+const genshin_optimizer_links = [
   {
-    title: () => 'Genshin Optimizer Discord',
+    title: () => 'Discord',
     icon: <DiscordIcon />,
-    tooltip: () => '',
     url: process.env['NX_URL_DISCORD_GO'],
-    color: 'discord',
   },
   {
-    title: () => 'Genshin Optimizer Github',
+    title: () => 'Github',
     icon: <GitHub />,
-    tooltip: () => '',
     url: process.env['NX_URL_GITHUB_GO'],
-    color: 'white',
   },
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.patchNotes.title`,
     icon: <Description />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.patchNotes.tooltip`,
     url: `${process.env['NX_URL_GITHUB_GO']}/releases`,
-    color: 'secondary',
   },
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.tyGuide.title`,
     icon: <YouTube />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.tyGuide.tooltip`,
     url: process.env['NX_URL_YOUTUBE_TUTPL'],
-    color: 'red',
   },
+]
+
+const frzyc_links = [
   {
-    title: () => 'Twitch (frzyc)',
+    title: () => 'Twitch',
     icon: <TwitchIcon />,
-    tooltip: () => '',
     url: process.env['NX_URL_TWITCH_FRZYC'],
-    color: 'twitch',
   },
   {
-    title: () => 'Twitter (frzyc)',
+    title: () => 'Twitter',
     icon: <Twitter />,
-    tooltip: () => '',
     url: process.env['NX_URL_TWITTER_FRZYC'],
-    color: 'twitter',
   },
   {
-    title: () => 'Patreon (frzyc)',
+    title: () => 'Patreon',
     icon: <PatreonIcon />,
-    tooltip: () => '',
     url: process.env['NX_URL_PATREON_FRZYC'],
-    color: 'patreon',
   },
   {
-    title: () => 'PayPal (frzyc)',
+    title: () => 'PayPal',
     icon: <PaypalIcon />,
-    tooltip: () => '',
     url: process.env['NX_URL_PAYPAL_FRZYC'],
-    color: 'paypal',
   },
+]
+
+const other_links = [
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.scanners.title`,
     icon: <Scanner />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.scanners.tooltip`,
-    to: '/scanner',
-    color: 'primary',
+    url: '/scanner',
   },
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.kqm.title`,
     icon: <Handshake />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.kqm.tooltip`,
     url: process.env['NX_URL_WEBSITE_KQM'],
-    color: 'keqing',
   },
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.devDiscord.title`,
     icon: <DiscordIcon />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.devDiscord.tooltip`,
     url: process.env['NX_URL_DISCORD_GDEV'],
-    color: 'discord',
   },
   {
     title: (t: TFunction) => t`quickLinksCard.buttons.good.title`,
     icon: <Article />,
-    tooltip: (t: TFunction) => t`quickLinksCard.buttons.good.tooltip`,
-    to: '/doc',
-    color: 'primary',
+    url: '/doc',
   },
-] as const
+]
 
 export default function QuickLinksCard() {
   const { t } = useTranslation(['page_home', 'ui'])
@@ -124,45 +104,51 @@ export default function QuickLinksCard() {
         avatar={<InsertLink fontSize="large" />}
       />
       <Divider />
-      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        {buttons.map((btnProps, i) => {
-          const { title, icon, tooltip, color } = btnProps
-          let button
-          if ('to' in btnProps)
-            button = (
-              <Button
-                fullWidth
-                key={i}
-                color={color}
-                component={RouterLink}
-                to={btnProps.to}
-                startIcon={icon}
-              >
-                {title(t)}
-              </Button>
+      <CardContent
+        sx={{ display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: 1 }}
+      >
+        <Box sx={{ border: 1, borderRadius: 4, padding: 2 }}>
+          <Typography marginBottom={1} variant="h6">
+            Genshin Optimizer
+          </Typography>
+          {genshin_optimizer_links.map((link) => {
+            const { title, icon, url } = link
+            return (
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                {icon}
+                <Link href={url}>{title(t)}</Link>
+              </Box>
             )
-          if ('url' in btnProps)
-            button = (
-              <Button
-                fullWidth
-                key={i}
-                color={color}
-                component={Link}
-                href={btnProps.url}
-                target="_blank"
-                rel="noopener"
-                startIcon={icon}
-              >
-                {title(t)}
-              </Button>
+          })}
+        </Box>
+        <Box sx={{ border: 1, borderRadius: 4, padding: 2 }}>
+          <Typography marginBottom={1} variant="h6">
+            frzyc
+          </Typography>
+          {frzyc_links.map((link) => {
+            const { title, icon, url } = link
+            return (
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                {icon}
+                <Link href={url}>{title()}</Link>
+              </Box>
             )
-          if (!button) return null
-          return (
-            <Tooltip key={i} title={tooltip(t)} placement="top" arrow>
-              {button}
-            </Tooltip>
-          )
-        })}
+          })}
+        </Box>
+        <Box sx={{ border: 1, borderRadius: 4, padding: 2 }}>
+          <Typography marginBottom={1} variant="h6">
+            Other links
+          </Typography>
+          {other_links.map((link) => {
+            const { title, icon, url } = link
+            return (
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                {icon}
+                <Link href={url}>{title(t)}</Link>
+              </Box>
+            )
+          })}
+        </Box>
       </CardContent>
     </CardThemed>
   )


### PR DESCRIPTION
## Describe your changes

Changing the quick link area to take more vertical space. Moving to links approach. Split links into 3 categories, as felt grouping was needed when we wanted to change this.

## Issue or discord link

#2140 

## Testing/validation

What used to be: 
![image](https://github.com/frzyc/genshin-optimizer/assets/25755821/92b111c0-3ede-4f3e-8119-b6afad8be530)


Now looks like: 
![image](https://github.com/frzyc/genshin-optimizer/assets/25755821/f3c28872-d955-4ab7-a63b-ae3339ec06e2)

Tested links according to what is in the .env file, and using prior environment variables so believe this should work. 

More than happy to discuss the approach and if we want to change how this looks, however felt this fits in the overall brand of Genshin Optimizer.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
