### PR TITLE
Enforce read-side and write-side query structure

### DIFF
--- a/libs/gi/formula/src/calculator.ts
+++ b/libs/gi/formula/src/calculator.ts
@@ -65,11 +65,11 @@ export class Calculator extends Base<CalcMeta> {
       case 'min':
       case 'max':
       case 'sumfrac': {
-        const empty = arithmetic[op]([], ex)
-        const ops = x.filter((x) => x!.val !== empty) as CalcResult<
-          number,
-          CalcMeta
-        >[]
+        let ops = x as CalcResult<number, CalcMeta>[]
+        if (ops.length > 1) {
+          const empty = arithmetic[op]([], ex)
+          ops = ops.filter((x) => x!.val !== empty)
+        }
         if (ops.length <= 1) {
           let meta = ops[0]?.meta ?? constOverride()
           if (meta.conds !== conds) meta = { ...meta, conds } // Use parent `conds` when short-circuiting

--- a/libs/gi/formula/src/data/util/sheet.ts
+++ b/libs/gi/formula/src/data/util/sheet.ts
@@ -45,7 +45,7 @@ export function customDmg(
     team,
     'dmg',
     tag(cond, { move }),
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     self.prep.ele.add(eleOverride ?? self.reaction.infusion),
     ...extra
   )
@@ -73,7 +73,7 @@ export function customShield(
     team,
     'shield',
     ele ? tag(cond, { ele }) : cond,
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     ...extra
   )
 }
@@ -89,7 +89,7 @@ export function customHeal(
     team,
     'heal',
     cond,
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     ...extra
   )
 }

--- a/libs/gi/formula/src/data/util/tag.ts
+++ b/libs/gi/formula/src/data/util/tag.ts
@@ -118,7 +118,7 @@ export const selfTag = {
   common: {
     weaponType: iso,
     critMode: fixed,
-    cappedCritRate_: iso,
+    cappedCritRate_: fixed,
     count: isoSum,
     eleCount: fixed,
   },

--- a/libs/gi/formula/src/example.test.ts
+++ b/libs/gi/formula/src/example.test.ts
@@ -25,6 +25,7 @@ import {
   artifactsData,
   charData,
   conditionalData,
+  noTeamData,
   teamData,
   weaponData,
   withMember,
@@ -185,7 +186,7 @@ describe('example', () => {
       'skill_hold',
       'skill_press',
     ])
-    expect(listing.filter((x) => x.sheet === 'static').length).toEqual(5)
+    expect(listing.filter((x) => x.sheet === 'static').length).toEqual(6)
   })
   test('calculate formulas in a listing', () => {
     const read = calc
@@ -273,7 +274,10 @@ describe('example', () => {
   })
 })
 describe('weapon-only example', () => {
-  const data: TagMapNodeEntries = [...weaponData(rawData[1].weapon as IWeapon)],
+  const data: TagMapNodeEntries = [
+      ...noTeamData(),
+      ...weaponData(rawData[1].weapon as IWeapon),
+    ],
     calc = genshinCalculatorWithEntries(data)
 
   const self = convert(selfTag, { et: 'self' })

--- a/libs/sr/formula/src/calculator.ts
+++ b/libs/sr/formula/src/calculator.ts
@@ -61,11 +61,11 @@ export class Calculator extends Base<CalcMeta> {
       case 'min':
       case 'max':
       case 'sumfrac': {
-        const empty = arithmetic[op]([], ex)
-        const ops = x.filter((x) => x!.val !== empty) as CalcResult<
-          number,
-          CalcMeta
-        >[]
+        let ops = x as CalcResult<number, CalcMeta>[]
+        if (ops.length > 1) {
+          const empty = arithmetic[op]([], ex)
+          ops = ops.filter((x) => x!.val !== empty)
+        }
         if (ops.length <= 1) {
           let meta = ops[0]?.meta ?? constOverride()
           if (meta.conds !== conds) meta = { ...meta, conds } // Use parent `conds` when short-circuiting

--- a/libs/sr/formula/src/data/char/util.ts
+++ b/libs/sr/formula/src/data/char/util.ts
@@ -25,6 +25,7 @@ import {
   listingItem,
   percent,
   self,
+  selfBuff,
   TypeKeyToListingType,
   type TagMapNodeEntries,
 } from '../util'
@@ -161,7 +162,7 @@ export function heal(
  */
 export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
   const { char } = self
-  const { eidolon, ascension, lvl, ele, path } = char
+  const { eidolon, ascension, lvl } = char
   // The "add" only applies to currLvl - 1, since "base" is stat at lvl 1
   const readLvl = sum(constant(-1), lvl)
   const statBoosts = Object.entries(data_gen.skillTree)
@@ -169,13 +170,13 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     .map(([_, s]) => s.levels?.[0]?.stats)
     .filter((s): s is SkillTreeNodeBonusStat => !!s)
   return [
-    ele.add(data_gen.damageType),
-    path.add(data_gen.path),
+    selfBuff.char.ele.add(data_gen.damageType),
+    selfBuff.char.path.add(data_gen.path),
     // Base stats
     ...(['hp', 'atk', 'def'] as const).map((sk) => {
       const basePerAsc = data_gen.ascension.map((p) => p[sk].base)
       const addPerAsc = data_gen.ascension.map((p) => p[sk].add)
-      return self.base[sk].add(
+      return selfBuff.base[sk].add(
         sum(
           subscript(ascension, basePerAsc),
           prod(readLvl, subscript(ascension, addPerAsc))
@@ -184,9 +185,9 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     }),
     ...(['crit_', 'crit_dmg_'] as const).map((sk) => {
       const statAsc = data_gen.ascension.map((p) => p[sk])
-      return self.premod[sk].add(subscript(ascension, statAsc))
+      return selfBuff.premod[sk].add(subscript(ascension, statAsc))
     }),
-    self.base.spd.add(
+    selfBuff.base.spd.add(
       subscript(
         ascension,
         data_gen.ascension.map((p) => p.spd)
@@ -195,7 +196,7 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     // Small trace stat boosts
     ...statBoosts.flatMap((statBoost, index) =>
       Object.entries(statBoost).map(([key, amt]) => {
-        return getStatFromStatKey(self.premod, key).add(
+        return getStatFromStatKey(selfBuff.premod, key).add(
           // TODO: Add automatic ascension requirement
           cmpEq(char[`statBoost${(index + 1) as StatBoostKey}`], 1, amt)
         )
@@ -205,7 +206,7 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     ...([3, 5] as const).flatMap((ei) =>
       Object.entries(data_gen.rankMap[3].skillTypeAddLevel).map(
         ([abilityKey, levelBoost]) =>
-          self.char[abilityKey].add(cmpGE(eidolon, ei, levelBoost))
+          selfBuff.char[abilityKey].add(cmpGE(eidolon, ei, levelBoost))
       )
     ),
     // Break base DMG
@@ -219,22 +220,22 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     ),
     // Formula listings for stats
     // TODO: Reorder this
-    self.listing.formulas.add(listingItem(self.final.hp)),
-    self.listing.formulas.add(listingItem(self.final.atk)),
-    self.listing.formulas.add(listingItem(self.final.def)),
-    self.listing.formulas.add(listingItem(self.final.spd)),
-    self.listing.formulas.add(listingItem(self.final.enerRegen_)),
-    self.listing.formulas.add(listingItem(self.final.eff_)),
-    self.listing.formulas.add(listingItem(self.final.eff_res_)),
-    self.listing.formulas.add(listingItem(self.final.brEff_)),
-    self.listing.formulas.add(listingItem(self.common.cappedCrit_)),
-    self.listing.formulas.add(listingItem(self.final.crit_dmg_)),
-    self.listing.formulas.add(listingItem(self.final.heal_)),
-    self.listing.formulas.add(
+    selfBuff.listing.formulas.add(listingItem(self.final.hp)),
+    selfBuff.listing.formulas.add(listingItem(self.final.atk)),
+    selfBuff.listing.formulas.add(listingItem(self.final.def)),
+    selfBuff.listing.formulas.add(listingItem(self.final.spd)),
+    selfBuff.listing.formulas.add(listingItem(self.final.enerRegen_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.eff_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.eff_res_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.brEff_)),
+    selfBuff.listing.formulas.add(listingItem(self.common.cappedCrit_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.crit_dmg_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.heal_)),
+    selfBuff.listing.formulas.add(
       listingItem(self.final.dmg_[TypeKeyToListingType[data_gen.damageType]])
     ),
-    self.listing.formulas.add(listingItem(self.final.dmg_)),
-    self.listing.formulas.add(listingItem(self.final.weakness_)),
-    self.listing.formulas.add(listingItem(self.final.resPen_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.dmg_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.weakness_)),
+    selfBuff.listing.formulas.add(listingItem(self.final.resPen_)),
   ]
 }

--- a/libs/sr/formula/src/data/lightCone/util.ts
+++ b/libs/sr/formula/src/data/lightCone/util.ts
@@ -1,7 +1,7 @@
 import { cmpEq, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import type { LightConeDatum } from '@genshin-optimizer/sr/stats'
 import type { TagMapNodeEntries } from '../util'
-import { getStatFromStatKey, self } from '../util'
+import { getStatFromStatKey, self, selfBuff } from '../util'
 
 export function entriesForLightCone(
   dataGen: LightConeDatum
@@ -14,7 +14,7 @@ export function entriesForLightCone(
     ...(['hp', 'atk', 'def'] as const).map((sk) => {
       const basePerAsc = dataGen.ascension.map((p) => p[sk].base)
       const addPerAsc = dataGen.ascension.map((p) => p[sk].add)
-      return self.base[sk].add(
+      return selfBuff.base[sk].add(
         sum(
           subscript(ascension, basePerAsc),
           prod(lvl1, subscript(ascension, addPerAsc))
@@ -24,7 +24,7 @@ export function entriesForLightCone(
     // Passive stats
     ...Object.entries(dataGen.superimpose.passiveStats).map(
       ([statKey, values]) =>
-        getStatFromStatKey(self.premod, statKey).add(
+        getStatFromStatKey(selfBuff.premod, statKey).add(
           cmpEq(dataGen.path, self.char.path, subscript(superimpose, values))
         )
     ),

--- a/libs/sr/formula/src/data/util/read.ts
+++ b/libs/sr/formula/src/data/util/read.ts
@@ -217,8 +217,8 @@ export function tagStr(tag: Tag, ex?: any): string {
   else if (q) required(`.${q}`, '')
 
   optional(elementalType, 'ele')
-  optional(`1:${damageType1}`, 'dmg1')
-  optional(`2:${damageType2}`, 'dmg2')
+  optional(damageType1 && `1:${damageType1}`, 'dmg1')
+  optional(damageType2 && `2:${damageType2}`, 'dmg2')
   if (ex) result += `[${ex}] `
   return result + '}'
 }

--- a/libs/sr/formula/src/data/util/sheet.ts
+++ b/libs/sr/formula/src/data/util/sheet.ts
@@ -8,7 +8,6 @@ import type { Read, Tag } from '.'
 import {
   percent,
   reader,
-  self,
   selfBuff,
   tag,
   teamBuff,
@@ -84,7 +83,7 @@ export function customDmg(
       team,
       'dmg',
       tag(cond, dmgTag),
-      self.formula.base.add(prod(base, percent(split))),
+      selfBuff.formula.base.add(prod(base, percent(split))),
       ...extra
     )
   )
@@ -111,7 +110,7 @@ export function customShield(
     team,
     'shield',
     cond,
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     ...extra
   )
 }
@@ -137,7 +136,7 @@ export function customHeal(
     team,
     'heal',
     cond,
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     ...extra
   )
 }
@@ -165,7 +164,7 @@ export function customBreakDmg(
     team,
     'breakDmg',
     tag(cond, dmgTag),
-    self.formula.base.add(base),
+    selfBuff.formula.base.add(base),
     ...extra
   )
 }

--- a/libs/sr/formula/src/util.ts
+++ b/libs/sr/formula/src/util.ts
@@ -30,10 +30,11 @@ export function withMember(
 
 export function charData(data: ICharacter): TagMapNodeEntries {
   const { lvl, basic, skill, ult, talent, ascension, eidolon } = self.char
+  const { char, iso, [data.key]: sheet } = reader.withAll('sheet', [])
 
   return [
-    reader.sheet('char').reread(reader.sheet(data.key)),
-    reader.withTag({ sheet: 'iso', et: 'self' }).reread(reader.sheet(data.key)),
+    char.reread(sheet),
+    iso.with('et', 'self').reread(sheet),
 
     lvl.add(data.level),
     basic.add(data.basic),
@@ -161,6 +162,17 @@ export function teamData(members: readonly Member[]): TagMapNodeEntries {
       teamEntry.add(reader.withTag({ src, et: 'self' }).sum)
     ),
   ].flat()
+}
+
+export function noTeamData(): TagMapNodeEntries {
+  const { self } = reader.sheet('agg').withAll('et', [])
+
+  // `Team Data` without `src:` and `dst:`
+  return [
+    // Self Buff
+    self.reread(reader.withTag({ et: 'selfBuff' })),
+    // TODO: Non-Stacking and Total Team Stat
+  ]
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

The current tag db is too lenient on how the buffs get added to a formula. Some formulas are added to `et:self` while others to `et:selfBuff`. This makes the system hard to design as it needs to accommodate both possibilities. This PR enforces more structure on `et:` as follows.

On the read side:
- Final query (value that includes all applicable contributions) reads from `et:self`,
  - `self.final.atk` yields the `final.atk` from character/weapon/artifact/etc,
- Contribution from a particular sheet reads from `et:*Buff` with appropriate `sheet:`,
  - `selfBuff.final.atk.sheet("Nahida")` yields Nahida's contribution to `self.final.atk`.

On the write side:
- Queries with `sheet:undefined` or `sheet:static` write to `et:self`,
- Queries in a sheet write to `et:selfBuff`/`teamBuff`/`notSelfBuff` (i.e., `et:*Buff`),
- Queries outside of a sheet never write to `et:*Buff`,

This structure allows the buff system to be design as
```
`self:` stat <= "determine contributions" <= `et:*Buff` entries
```
It however requires linkage from `self:` <= `et:*Buff` at all time, so we also add `noTeamData` in case there is no team member (and so `src:dst:` are unnecessary).

## Issue or discord link

https://discord.com/channels/785153694478893126/1189329506842984570/1272737073522278570

## Testing/validation

Unit tests are added to enforce write-side entries.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
