### PR TITLE
Remove clear button in weapon page

### DIFF
--- a/libs/common/ui/src/components/GeneralAutocomplete.tsx
+++ b/libs/common/ui/src/components/GeneralAutocomplete.tsx
@@ -44,7 +44,7 @@ export type GeneralAutocompleteProps<T extends string> =
     valueKey: T | null
     onChange: (v: T | null) => void
   } & Omit<
-      AutocompleteProps<GeneralAutocompleteOption<T>, false, false, false>,
+      AutocompleteProps<GeneralAutocompleteOption<T>, false, boolean, false>,
       | 'renderInput'
       | 'isOptionEqualToValue'
       | 'renderOption'

--- a/libs/gi/ui/src/components/character/LocationAutocomplete.tsx
+++ b/libs/gi/ui/src/components/character/LocationAutocomplete.tsx
@@ -29,7 +29,7 @@ type LocationAutocompleteProps = {
     AutocompleteProps<
       GeneralAutocompleteOption<LocationKey>,
       false,
-      false,
+      boolean,
       false
     >,
     'renderInput' | 'onChange' | 'options'

--- a/libs/gi/ui/src/components/weapon/WeaponCard.tsx
+++ b/libs/gi/ui/src/components/weapon/WeaponCard.tsx
@@ -205,7 +205,10 @@ export function WeaponCard({
                 location={location}
                 setLocation={setLocation}
                 filter={filter}
-                autoCompleteProps={{ getOptionDisabled: (t) => !t.key }}
+                autoCompleteProps={{
+                  getOptionDisabled: (t) => !t.key,
+                  disableClearable: true,
+                }}
               />
             ) : (
               <LocationName location={location} />

--- a/libs/gi/ui/src/components/weapon/WeaponEditor.tsx
+++ b/libs/gi/ui/src/components/weapon/WeaponEditor.tsx
@@ -265,7 +265,10 @@ export function WeaponEditor({
                   location={location}
                   setLocation={setLocation}
                   filter={filter}
-                  autoCompleteProps={{ getOptionDisabled: (t) => !t.key }}
+                  autoCompleteProps={{
+                    getOptionDisabled: (t) => !t.key,
+                    disableClearable: true,
+                  }}
                 />
               </Grid>
             </Grid>


### PR DESCRIPTION
## Describe your changes

Remove the clear button in weapon card and weapon editor

## Issue or discord link

- Closes #2256

## Testing/validation

![image](https://github.com/frzyc/genshin-optimizer/assets/70012600/295e804c-794e-46e5-93db-04d9ccc995f7)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
