### PR TITLE
[GO] Fix TeamCard weapon sizing on Firefox

### DIFF
--- a/libs/gi/ui/src/components/team/TeamCard.tsx
+++ b/libs/gi/ui/src/components/team/TeamCard.tsx
@@ -423,7 +423,6 @@ function WeaponCard({ weapon }: { weapon: ICachedWeapon }) {
       bgt="neutral600"
       sx={{
         height: '100%',
-        maxHeight: '50px',
         display: 'flex',
         flexDirection: 'horizontal',
         boxShadow: `0 0 10px rgba(0,0,0,0.4)`,
@@ -433,7 +432,7 @@ function WeaponCard({ weapon }: { weapon: ICachedWeapon }) {
         component={NextImage ? NextImage : 'img'}
         src={weaponAsset(weapon.key, weapon.ascension >= 2)}
         maxWidth="100%"
-        maxHeight="100%"
+        maxHeight="50px"
         sx={{ mt: 'auto' }}
       />
       <Box


### PR DESCRIPTION
## Describe your changes
- Force `maxHeight: 50px` on `weaponAsset` image component instead of parent container

Firefox specifically renders the full size of the original `img` rather than calculating the width based off the flex parent dictating the size, causing the weapon block to take up extra space it shouldn't. Moving `maxHeight: 50px` onto the `img` directly will fix this and make it align with the expected behavior based on Chrome. 

## Issue or discord link
https://discord.com/channels/785153694478893126/1273395678227464272

## Testing/validation
Tested on Chrome, Safari, and Firefox on 1440x685px screen size, with standard browser zoom test for accessibility. Additional testing on larger monitor sizes may be preferred.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
