### PR TITLE
Move confirmation to top of swap modal.

### DIFF
--- a/libs/gi/ui/src/components/build/EquipBuildModal.tsx
+++ b/libs/gi/ui/src/components/build/EquipBuildModal.tsx
@@ -113,6 +113,52 @@ function Content(props: Props) {
           gap: 1,
         }}
       >
+        {/* Confirmation Message */}
+        <Typography sx={{ fontSize: 20 }}>
+          Do you want to make the changes shown below?
+        </Typography>
+        {teamCharId && (
+          <FormControlLabel
+            label={
+              <>
+                Copy the current equipment in <strong>{currentName}</strong> to
+                a new build. Otherwise, they will be overwritten.
+              </>
+            }
+            control={
+              <Checkbox
+                checked={copyCurrent}
+                onChange={(event) => setCopyCurrent(event.target.checked)}
+                color={copyCurrent ? 'success' : 'secondary'}
+              />
+            }
+          />
+        )}
+        {copyCurrent && (
+          <TextField
+            label="Build Name"
+            placeholder={`Duplicate of ${currentName}`}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            size="small"
+            sx={{ width: '75%', marginX: 4 }}
+          />
+        )}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 1,
+            marginTop: 4,
+          }}
+        >
+          <Button color="error" onClick={onHide}>
+            Cancel
+          </Button>
+          <Button color="success" onClick={toEquip}>
+            Equip
+          </Button>
+        </Box>
         {/* Active Build */}
         <CardThemed bgt="light">
           <CardContent
@@ -206,51 +252,6 @@ function Content(props: Props) {
             </DataWrapper>
           </CardContent>
         </CardThemed>
-        <Typography sx={{ fontSize: 20 }}>
-          Do you want to make the changes shown above?
-        </Typography>
-        {teamCharId && (
-          <FormControlLabel
-            label={
-              <>
-                Copy the current equipment in <strong>{currentName}</strong> to
-                a new build. Otherwise, they will be overwritten.
-              </>
-            }
-            control={
-              <Checkbox
-                checked={copyCurrent}
-                onChange={(event) => setCopyCurrent(event.target.checked)}
-                color={copyCurrent ? 'success' : 'secondary'}
-              />
-            }
-          />
-        )}
-        {copyCurrent && (
-          <TextField
-            label="Build Name"
-            placeholder={`Duplicate of ${currentName}`}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            size="small"
-            sx={{ width: '75%', marginX: 4 }}
-          />
-        )}
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: 1,
-            marginTop: 4,
-          }}
-        >
-          <Button color="error" onClick={onHide}>
-            Cancel
-          </Button>
-          <Button color="success" onClick={toEquip}>
-            Equip
-          </Button>
-        </Box>
       </CardContent>
     </CardThemed>
   )


### PR DESCRIPTION
## Describe your changes
Move the confirmation message and buttons up to the top of the Equipment Swap modal as described in the linked issue.

## Issue or discord link

-Resolves #2385 Move confirmation of equipment change to the top

## Testing/validation
Before:
![before-2](https://github.com/user-attachments/assets/beda4238-096a-48ef-92bd-c1a119dff042)

After:
![after-1](https://github.com/user-attachments/assets/f17b2f4a-7e38-4610-881d-004024369910)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki. (n/a)
- [ ] For front-end changes, I have updated the corresponding English translations. (n/a)
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed (n/a)
