### PR TITLE
Manual exclusion

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -53,7 +53,7 @@ export function TargetSelectorModal({
               key,
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
-                  const { path, unit, variant, source } = resolveInfo(node.info)
+                  const { path, unit, variant } = resolveInfo(node.info)
 
                   if (flatOnly && unit === '%') return false
 
@@ -62,7 +62,7 @@ export function TargetSelectorModal({
                   if (
                     !showEmptyTargets &&
                     node.isEmpty &&
-                    (path !== 'eleMas' || source === 'KeyOfKhajNisut')
+                    (path !== 'eleMas' || key !== 'basic')
                   )
                     return false
 

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -53,12 +53,12 @@ export function TargetSelectorModal({
               key,
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
-                  const { unit, variant } = resolveInfo(node.info)
+                  const { path, unit, variant } = resolveInfo(node.info)
                   if (flatOnly && unit === '%') return false
 
                   if (excludeHeal && variant === 'heal') return false
 
-                  if (!showEmptyTargets && node.isEmpty) return false
+                  if (!showEmptyTargets && node.isEmpty && path !== 'eleMas') return false
                   return true
                 })
               ) as DisplaySub<CalcResult>,

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -53,17 +53,13 @@ export function TargetSelectorModal({
               key,
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
-                  const { path, unit, variant } = resolveInfo(node.info)
+                  const { unit, variant } = resolveInfo(node.info)
 
                   if (flatOnly && unit === '%') return false
 
                   if (excludeHeal && variant === 'heal') return false
 
-                  if (
-                    !showEmptyTargets &&
-                    node.isEmpty &&
-                    (path !== 'eleMas' || key !== 'basic')
-                  )
+                  if (!showEmptyTargets && node.isEmpty && key !== 'basic')
                     return false
 
                   return true

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -53,12 +53,14 @@ export function TargetSelectorModal({
               key,
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
-                  const { path, unit, variant } = resolveInfo(node.info)
+                  const { path, unit, variant, source } = resolveInfo(node.info)
+                  console.log('source is ' + source +  ', path is ' + path);
                   if (flatOnly && unit === '%') return false
 
                   if (excludeHeal && variant === 'heal') return false
 
-                  if (!showEmptyTargets && node.isEmpty && path !== 'eleMas') return false
+                  if (!showEmptyTargets && node.isEmpty && (path !== 'eleMas' || source === 'KeyOfKhajNisut')) return false
+
                   return true
                 })
               ) as DisplaySub<CalcResult>,

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/TargetSelectorModal.tsx
@@ -54,12 +54,17 @@ export function TargetSelectorModal({
               Object.fromEntries(
                 Object.entries(sectionObj).filter(([_sectionKey, node]) => {
                   const { path, unit, variant, source } = resolveInfo(node.info)
-                  console.log('source is ' + source +  ', path is ' + path);
+
                   if (flatOnly && unit === '%') return false
 
                   if (excludeHeal && variant === 'heal') return false
 
-                  if (!showEmptyTargets && node.isEmpty && (path !== 'eleMas' || source === 'KeyOfKhajNisut')) return false
+                  if (
+                    !showEmptyTargets &&
+                    node.isEmpty &&
+                    (path !== 'eleMas' || source === 'KeyOfKhajNisut')
+                  )
+                    return false
 
                   return true
                 })


### PR DESCRIPTION
## Describe your changes

Adds EM as optimization target even when the character has 0 EM.

## Issue or discord link

- Fixes [Add manual exclusions for targets to appear in results](https://github.com/frzyc/genshin-optimizer/issues/2156)

## Testing/validation
0 EM,  0 HB%, 0 Phys% Albedo optimization targets list:
![manual-exclusion](https://github.com/frzyc/genshin-optimizer/assets/169850839/bbcd83e6-d17b-4877-9dcd-04c0346a2967)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
