### PR TITLE
Add ability to edit/delete relics

### DIFF
--- a/libs/sr/page-relics/src/index.tsx
+++ b/libs/sr/page-relics/src/index.tsx
@@ -12,7 +12,10 @@ export default function PageRelics() {
         relicIdToEdit={relicIdToEdit}
         cancelEdit={() => setRelicIdToEdit('')}
       />
-      <RelicInventory onAdd={() => setRelicIdToEdit('new')} />
+      <RelicInventory
+        onAdd={() => setRelicIdToEdit('new')}
+        onEdit={setRelicIdToEdit}
+      />
     </Box>
   )
 }

--- a/libs/sr/ui/src/Relic/RelicCard.tsx
+++ b/libs/sr/ui/src/Relic/RelicCard.tsx
@@ -1,29 +1,114 @@
-import { CardThemed } from '@genshin-optimizer/common/ui'
+import { BootstrapTooltip, CardThemed } from '@genshin-optimizer/common/ui'
+import type { LocationKey } from '@genshin-optimizer/sr/consts'
 import type { IRelic } from '@genshin-optimizer/sr/srod'
 import { getRelicMainStatDisplayVal } from '@genshin-optimizer/sr/util'
-import { CardContent, Typography } from '@mui/material'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
+import EditIcon from '@mui/icons-material/Edit'
+import { Box, Button, CardContent, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { LocationAutocomplete } from '../Character'
 
-export function RelicCard({ relic }: { relic: IRelic }) {
+export type RelicCardProps = {
+  relic: IRelic
+  onEdit?: () => void
+  onDelete?: () => void
+  setLocation?: (lk: LocationKey) => void
+  extraButtons?: JSX.Element
+}
+
+export function RelicCard({
+  relic,
+  onEdit,
+  onDelete,
+  setLocation,
+  extraButtons,
+}: RelicCardProps) {
+  const { t } = useTranslation('relic')
+  const {
+    lock,
+    slotKey,
+    setKey,
+    rarity,
+    level,
+    mainStatKey,
+    substats,
+    location = '',
+  } = relic
+
   return (
-    <CardThemed sx={{ height: '100%' }}>
+    <CardThemed
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
       <CardContent>
-        <Typography>Slot: {relic.slotKey}</Typography>
-        <Typography>Set: {relic.setKey}</Typography>
-        <Typography>Level: {relic.level}</Typography>
+        <Typography>Slot: {slotKey}</Typography>
+        <Typography>Set: {setKey}</Typography>
+        <Typography>Level: {level}</Typography>
         <Typography>
-          Main: {relic.mainStatKey} ◦{' '}
-          {getRelicMainStatDisplayVal(
-            relic.rarity,
-            relic.mainStatKey,
-            relic.level
-          )}
+          Main: {mainStatKey} ◦{' '}
+          {getRelicMainStatDisplayVal(rarity, mainStatKey, level)}
         </Typography>
-        {relic.substats.map((substat) => (
+        {substats.map((substat) => (
           <Typography key={substat.key}>
             Sub: {substat.key} ◦ {substat.value}
           </Typography>
         ))}
       </CardContent>
+      <Box
+        sx={{
+          p: 1,
+          display: 'flex',
+          gap: 1,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ flexGrow: 1 }}>
+          {setLocation ? (
+            <LocationAutocomplete locKey={location} setLocKey={setLocation} />
+          ) : (
+            // TODO: replace with LocationName component after porting it from GO
+            <Typography>{location}</Typography>
+          )}
+        </Box>
+        <Box
+          display="flex"
+          gap={1}
+          alignItems="stretch"
+          height="100%"
+          sx={{ '& .MuiButton-root': { minWidth: 0, height: '100%' } }}
+        >
+          {!!onEdit && (
+            <BootstrapTooltip
+              title={<Typography>{t`relic:edit`}</Typography>}
+              placement="top"
+              arrow
+            >
+              <Button color="info" size="small" onClick={onEdit}>
+                <EditIcon />
+              </Button>
+            </BootstrapTooltip>
+          )}
+          {!!onDelete && (
+            <BootstrapTooltip
+              title={lock ? t('relic:cantDeleteLock') : ''}
+              placement="top"
+            >
+              <span>
+                <Button
+                  color="error"
+                  size="small"
+                  onClick={onDelete}
+                  disabled={lock}
+                  sx={{ top: '1px' }}
+                >
+                  <DeleteForeverIcon />
+                </Button>
+              </span>
+            </BootstrapTooltip>
+          )}
+          {extraButtons}
+        </Box>
+      </Box>
     </CardThemed>
   )
 }

--- a/libs/sr/ui/src/Relic/RelicInventory.tsx
+++ b/libs/sr/ui/src/Relic/RelicInventory.tsx
@@ -22,9 +22,10 @@ const numToShowMap = { xs: 10, sm: 12, md: 24, lg: 24, xl: 24 }
 
 export type RelicInventoryProps = {
   onAdd?: () => void
+  onEdit?: (id: string) => void
 }
 
-export function RelicInventory({ onAdd }: RelicInventoryProps) {
+export function RelicInventory({ onAdd, onEdit }: RelicInventoryProps) {
   const { t } = useTranslation('relic')
   const { database } = useDatabaseContext()
   const [dirtyDatabase, setDirtyDatabase] = useForceUpdate()
@@ -101,7 +102,14 @@ export function RelicInventory({ onAdd }: RelicInventoryProps) {
         <Grid container columns={columns} spacing={1}>
           {relicsIdsToShow.map((relicId) => (
             <Grid item key={relicId} xs={1}>
-              <RelicCard relic={database.relics.get(relicId)!} />
+              <RelicCard
+                relic={database.relics.get(relicId)!}
+                onEdit={() => onEdit?.(relicId)}
+                onDelete={() => database.relics.remove(relicId)}
+                setLocation={(location) =>
+                  database.relics.set(relicId, { location })
+                }
+              />
             </Grid>
           ))}
         </Grid>


### PR DESCRIPTION
## Describe your changes
- add ability to edit/delete existing relics
- add Edit and Delete buttons to Relic Card

soft list of things missing in SRO version compared to GO version:
- Editor: 
    - `allowEmpty` check on substats (unsure if it should be implemented here or when substat validation gets added)
    - UI for duplicate/upgraded/edited relics
- Card:
    - `LocationAutocomplete` having more props/params passed to it as well as changed to `size="small"` because right now the larger size looks a bit awkward (should this get passed in manually instead as part of the extra props/params?)

## Issue or discord link

Resolves #2189

## Testing/validation
relic inventory
<img width="1576" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/46ccd2da-0ad3-4332-b60e-986545d4653a">

clicking on edit relic
<img width="1434" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/6cfcb613-34b6-43fe-be40-7dfa8cec062b">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
