### PR TITLE
Add gi-assets-data with filenames for assets

### DIFF
--- a/libs/gi/assets-data/.eslintrc.json
+++ b/libs/gi/assets-data/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/gi/assets-data/README.md
+++ b/libs/gi/assets-data/README.md
@@ -1,0 +1,3 @@
+# gi-assets-data
+
+This library was generated with [Nx](https://nx.dev).

--- a/libs/gi/assets-data/project.json
+++ b/libs/gi/assets-data/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "gi-assets-data",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/gi/assets-data/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project gi-assets-data --web",
+  "targets": {}
+}

--- a/libs/gi/assets-data/src/AssetData.ts
+++ b/libs/gi/assets-data/src/AssetData.ts
@@ -1,0 +1,221 @@
+import { layeredAssignment } from '@genshin-optimizer/common/util'
+import type {
+  ArtifactSetKey,
+  ArtifactSlotKey,
+  LocationGenderedCharacterKey,
+  WeaponKey,
+} from '@genshin-optimizer/gi/consts'
+import type {
+  AvatarSkillDepotExcelConfigData,
+  CharacterId,
+  WeaponId,
+} from '@genshin-optimizer/gi/dm'
+import {
+  artifactIdMap,
+  artifactSlotMap,
+  avatarExcelConfigData,
+  avatarSkillDepotExcelConfigData,
+  avatarSkillExcelConfigData,
+  avatarTalentExcelConfigData,
+  characterIdMap,
+  fetterCharacterCardExcelConfigData,
+  materialExcelConfigData,
+  proudSkillExcelConfigData,
+  reliquaryExcelConfigData,
+  reliquarySetExcelConfigData,
+  rewardExcelConfigData,
+  weaponExcelConfigData,
+  weaponIdMap,
+} from '@genshin-optimizer/gi/dm'
+
+type CharacterIcon = {
+  icon: string
+  iconSide: string
+  banner?: string
+  bar?: string
+  skill?: string
+  burst?: string
+  sprint?: string
+  passive1?: string
+  passive2?: string
+  passive3?: string
+  passive?: string
+  constellation1?: string
+  constellation2?: string
+  constellation3?: string
+  constellation4?: string
+  constellation5?: string
+  constellation6?: string
+}
+type CharacterIconData = Record<LocationGenderedCharacterKey, CharacterIcon>
+//An object to store all the asset related data.
+export const AssetData = {
+  weapons: {} as Record<WeaponKey, { icon: string; awakenIcon: string }>,
+  artifacts: {} as Record<
+    ArtifactSetKey,
+    Partial<Record<ArtifactSlotKey, string>>
+  >,
+  chars: {} as CharacterIconData,
+}
+
+// Get icons for each artifact piece
+Object.entries(reliquarySetExcelConfigData).forEach(([setId, data]) => {
+  const { equipAffixId, containsList } = data
+  if (!equipAffixId) return
+
+  const pieces = Object.fromEntries(
+    containsList.map((pieceId) => {
+      const pieceData = reliquaryExcelConfigData[pieceId]
+      if (!pieceData)
+        throw new Error(`No piece data with id ${pieceId} in setId ${setId}`)
+      const { icon, equipType } = pieceData
+      return [artifactSlotMap[equipType], icon]
+    })
+  ) as Partial<Record<ArtifactSlotKey, string>>
+
+  AssetData.artifacts[artifactIdMap[setId]] = pieces
+})
+
+// Get the icon/awakened for each weapon
+Object.entries(weaponExcelConfigData).forEach(([weaponid, weaponData]) => {
+  const { icon, awakenIcon } = weaponData
+  AssetData.weapons[weaponIdMap[weaponid as WeaponId]] = {
+    icon,
+    awakenIcon,
+  }
+})
+
+// parse baseStat/ascension/basic data for characters.
+Object.entries(avatarExcelConfigData).forEach(([charid, charData]) => {
+  const { iconName, sideIconName } = charData
+
+  let banner, bar
+  if (fetterCharacterCardExcelConfigData[charid as CharacterId]) {
+    const { rewardId } = fetterCharacterCardExcelConfigData[charid]
+    const { rewardItemList } = rewardExcelConfigData[rewardId]
+    const { itemId } = rewardItemList[0]
+    ;({
+      picPath: [bar, banner],
+    } = materialExcelConfigData[itemId])
+  }
+  const assets = banner
+    ? {
+        icon: iconName,
+        iconSide: sideIconName,
+        banner,
+        bar: bar!,
+      }
+    : {
+        icon: iconName,
+        iconSide: sideIconName,
+      }
+  AssetData.chars[characterIdMap[charid]] = assets
+})
+
+const assetChar = AssetData.chars
+Object.entries(avatarExcelConfigData).forEach(([charid, charData]) => {
+  const { iconName, sideIconName, skillDepotId, candSkillDepotIds } = charData
+
+  const cKey = characterIdMap[charid]
+  layeredAssignment(assetChar, [cKey, 'icon'], iconName)
+  layeredAssignment(assetChar, [cKey, 'iconSide'], sideIconName)
+
+  if (fetterCharacterCardExcelConfigData[charid]) {
+    const { rewardId } = fetterCharacterCardExcelConfigData[charid]
+    const { rewardItemList } = rewardExcelConfigData[rewardId]
+    const { itemId } = rewardItemList[0]
+    const {
+      picPath: [bar, banner],
+    } = materialExcelConfigData[itemId]
+    bar && layeredAssignment(assetChar, [cKey, 'bar'], bar)
+    banner && layeredAssignment(assetChar, [cKey, 'banner'], banner)
+  }
+  function genTalentHash(ck: string, depot: AvatarSkillDepotExcelConfigData) {
+    const {
+      energySkill: burst,
+      skills: [_normal, skill, sprint],
+      talents,
+      inherentProudSkillOpens: [passive1, passive2, passive3, , passive],
+    } = depot
+
+    // auto icons are shared.
+    // layeredAssignment(characterAssetDump, [cKey, "auto"], talents[normal].skillIcon)
+    layeredAssignment(
+      assetChar,
+      [ck, 'skill'],
+      avatarSkillExcelConfigData[skill].skillIcon
+    )
+
+    // burst has a more detailed _HD version
+    layeredAssignment(
+      assetChar,
+      [ck, 'burst'],
+      avatarSkillExcelConfigData[burst].skillIcon + '_HD'
+    )
+    if (sprint)
+      layeredAssignment(
+        assetChar,
+        [ck, 'sprint'],
+        avatarSkillExcelConfigData[sprint].skillIcon
+      )
+
+    passive1.proudSkillGroupId &&
+      layeredAssignment(
+        assetChar,
+        [ck, 'passive1'],
+        proudSkillExcelConfigData[passive1.proudSkillGroupId][0].icon
+      )
+    passive2.proudSkillGroupId &&
+      layeredAssignment(
+        assetChar,
+        [ck, 'passive2'],
+        proudSkillExcelConfigData[passive2.proudSkillGroupId][0].icon
+      )
+    if (passive3?.proudSkillGroupId)
+      layeredAssignment(
+        assetChar,
+        [ck, 'passive3'],
+        proudSkillExcelConfigData[passive3.proudSkillGroupId][0].icon
+      )
+
+    // Seems to be only used by SangonomiyaKokomi
+    if (passive?.proudSkillGroupId)
+      layeredAssignment(
+        assetChar,
+        [ck, 'passive'],
+        proudSkillExcelConfigData[passive.proudSkillGroupId][0].icon
+      )
+
+    talents.forEach((skId, i) => {
+      layeredAssignment(
+        assetChar,
+        [ck, `constellation${i + 1}`],
+        avatarTalentExcelConfigData[skId].icon
+      )
+    })
+  }
+
+  if (candSkillDepotIds.length) {
+    // Traveler
+    const [, , hydro, anemo, , geo, electro, dendro] = candSkillDepotIds
+    // const gender = characterIdMap[charid] === "TravelerF" ? "F" : "M"
+    genTalentHash('TravelerAnemo', avatarSkillDepotExcelConfigData[anemo])
+    genTalentHash('TravelerGeo', avatarSkillDepotExcelConfigData[geo])
+    genTalentHash('TravelerElectro', avatarSkillDepotExcelConfigData[electro])
+    genTalentHash('TravelerDendro', avatarSkillDepotExcelConfigData[dendro])
+    genTalentHash('TravelerHydro', avatarSkillDepotExcelConfigData[hydro])
+  } else {
+    genTalentHash(cKey, avatarSkillDepotExcelConfigData[skillDepotId])
+  }
+})
+
+// Dump out the asset List.
+// dumpFile(`${__dirname}/AssetData_gen.json`, assetChar)
+
+// Add in manually added assets that can't be datamined
+AssetData.chars['Somnia'] = {} as CharacterIcon
+AssetData.weapons['QuantumCatalyst'] = {} as {
+  icon: string
+  awakenIcon: string
+}
+// await generateIndexFromObj(AssetData, `${DEST_PROJ_PATH}/gen`)

--- a/libs/gi/assets-data/src/index.ts
+++ b/libs/gi/assets-data/src/index.ts
@@ -1,0 +1,1 @@
+export * from './AssetData'

--- a/libs/gi/assets-data/tsconfig.json
+++ b/libs/gi/assets-data/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/gi/assets-data/tsconfig.lib.json
+++ b/libs/gi/assets-data/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/gi/assets/src/executors/gen-assets/executor.ts
+++ b/libs/gi/assets/src/executors/gen-assets/executor.ts
@@ -1,56 +1,13 @@
 import { generateIndexFromObj } from '@genshin-optimizer/common/pipeline'
-import { crawlObject, layeredAssignment } from '@genshin-optimizer/common/util'
-import type {
-  ArtifactSetKey,
-  ArtifactSlotKey,
-  WeaponKey,
-} from '@genshin-optimizer/gi/consts'
-import type {
-  AvatarSkillDepotExcelConfigData,
-  CharacterId,
-  WeaponId,
-} from '@genshin-optimizer/gi/dm'
-import {
-  DM2D_PATH,
-  artifactIdMap,
-  artifactSlotMap,
-  avatarExcelConfigData,
-  avatarSkillDepotExcelConfigData,
-  avatarSkillExcelConfigData,
-  avatarTalentExcelConfigData,
-  characterIdMap,
-  fetterCharacterCardExcelConfigData,
-  materialExcelConfigData,
-  proudSkillExcelConfigData,
-  reliquaryExcelConfigData,
-  reliquarySetExcelConfigData,
-  rewardExcelConfigData,
-  weaponExcelConfigData,
-  weaponIdMap,
-} from '@genshin-optimizer/gi/dm'
+import { crawlObject } from '@genshin-optimizer/common/util'
+import { AssetData } from '@genshin-optimizer/gi/assets-data'
+import { DM2D_PATH } from '@genshin-optimizer/gi/dm'
 import { workspaceRoot } from '@nx/devkit'
 import * as fs from 'fs'
 import * as path from 'path'
 import type { GenAssetsExecutorSchema } from './schema'
 
 export const DEST_PROJ_PATH = `${workspaceRoot}/libs/gi/assets/src` as const
-
-type CharacterIcon = {
-  icon: string
-  iconSide: string
-  banner?: string
-  bar?: string
-}
-type CharacterIconData = { [key: string]: CharacterIcon }
-//An object to store all the asset related data.
-export const AssetData = {
-  weapons: {} as Record<WeaponKey, { icon: string; awakenIcon: string }>,
-  artifacts: {} as Record<
-    ArtifactSetKey,
-    Partial<Record<ArtifactSlotKey, string>>
-  >,
-  chars: {} as CharacterIconData,
-}
 
 export default async function runExecutor(
   _options: GenAssetsExecutorSchema
@@ -74,159 +31,6 @@ export default async function runExecutor(
     })
   }
 
-  // Get icons for each artifact piece
-  Object.entries(reliquarySetExcelConfigData).forEach(([setId, data]) => {
-    const { equipAffixId, containsList } = data
-    if (!equipAffixId) return
-
-    const pieces = Object.fromEntries(
-      containsList.map((pieceId) => {
-        const pieceData = reliquaryExcelConfigData[pieceId]
-        if (!pieceData)
-          throw new Error(`No piece data with id ${pieceId} in setId ${setId}`)
-        const { icon, equipType } = pieceData
-        return [artifactSlotMap[equipType], icon]
-      })
-    ) as Partial<Record<ArtifactSlotKey, string>>
-
-    AssetData.artifacts[artifactIdMap[setId]] = pieces
-  })
-
-  // Get the icon/awakened for each weapon
-  Object.entries(weaponExcelConfigData).forEach(([weaponid, weaponData]) => {
-    const { icon, awakenIcon } = weaponData
-    AssetData.weapons[weaponIdMap[weaponid as WeaponId]] = {
-      icon,
-      awakenIcon,
-    }
-  })
-
-  // parse baseStat/ascension/basic data for characters.
-  Object.entries(avatarExcelConfigData).forEach(([charid, charData]) => {
-    const { iconName, sideIconName } = charData
-
-    let banner, bar
-    if (fetterCharacterCardExcelConfigData[charid as CharacterId]) {
-      const { rewardId } = fetterCharacterCardExcelConfigData[charid]
-      const { rewardItemList } = rewardExcelConfigData[rewardId]
-      const { itemId } = rewardItemList[0]
-      ;({
-        picPath: [bar, banner],
-      } = materialExcelConfigData[itemId])
-    }
-    const assets = banner
-      ? {
-          icon: iconName,
-          iconSide: sideIconName,
-          banner,
-          bar: bar!,
-        }
-      : {
-          icon: iconName,
-          iconSide: sideIconName,
-        }
-    AssetData.chars[characterIdMap[charid]] = assets
-  })
-
-  const assetChar = AssetData.chars
-  Object.entries(avatarExcelConfigData).forEach(([charid, charData]) => {
-    const { iconName, sideIconName, skillDepotId, candSkillDepotIds } = charData
-
-    const cKey = characterIdMap[charid]
-    layeredAssignment(assetChar, [cKey, 'icon'], iconName)
-    layeredAssignment(assetChar, [cKey, 'iconSide'], sideIconName)
-
-    if (fetterCharacterCardExcelConfigData[charid]) {
-      const { rewardId } = fetterCharacterCardExcelConfigData[charid]
-      const { rewardItemList } = rewardExcelConfigData[rewardId]
-      const { itemId } = rewardItemList[0]
-      const {
-        picPath: [bar, banner],
-      } = materialExcelConfigData[itemId]
-      bar && layeredAssignment(assetChar, [cKey, 'bar'], bar)
-      banner && layeredAssignment(assetChar, [cKey, 'banner'], banner)
-    }
-    function genTalentHash(ck: string, depot: AvatarSkillDepotExcelConfigData) {
-      const {
-        energySkill: burst,
-        skills: [_normal, skill, sprint],
-        talents,
-        inherentProudSkillOpens: [passive1, passive2, passive3, , passive],
-      } = depot
-
-      // auto icons are shared.
-      // layeredAssignment(characterAssetDump, [cKey, "auto"], talents[normal].skillIcon)
-      layeredAssignment(
-        assetChar,
-        [ck, 'skill'],
-        avatarSkillExcelConfigData[skill].skillIcon
-      )
-
-      // burst has a more detailed _HD version
-      layeredAssignment(
-        assetChar,
-        [ck, 'burst'],
-        avatarSkillExcelConfigData[burst].skillIcon + '_HD'
-      )
-      if (sprint)
-        layeredAssignment(
-          assetChar,
-          [ck, 'sprint'],
-          avatarSkillExcelConfigData[sprint].skillIcon
-        )
-
-      passive1.proudSkillGroupId &&
-        layeredAssignment(
-          assetChar,
-          [ck, 'passive1'],
-          proudSkillExcelConfigData[passive1.proudSkillGroupId][0].icon
-        )
-      passive2.proudSkillGroupId &&
-        layeredAssignment(
-          assetChar,
-          [ck, 'passive2'],
-          proudSkillExcelConfigData[passive2.proudSkillGroupId][0].icon
-        )
-      if (passive3?.proudSkillGroupId)
-        layeredAssignment(
-          assetChar,
-          [ck, 'passive3'],
-          proudSkillExcelConfigData[passive3.proudSkillGroupId][0].icon
-        )
-
-      // Seems to be only used by SangonomiyaKokomi
-      if (passive?.proudSkillGroupId)
-        layeredAssignment(
-          assetChar,
-          [ck, 'passive'],
-          proudSkillExcelConfigData[passive.proudSkillGroupId][0].icon
-        )
-
-      talents.forEach((skId, i) => {
-        layeredAssignment(
-          assetChar,
-          [ck, `constellation${i + 1}`],
-          avatarTalentExcelConfigData[skId].icon
-        )
-      })
-    }
-
-    if (candSkillDepotIds.length) {
-      // Traveler
-      const [, , hydro, anemo, , geo, electro, dendro] = candSkillDepotIds
-      // const gender = characterIdMap[charid] === "TravelerF" ? "F" : "M"
-      genTalentHash('TravelerAnemo', avatarSkillDepotExcelConfigData[anemo])
-      genTalentHash('TravelerGeo', avatarSkillDepotExcelConfigData[geo])
-      genTalentHash('TravelerElectro', avatarSkillDepotExcelConfigData[electro])
-      genTalentHash('TravelerDendro', avatarSkillDepotExcelConfigData[dendro])
-      genTalentHash('TravelerHydro', avatarSkillDepotExcelConfigData[hydro])
-    } else {
-      genTalentHash(cKey, avatarSkillDepotExcelConfigData[skillDepotId])
-    }
-  })
-
-  // Dump out the asset List.
-
   // dumpFile(`${__dirname}/AssetData_gen.json`, assetChar)
   if (copyAssets) {
     crawlObject(
@@ -242,12 +46,6 @@ export default async function runExecutor(
     )
   }
 
-  // Add in manually added assets that can't be datamined
-  AssetData.chars['Somnia'] = {} as CharacterIcon
-  AssetData.weapons['QuantumCatalyst'] = {} as {
-    icon: string
-    awakenIcon: string
-  }
   await generateIndexFromObj(AssetData, `${DEST_PROJ_PATH}/gen`)
   return { success: true }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -53,6 +53,7 @@
       "@genshin-optimizer/common/util": ["libs/common/util/src/index.ts"],
       "@genshin-optimizer/gi/art-scanner": ["libs/gi/art-scanner/src/index.ts"],
       "@genshin-optimizer/gi/assets": ["libs/gi/assets/src/index.ts"],
+      "@genshin-optimizer/gi/assets-data": ["libs/gi/assets-data/src/index.ts"],
       "@genshin-optimizer/gi/char-cards": ["libs/gi/char-cards/src/index.ts"],
       "@genshin-optimizer/gi/consts": ["libs/gi/consts/src/index.ts"],
       "@genshin-optimizer/gi/db": ["libs/gi/db/src/index.ts"],


### PR DESCRIPTION
## Describe your changes

Extract out gi-assets `AssetData` object to a separate library. This is honestly better code anyways, as this processing doesn't need to be done in the generator itself.
Now the generator serves to create the asset index files, and copy over Texture2D if needed, which fits better for its responsibility as a generator.

This was needed because importing AssetData from gi-assets would also end up importing the rest of the library, which contains references to png files. These are not handled well by node and would cause issues for node-based apps, like Somnia.
And as mentioned before, this is better separation of concerns/ui vs non-ui code.

## Issue or discord link

- Resolves #2299

## Testing/validation

* Deleted generated asset files and reran `nx run gi-assets:gen-file`. Verified that the files were regenerated as expected
* Tested briefly with Somnia and was able to print out asset file names
![image](https://github.com/frzyc/genshin-optimizer/assets/36019388/8d4c9e81-c2bc-4ef1-aa5d-89787e232115)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
