### PR TITLE
Bold the selected header tab text

### DIFF
--- a/apps/frontend/src/app/Header.tsx
+++ b/apps/frontend/src/app/Header.tsx
@@ -269,7 +269,7 @@ function HeaderContent({ anchor }: { anchor: string }) {
                 label={
                   isXL || textSuffix ? (
                     <Box display="flex" gap={0.5} alignItems="center">
-                      {isXL && <Typography>{t(i18Key)}</Typography>}
+                      {isXL && <Typography sx={{ fontWeight: currentTab === value ? 'bold' : 'normal' }} >{t(i18Key)}</Typography>}
                       {textSuffix}
                     </Box>
                   ) : undefined


### PR DESCRIPTION
**Changes**
Updated heading styling to meet the requirement of displaying the selected tab text in bold

**Issue :**  
Bold the selected header tab text 
https://github.com/frzyc/genshin-optimizer/issues/2263

### validation
**Before** 
<img width="933" alt="Before Changes" src="https://github.com/frzyc/genshin-optimizer/assets/142216709/83a08916-cb53-4ac9-9f18-5ba9402e82ef">
 **After** 
<img width="932" alt="After changes" src="https://github.com/frzyc/genshin-optimizer/assets/142216709/36a91c97-0b62-4b8a-aada-c2163997bed2">

