### PR TITLE
Fixed issue #2241 GO team page title shows tabs.undefined

### DIFF
--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -129,17 +129,23 @@ function Page({ teamId }: { teamId: string }) {
   ])
 
   useTitle(
-    useMemo(
-      () =>
-        `${team.name} - ${t(
-          `${silly ? 'sillyWisher_charNames' : 'charNames_gen'}:${
-            characterKey
-              ? charKeyToLocGenderedCharKey(characterKey, gender)
-              : 'Character'
-          }`
-        )} - ${t(`page_character:tabs.${tab}`)}`,
-      [t, team.name, silly, characterKey, gender, tab]
-    )
+    useMemo(() => {
+      const charName = characterKey
+        ? t(
+            `${
+              silly ? 'sillyWisher_charNames' : 'charNames_gen'
+            }:${charKeyToLocGenderedCharKey(characterKey, gender)}`
+          )
+        : t('Team Settings')
+      const tabName = tab
+        ? t(`page_character:tabs.${tab}`)
+        : characterKey
+        ? t('Loadout/Build')
+        : tab
+      return tabName
+        ? `${team.name} - ${charName} - ${tabName}`
+        : `${team.name} - ${charName}`
+    }, [t, team.name, silly, characterKey, gender, tab])
   )
 
   const teamCharacterContextValue: TeamCharacterContextObj | undefined =


### PR DESCRIPTION
## Describe your changes

Changed default behavior when `tab` is null or `characterKey` is null. 

When `characterKey` is null (when on team settings page), formatted as "\<Team Name\> - Team Settings - Genshin Optimizer". Note that `tab` will always be null in this case. 

When `characterKey` is not null and `tab` is null, this means that we're on the "Loadout/Build" tab, so formatted appropriately.

Do note that there's another issue with the Artifact Upgrader tab, where it doesn't display properly, but I'm not familiar enough with the codebase to fix this. 

## Issue or discord link

- Fix <https://github.com/frzyc/genshin-optimizer/issues/2241>

## Testing/validation

Two of the fixed pages, and the one that's still broken, I can make another issue for that one.

<img width="298" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/49707036/96cc8f62-0ea8-4ccc-82c3-35721722e710">

<img width="352" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/49707036/5f7a3979-b81e-44b5-9674-839689bb76a6">

<img width="382" alt="image" src="https://github.com/frzyc/genshin-optimizer/assets/49707036/eaa0df87-181f-42f1-afd7-6c93cfca8289">



## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
