### PR TITLE
Increase spacing between teamcards in /teams

### DIFF
--- a/libs/gi/page-teams/src/index.tsx
+++ b/libs/gi/page-teams/src/index.tsx
@@ -227,7 +227,7 @@ export default function PageTeams() {
           />
         }
       >
-        <Grid container spacing={1} columns={columns}>
+        <Grid container spacing={2} columns={columns}>
           {TeamIdsToShow.map((tid) => (
             <Grid item xs={1} key={tid}>
               <Suspense


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

Closes #2159 

This PR increases the spacing between teamcards on the `teams` page from 1 to 2. See screenshot below.
## Testing/validation

<!--- Add screenshots if possible -->
<img width="1440" alt="Screenshot 2024-05-21 at 19 42 31" src="https://github.com/frzyc/genshin-optimizer/assets/106209849/826d12ab-9b1c-4211-b5a0-f96bfa39322d">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
