### PR TITLE
Update parallel tasks for CI to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           yarn install --immutable --immutable-cache
       - name: Run lint
         run: |
-          yarn run nx run-many --target=eslint:lint --fix=false --max-warnings=0
+          yarn run nx run-many --target=eslint:lint --fix=false --max-warnings=0 --parallel=4
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -54,7 +54,7 @@ jobs:
           yarn install --immutable --immutable-cache
       - name: Run Tests
         run: |
-          yarn run nx run-many --target=test
+          yarn run nx run-many --target=test --parallel=4
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -90,7 +90,7 @@ jobs:
           yarn install --immutable --immutable-cache
       - name: Check types
         run: |
-          yarn run nx run-many --target=typecheck
+          yarn run nx run-many --target=typecheck --parallel=4
   gen-file:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -122,5 +122,5 @@ jobs:
           yarn install --immutable --immutable-cache
       - name: Check Gen File
         run: |
-          yarn run nx run-many -t gen-file
+          yarn run nx run-many -t gen-file --parallel=4
           test -z "$(git status --porcelain | tee /dev/stderr)"


### PR DESCRIPTION
## Describe your changes

Update parallel tasks for CI from (default) 3 to 4, because GitHub hosted runners have 4 'Process or CPU'
https://nx.dev/nx-api/nx/documents/run-many#parallel
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
![image](https://github.com/user-attachments/assets/447fe238-73e2-46e0-a3f6-bb94bc389ade)


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
