### PR TITLE
Convert RelicEditor and LightConeEditor to modals

### DIFF
--- a/libs/sr/page-lightcones/src/index.tsx
+++ b/libs/sr/page-lightcones/src/index.tsx
@@ -1,11 +1,18 @@
 import { LightConeEditor, LightConeInventory } from '@genshin-optimizer/sr/ui'
 import { Box } from '@mui/material'
 
+import { useState } from 'react'
+
 export default function PageLightCones() {
+  const [lightConeIdToEdit, setLightConeIdToEdit] = useState('')
+
   return (
     <Box display="flex" flexDirection="column" gap={1} my={1}>
-      <LightConeEditor />
-      <LightConeInventory />
+      <LightConeEditor
+        lightConeIdToEdit={lightConeIdToEdit}
+        cancelEdit={() => setLightConeIdToEdit('')}
+      />
+      <LightConeInventory onAdd={() => setLightConeIdToEdit('new')} />
     </Box>
   )
 }

--- a/libs/sr/page-relics/src/index.tsx
+++ b/libs/sr/page-relics/src/index.tsx
@@ -1,11 +1,18 @@
 import { RelicEditor, RelicInventory } from '@genshin-optimizer/sr/ui'
 import { Box } from '@mui/material'
 
+import { useState } from 'react'
+
 export default function PageRelics() {
+  const [relicIdToEdit, setRelicIdToEdit] = useState('')
+
   return (
     <Box display="flex" flexDirection="column" gap={1} my={1}>
-      <RelicEditor />
-      <RelicInventory />
+      <RelicEditor
+        relicIdToEdit={relicIdToEdit}
+        cancelEdit={() => setRelicIdToEdit('')}
+      />
+      <RelicInventory onAdd={() => setRelicIdToEdit('new')} />
     </Box>
   )
 }

--- a/libs/sr/ui/src/LightCone/LightConeInventory.tsx
+++ b/libs/sr/ui/src/LightCone/LightConeInventory.tsx
@@ -10,15 +10,29 @@ import {
   lightConeSortKeys,
   lightConeSortMap,
 } from '@genshin-optimizer/sr/util'
-import { Box, CardContent, Grid, Skeleton, Typography } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import {
+  Box,
+  Button,
+  CardContent,
+  Grid,
+  Skeleton,
+  Typography,
+} from '@mui/material'
 import { Suspense, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useDatabaseContext } from '../Context'
 import { LightConeCard } from './LightConeCard'
 
 const columns = { xs: 1, sm: 2, md: 3, lg: 3, xl: 4 }
 const numToShowMap = { xs: 10, sm: 12, md: 24, lg: 24, xl: 24 }
 
-export function LightConeInventory() {
+export type LightConeInventoryProps = {
+  onAdd?: () => void
+}
+
+export function LightConeInventory({ onAdd }: LightConeInventoryProps) {
+  const { t } = useTranslation('lightCone')
   const { database } = useDatabaseContext()
   const [dirtyDatabase, setDirtyDatabase] = useForceUpdate()
 
@@ -94,6 +108,18 @@ export function LightConeInventory() {
           </Box>
         </CardContent>
       </CardThemed>
+      <Grid container columns={columns} spacing={1}>
+        <Grid item xs>
+          <Button
+            fullWidth
+            onClick={onAdd}
+            color="info"
+            startIcon={<AddIcon />}
+          >
+            {t`addNew`}
+          </Button>
+        </Grid>
+      </Grid>
       <Suspense
         fallback={
           <Skeleton
@@ -102,7 +128,7 @@ export function LightConeInventory() {
           />
         }
       >
-        <Grid container spacing={1} columns={columns}>
+        <Grid container columns={columns} spacing={1}>
           {lightConeIdsToShow.map((lightConeId) => (
             <Grid item key={lightConeId} xs={1}>
               <LightConeCard lightConeId={lightConeId} />

--- a/libs/sr/ui/src/Relic/RelicEditor/RelicEditor.tsx
+++ b/libs/sr/ui/src/Relic/RelicEditor/RelicEditor.tsx
@@ -37,8 +37,8 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+import type { MouseEvent } from 'react'
 import {
-  MouseEvent,
   Suspense,
   useCallback,
   useEffect,

--- a/libs/sr/ui/src/Relic/RelicInventory.tsx
+++ b/libs/sr/ui/src/Relic/RelicInventory.tsx
@@ -3,15 +3,29 @@ import {
   useMediaQueryUp,
 } from '@genshin-optimizer/common/react-util'
 import { CardThemed, useInfScroll } from '@genshin-optimizer/common/ui'
-import { Box, CardContent, Grid, Skeleton, Typography } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import {
+  Box,
+  Button,
+  CardContent,
+  Grid,
+  Skeleton,
+  Typography,
+} from '@mui/material'
 import { Suspense, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useDatabaseContext } from '../Context'
 import { RelicCard } from './RelicCard'
 
 const columns = { xs: 1, sm: 2, md: 3, lg: 3, xl: 4 }
 const numToShowMap = { xs: 10, sm: 12, md: 24, lg: 24, xl: 24 }
 
-export function RelicInventory() {
+export type RelicInventoryProps = {
+  onAdd?: () => void
+}
+
+export function RelicInventory({ onAdd }: RelicInventoryProps) {
+  const { t } = useTranslation('relic')
   const { database } = useDatabaseContext()
   const [dirtyDatabase, setDirtyDatabase] = useForceUpdate()
 
@@ -64,6 +78,18 @@ export function RelicInventory() {
           </Box>
         </CardContent>
       </CardThemed>
+      <Grid container columns={columns} spacing={1}>
+        <Grid item xs>
+          <Button
+            fullWidth
+            onClick={onAdd}
+            color="info"
+            startIcon={<AddIcon />}
+          >
+            {t`addNew`}
+          </Button>
+        </Grid>
+      </Grid>
       <Suspense
         fallback={
           <Skeleton
@@ -72,7 +98,7 @@ export function RelicInventory() {
           />
         }
       >
-        <Grid container spacing={1} columns={columns}>
+        <Grid container columns={columns} spacing={1}>
           {relicsIdsToShow.map((relicId) => (
             <Grid item key={relicId} xs={1}>
               <RelicCard relic={database.relics.get(relicId)!} />


### PR DESCRIPTION
## Describe your changes
- Wrap `RelicEditor` and `LightConeEditor` in modals
- Create 'Add New' buttons on respective pages to bring up editors to add items

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation
relic page
<img width="1585" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/b4c733f4-9fc5-4f0f-bae1-9d05c59ed21b">

lightcone page, adding a new lightcone and the subsequently created LC afterwards:
<img width="1524" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/5f3c1545-a9e9-45ba-ac2f-4761b31503e6">
<img width="1500" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/15e3d129-2072-4800-be40-34cc76587d05">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
