### PR TITLE
Add an icon indication if a target has a description

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomTargetDisplay.tsx
@@ -14,7 +14,8 @@ import {
 } from '@genshin-optimizer/gi/ui'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
 import BarChartIcon from '@mui/icons-material/BarChart'
-import { Box, CardActionArea, Chip, Typography } from '@mui/material'
+import CommentIcon from '@mui/icons-material/Comment'
+import { Avatar, Box, CardActionArea, Chip, Typography } from '@mui/material'
 import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import OptimizationTargetDisplay from '../Tabs/TabOptimize/Components/OptimizationTargetDisplay'
@@ -32,8 +33,15 @@ export default function CustomTargetDisplay({
 }) {
   const { t } = useTranslation('page_character')
   const { data } = useContext(DataContext)
-  const { path, weight, hitMode, reaction, infusionAura, bonusStats } =
-    customTarget
+  const {
+    path,
+    weight,
+    hitMode,
+    reaction,
+    infusionAura,
+    bonusStats,
+    description,
+  } = customTarget
 
   const node = objPathValue(data.getDisplay(), path) as CalcResult | undefined
 
@@ -74,6 +82,11 @@ export default function CustomTargetDisplay({
             />
           )}
           <Chip label={t(`hitmode.${hitMode}`)} />
+          {description && (
+            <Avatar style={{ backgroundColor: '#4C566A' }}>
+              <CommentIcon style={{ color: 'white' }} />
+            </Avatar>
+          )}
         </Typography>
       </CardActionArea>
     </CardThemed>


### PR DESCRIPTION
## Describe your changes

thought about adding a tooltip when hovering over the icon that shows truncated description but I'm not sure, would like some input on that

## Issue or discord link

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/61787059/c70316eb-6570-4e2f-8228-f16d09534856)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
