### PR TITLE
Replace specialized stats with individual entries

### DIFF
--- a/libs/gi/formula/src/data/char/util.ts
+++ b/libs/gi/formula/src/data/char/util.ts
@@ -175,10 +175,8 @@ export function entriesForChar(
 
     // Listing (specialized)
     ...[...specialized].map((stat) =>
-      self.listing.specialized.add(
-        // Sheet-specific data (i.e., `sheet:<key>`)
-        listingItem(readStat(self.premod, stat).sheet(key))
-      )
+      // Sheet-specific data (i.e., `sheet:<key>`)
+      self.char.specialized.add(readStat(self.premod, stat).sheet(key))
     ),
   ]
 }

--- a/libs/gi/formula/src/data/util/tag.ts
+++ b/libs/gi/formula/src/data/util/tag.ts
@@ -105,8 +105,15 @@ export const selfTag = {
     skill: agg,
     burst: agg,
     stamina: agg,
+    specialized: iso,
   },
-  weapon: { lvl: iso, refinement: iso, ascension: iso },
+  weapon: {
+    lvl: iso,
+    refinement: iso,
+    ascension: iso,
+    primary: agg,
+    secondary: agg,
+  },
   common: {
     weaponType: iso,
     critMode: fixed,
@@ -146,7 +153,6 @@ export const selfTag = {
   },
   listing: {
     formulas: aggStr,
-    specialized: aggStr,
   },
 } as const
 export const enemyTag = {

--- a/libs/gi/formula/src/data/weapon/util.ts
+++ b/libs/gi/formula/src/data/weapon/util.ts
@@ -2,7 +2,7 @@ import { type WeaponKey } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
 import { prod, subscript } from '@genshin-optimizer/pando/engine'
 import type { TagMapNodeEntries } from '../util'
-import { allStatics, listingItem, readStat, self } from '../util'
+import { allStatics, readStat, self } from '../util'
 
 export function entriesForWeapon(key: WeaponKey): TagMapNodeEntries {
   const gen = allStats.weapon.data[key]
@@ -33,25 +33,10 @@ export function entriesForWeapon(key: WeaponKey): TagMapNodeEntries {
       ).add(subscript(refinement, values))
     ),
 
-    // Listing (specialized)
-    // All items here are sheet-specific data (i.e., `sheet:<key>`)
-    self.listing.specialized.add(
-      listingItem(self.base[primaryStat].sheet(key))
-    ),
+    // Specialized stats, items here are sheet-specific data (i.e., `sheet:<key>`)
+    self.weapon.primary.add(self.base[primaryStat].sheet(key)),
     ...[...nonPrimaryStat].map((stat) =>
-      self.listing.specialized.add(
-        listingItem(readStat(self.premod, stat).sheet(key))
-      )
-    ),
-    ...[...Object.keys(gen.refinementBonus)].map((stat) =>
-      self.listing.specialized.add(
-        listingItem(
-          readStat(
-            self.weaponRefinement,
-            stat as keyof typeof gen.refinementBonus
-          ).sheet(key)
-        )
-      )
+      self.weapon.secondary.add(readStat(self.premod, stat).sheet(key))
     ),
   ]
 }

--- a/libs/gi/formula/src/example.test.ts
+++ b/libs/gi/formula/src/example.test.ts
@@ -112,6 +112,12 @@ describe('example', () => {
     )
     expect(calc.compute(member0.common.cappedCritRate_).val).toBe(0.05)
     expect(calc.compute(member0.common.cappedCritRate_.burgeon).val).toBe(0.25)
+    const specialized = calc.compute(member0.char.specialized)
+    expect(specialized.val).toBe(0)
+    // Specialized stat include the stat tag
+    expect(specialized.meta.tag?.['sheet']).toBe('Nahida')
+    expect(specialized.meta.tag!['qt']).toBe('premod')
+    expect(specialized.meta.tag!['q']).toBe('eleMas')
   })
   test('calculate team stats', () => {
     // Nahida's contribution to `common.count`
@@ -272,16 +278,18 @@ describe('weapon-only example', () => {
 
   const self = convert(selfTag, { et: 'self' })
 
-  test('retrieve formulas in a listing', () => {
-    const listing = calc.listFormulas(self.listing.specialized)
-    expect(listing.length).toEqual(3)
-  })
-  test('calculate formulas in a listing', () => {
-    // Some listings require character data (e.g., `formulas` listing) and will crash if used
-    const listing = calc.listFormulas(self.listing.specialized)
+  test('calculate specialized stats', () => {
+    const primary = calc.compute(self.weapon.primary)
+    expect(primary.val).toBeCloseTo(337.96) // atk
+    expect(primary.meta.tag?.['sheet']).toEqual('KeyOfKhajNisut')
+    expect(primary.meta.tag?.['qt']).toEqual('base')
+    expect(primary.meta.tag?.['q']).toEqual('atk')
 
-    expect(calc.compute(listing[0]).val).toBeCloseTo(337.96) // atk
-    expect(calc.compute(listing[1]).val).toBeCloseTo(0.458) // hp_
-    expect(calc.compute(listing[2]).val).toBeCloseTo(0.3) // refinement hp_
+    // If there are multiple, or none, use `calc.get` instead
+    const secondary = calc.compute(self.weapon.secondary)
+    expect(secondary.val).toBeCloseTo(0.458) // hp_
+    expect(secondary.meta.tag?.['sheet']).toEqual('KeyOfKhajNisut')
+    expect(secondary.meta.tag?.['qt']).toEqual('premod')
+    expect(secondary.meta.tag?.['q']).toEqual('hp_')
   })
 })

--- a/libs/gi/formula/src/example.test.ts
+++ b/libs/gi/formula/src/example.test.ts
@@ -282,14 +282,14 @@ describe('weapon-only example', () => {
     const primary = calc.compute(self.weapon.primary)
     expect(primary.val).toBeCloseTo(337.96) // atk
     expect(primary.meta.tag?.['sheet']).toEqual('KeyOfKhajNisut')
-    expect(primary.meta.tag?.['qt']).toEqual('base')
-    expect(primary.meta.tag?.['q']).toEqual('atk')
+    expect(primary.meta.tag!['qt']).toEqual('base')
+    expect(primary.meta.tag!['q']).toEqual('atk')
 
     // If there are multiple, or none, use `calc.get` instead
     const secondary = calc.compute(self.weapon.secondary)
     expect(secondary.val).toBeCloseTo(0.458) // hp_
     expect(secondary.meta.tag?.['sheet']).toEqual('KeyOfKhajNisut')
-    expect(secondary.meta.tag?.['qt']).toEqual('premod')
-    expect(secondary.meta.tag?.['q']).toEqual('hp_')
+    expect(secondary.meta.tag!['qt']).toEqual('premod')
+    expect(secondary.meta.tag!['q']).toEqual('hp_')
   })
 })


### PR DESCRIPTION
## Describe your changes

Formula listing proves unergonomical for specialized stats, which are statically known. This PR replaces the listing with individual stats. Each stat can then be accessed via `calc.compute`, e.g., `calc.compute(member0.char.specialized)`.

Note that nested' Read' uses the inner tag in the current (formula text) convention. So, the `calc.compute` result has the (correct) stat tag.

## Issue or discord link

https://discord.com/channels/785153694478893126/1189329506842984570/1266101081306562602

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [X] I have commented my code in hard-to understand areas.
- [X] I have made corresponding changes to README or wiki.
- [X] For front-end changes, I have updated the corresponding English translations.
- [X] I have run `yarn run mini-ci` locally to validate format and lint.
- [X] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
