### PR TITLE
add select on focus

### DIFF
--- a/libs/common/ui/src/components/NumberInputLazy.tsx
+++ b/libs/common/ui/src/components/NumberInputLazy.tsx
@@ -1,6 +1,6 @@
 import type { TextFieldProps } from '@mui/material'
 import { TextField } from '@mui/material'
-import type { ChangeEvent } from 'react'
+import type { ChangeEvent, FocusEvent } from 'react'
 import { useEffect, useState } from 'react'
 
 /**
@@ -50,11 +50,18 @@ export function NumberInputLazy({
     setValue(val)
   }
 
+  const onFocus = (
+    event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    event.target.select()
+  }
+
   return (
     <TextField
       value={value?.toString()}
       onChange={handleChange}
       onBlur={saveValue}
+      onFocus={onFocus}
       onKeyDown={(e) => e.key === 'Enter' && !props.multiline && saveValue()}
       {...props}
       inputProps={{


### PR DESCRIPTION
## Describe your changes

Changes NumberInputLazy fields to automatically select the whole text when focused, for ease of user experience.

## Issue or discord link

- Closes [Update NumberInputLazy to select the text automatically](https://github.com/frzyc/genshin-optimizer/issues/2176)

## Testing/validation

Tested locally, made sure that NumberInputLazy fields would automatically select the whole text. Difficult to screenshot this process.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
