### PR TITLE
Relic Editor improvements

### DIFF
--- a/libs/sr/consts/src/relic.ts
+++ b/libs/sr/consts/src/relic.ts
@@ -1,8 +1,8 @@
 export const allRelicPlanarSlotKeys = ['sphere', 'rope'] as const
-export type RelicPlanarSlotKey = (typeof allRelicSlotKeys)[number]
+export type RelicPlanarSlotKey = (typeof allRelicPlanarSlotKeys)[number]
 
 export const allRelicCavernSlotKeys = ['head', 'hand', 'body', 'feet'] as const
-export type RelicCavernSlotKey = (typeof allRelicSlotKeys)[number]
+export type RelicCavernSlotKey = (typeof allRelicCavernSlotKeys)[number]
 
 export const allRelicSlotKeys = [
   ...allRelicCavernSlotKeys,

--- a/libs/sr/page-relics/src/index.tsx
+++ b/libs/sr/page-relics/src/index.tsx
@@ -11,6 +11,7 @@ export default function PageRelics() {
       <RelicEditor
         relicIdToEdit={relicIdToEdit}
         cancelEdit={() => setRelicIdToEdit('')}
+        allowEmpty
       />
       <RelicInventory
         onAdd={() => setRelicIdToEdit('new')}

--- a/libs/sr/ui/src/Character/LocationAutocomplete.tsx
+++ b/libs/sr/ui/src/Character/LocationAutocomplete.tsx
@@ -10,10 +10,15 @@ import { useDatabaseContext } from '../Context'
 type LocationAutocompleteProps = {
   locKey: CharacterLocationKey | ''
   setLocKey: (v: CharacterLocationKey | '') => void
+  props?: Omit<
+    GeneralAutocompleteOption<CharacterLocationKey | ''>,
+    'options' | 'valueKey' | 'onChange' | 'toImg'
+  >
 }
 export function LocationAutocomplete({
   locKey,
   setLocKey,
+  ...props
 }: LocationAutocompleteProps) {
   const { t } = useTranslation(['character', 'charNames_gen'])
   const { database } = useDatabaseContext()
@@ -54,10 +59,12 @@ export function LocationAutocomplete({
   return (
     <Suspense fallback={<Skeleton variant="text" width={100} />}>
       <GeneralAutocomplete
+        size="small"
         options={options}
         toImg={() => <> </>} // TODO
         valueKey={locKey}
         onChange={(k) => setLocKey(k ?? '')}
+        {...props}
       />
     </Suspense>
   )

--- a/libs/sr/ui/src/Relic/RelicEditor/RelicSetAutocomplete.tsx
+++ b/libs/sr/ui/src/Relic/RelicEditor/RelicSetAutocomplete.tsx
@@ -1,0 +1,50 @@
+import type { GeneralAutocompleteProps } from '@genshin-optimizer/common/ui'
+import { GeneralAutocomplete } from '@genshin-optimizer/common/ui'
+import type { RelicSetKey } from '@genshin-optimizer/sr/consts'
+import { allRelicSetKeys } from '@genshin-optimizer/sr/consts'
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type RelicSetAutocompleteProps = {
+  relicSetKey: RelicSetKey | ''
+  setRelicSetKey: (key: RelicSetKey | '') => void
+  label?: string
+  props?: Omit<
+    GeneralAutocompleteProps<RelicSetKey | ''>,
+    'options' | 'valueKey' | 'onChange' | 'toImg' | 'groupBy' | 'renderGroup'
+  >
+}
+
+export function RelicSetAutocomplete({
+  relicSetKey,
+  setRelicSetKey,
+  label = '',
+  ...props
+}: RelicSetAutocompleteProps) {
+  const { t } = useTranslation(['relic', 'relicNames_gen'])
+  label = label ? label : t('relic:autocompleteLabels.set')
+
+  const options = useMemo(
+    () =>
+      allRelicSetKeys.map((set) => ({
+        key: set,
+        label: t(`relicNames_gen:${set}`),
+      })),
+    [t]
+  )
+
+  const onChange = useCallback(
+    (k: RelicSetKey | '' | null) => setRelicSetKey(k ?? ''),
+    [setRelicSetKey]
+  )
+  return (
+    <GeneralAutocomplete
+      options={options}
+      valueKey={relicSetKey}
+      onChange={onChange}
+      toImg={() => <> </>}
+      label={label}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Describe your changes
- add duplicate/upgrade/edit UI to relic editor
- add `allowEmpty` prop (this ended up not really being an issue but it doesn't really create errors without substat validation)
- make basic relic set autocomplete component and switch to using it
- adjust location autocomplete styling + props
- nit: change planar/cavern slot keys type to be of planar/cavern type instead of generic slot key type - i noticed that `RelicPlanarSlotKey` and `RelicCavernSlotKey` were both calling `typeof allRelicSlotKeys` instead of their respective sub `allRelic[X]Keys`, which seemed out of place when compared with how the `SetKeys` versions were initialized to the proper types.

## Issue or discord link

## Testing/validation

Duplicate/Upgrade/Edit UI:
<img width="1846" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/622cc207-f181-416e-920c-1f11a54321df">
<img width="2006" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/2e52bacd-4332-4b60-b2ec-68b86ac5d7ce">
<img width="1714" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/8635193/aecbde4e-7e25-48f8-b2f3-0343d321ec68">

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
