### PR TITLE
Add a "Add Artifact" button in Artifact Upgrader

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -86,7 +86,7 @@ function AddArtifactButton({ onClick }: AddArtifactButtonProps) {
 }
 
 export default function TabUpopt() {
-  const { t, i18n } = useTranslation('page_character_optimize')
+  const { t } = useTranslation('page_character_optimize')
   const {
     teamId,
     teamCharId,

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -39,6 +39,7 @@ import {
 import { uiDataForTeam } from '@genshin-optimizer/gi/uidata'
 import type { NumNode } from '@genshin-optimizer/gi/wr'
 import { mergeData, optimize } from '@genshin-optimizer/gi/wr'
+import AddIcon from '@mui/icons-material/Add'
 import {
   Alert,
   Box,
@@ -49,6 +50,7 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material'
+import Button, { ButtonProps } from '@mui/material/Button'
 import { Stack } from '@mui/system'
 import {
   Suspense,
@@ -69,8 +71,22 @@ import { LevelFilter } from './LevelFilter'
 import UpgradeOptChartCard from './UpgradeOptChartCard'
 import { UpOptCalculator } from './upOpt'
 
+// button gets its own type so multiple translations can be used
+type AddArtifactButtonProps = Omit<ButtonProps, 'onClick'> & {
+  onClick: () => void
+}
+
+function AddArtifactButton({ onClick }: AddArtifactButtonProps) {
+  const { t } = useTranslation(['artifact', 'ui'])
+  return (
+    <Button fullWidth onClick={onClick} color="info" startIcon={<AddIcon />}>
+      {t`addNew`}
+    </Button>
+  )
+}
+
 export default function TabUpopt() {
-  const { t } = useTranslation('page_character_optimize')
+  const { t, i18n } = useTranslation('page_character_optimize')
   const {
     teamId,
     teamCharId,
@@ -450,7 +466,9 @@ export default function TabUpopt() {
                   gap={1}
                 >
                   <ArtifactSetConfig disabled={false} />
-
+                  <AddArtifactButton
+                    onClick={() => setArtifactIdToEdit('new')}
+                  />
                   <StatFilterCard disabled={false} />
                   <AdResponsive bgt="light" dataAdSlot="3955015620" />
                 </Grid>

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -50,7 +50,8 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material'
-import Button, { ButtonProps } from '@mui/material/Button'
+import Button from '@mui/material/Button'
+import type { ButtonProps } from '@mui/material/Button'
 import { Stack } from '@mui/system'
 import {
   Suspense,
@@ -71,7 +72,7 @@ import { LevelFilter } from './LevelFilter'
 import UpgradeOptChartCard from './UpgradeOptChartCard'
 import { UpOptCalculator } from './upOpt'
 
-// button gets its own type so multiple translations can be used
+// artifact button gets its own type so multiple translations can be used
 type AddArtifactButtonProps = Omit<ButtonProps, 'onClick'> & {
   onClick: () => void
 }

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -50,8 +50,8 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material'
-import Button from '@mui/material/Button'
 import type { ButtonProps } from '@mui/material/Button'
+import Button from '@mui/material/Button'
 import { Stack } from '@mui/system'
 import {
   Suspense,


### PR DESCRIPTION
## Describe your changes

Added an "Add Artifact" button on the artifact upgrader page, to complement being able to paste a screenshot to add an artifact.

## Issue or discord link

- Closes [Add a "Add Artifact" button in Artifact Upgrader](https://github.com/frzyc/genshin-optimizer/issues/2131)

## Testing/validation

Tested button functionality: correctly opens artifact editor menu, correctly adds the artifact to the pool once finished.
![addartifactbutton-1](https://github.com/frzyc/genshin-optimizer/assets/169850839/0635f3da-b2ae-4ea2-9948-ce9d18cb36ab)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
