### PR TITLE
Explicitly specify job name for required status checks

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    name: 'build'
     steps:
       - uses: actions/checkout@v4
       - name: Get Cache Key

--- a/.github/workflows/build-go-next-pr.yml
+++ b/.github/workflows/build-go-next-pr.yml
@@ -18,7 +18,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  call-build-gi-frontend:
+  call-build:
     uses: ./.github/workflows/build-frontend.yml
     with:
       frontend_name: 'gi-frontend'

--- a/.github/workflows/build-go-wr-pr.yml
+++ b/.github/workflows/build-go-wr-pr.yml
@@ -19,7 +19,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  call-build-frontend:
+  call-build:
     uses: ./.github/workflows/build-frontend.yml
     with:
       frontend_name: 'frontend'

--- a/.github/workflows/build-somnia.yml
+++ b/.github/workflows/build-somnia.yml
@@ -46,7 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: 'build'
+    name: 'call-build / build'
     steps:
       - uses: actions/checkout@v4
       - name: Get Cache Key

--- a/.github/workflows/build-somnia.yml
+++ b/.github/workflows/build-somnia.yml
@@ -46,6 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    name: 'build'
     steps:
       - uses: actions/checkout@v4
       - name: Get Cache Key

--- a/.github/workflows/build-sro-pr.yml
+++ b/.github/workflows/build-sro-pr.yml
@@ -15,7 +15,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  call-build-sr-frontend:
+  call-build:
     uses: ./.github/workflows/build-frontend.yml
     with:
       frontend_name: 'sr-frontend'

--- a/.github/workflows/build-sro-pr.yml
+++ b/.github/workflows/build-sro-pr.yml
@@ -15,7 +15,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  call-build-frontend:
+  call-build-sr-frontend:
     uses: ./.github/workflows/build-frontend.yml
     with:
       frontend_name: 'sr-frontend'


### PR DESCRIPTION
## Describe your changes

We can explicitly define all our job names to be the same, so that way we can put a required status check on `call-build / build` and require at least one build per PR, even if that build is not of our typical frontend.

We need to change our ruleset to require `call-build / build` instead of `call-build-frontend / build` before this PR can merge

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Added a rule for `call-build / build` on my personal repo and noted that all builds were required
![image](https://github.com/user-attachments/assets/4c8e77b1-ee32-4968-81a3-25373c0a292d)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
