### PR TITLE
Fix mini-ci tests hanging and not checking for linter warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "frontend": "nx serve frontend",
     "build-all": "nx run-many -t build",
-    "mini-ci": "nx format:write && nx affected -t test,eslint:lint,typecheck",
+    "mini-ci": "nx format:write && nx affected -t typecheck && nx affected -t eslint:lint --max-warnings=0 && CI=true nx affected -t test",
     "reload-dm": "git submodule update --init",
     "update-dm": "git submodule update --remote",
     "test": "nx run-many -t test"


### PR DESCRIPTION
## Describe your changes
Currently `nx affected/run-many -t test` is currently being set to watch for input due to some issues on Nx's side, making them hang (https://github.com/nrwl/nx/issues/26223); we can temporarily get around this by adding `CI=true`. Also split up targets into individual commands so we can pass `max-warnings` flag to catch lint warnings instead of them being skipped.

## Issue or discord link

## Testing/validation

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
