### PR TITLE
Reset scrolling when going from Teams page to specific team

### DIFF
--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -112,6 +112,9 @@ function Page({ teamId }: { teamId: string }) {
   }, [loadoutData, database.teamChars, characterKeyRaw])
 
   useEffect(() => {
+    window.scrollTo({ top: 0 })
+  }, [])
+  useEffect(() => {
     if (!loadoutDatum) navigate('', { replace: true })
   }, [loadoutDatum, navigate])
 


### PR DESCRIPTION
## Describe your changes

Adds useEffect to scroll to top of page, when `/team/team_XXX` is loaded on component mount.

## Issue or discord link


- Closes #2155 

## Testing/validation

<!--- Add screenshots if possible -->
![scroll](https://github.com/frzyc/genshin-optimizer/assets/78663777/43ea7a38-4e61-47f8-bd1e-4544106cd5bd)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
