### PR TITLE
Fix crash when optimizing with Scroll set

### DIFF
--- a/libs/gi/sheets/src/Artifacts/ScrollOfTheHeroOfCinderCity/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/ScrollOfTheHeroOfCinderCity/index.tsx
@@ -27,24 +27,23 @@ const condReacts = objKeyMap(allElementKeys, (ele) =>
   condReadNode(condReactPaths[ele])
 )
 
-const condReactNodes = objKeyMap(allElementKeys, (triggerEle) =>
-  greaterEq(
-    input.artSet.ScrollOfTheHeroOfCinderCity,
-    4,
-    equal(condReacts[triggerEle], triggerEle, 1)
-  )
+const reactNodeOnCount = sum(
+  ...allElementKeys.map((ele) => equal(condReacts[ele], ele, 1))
 )
-const reactNodeOnCount = sum(...Object.values(condReactNodes))
 
 const condReactBuffs = objKeyValMap(allElementKeys, (ele) => [
   `${ele}_dmg_`,
-  threshold(
-    equal(input.charEle, ele, 1),
-    1,
-    // buffing self elemental damage, check if any of the reactions are enabled
-    greaterEq(reactNodeOnCount, 1, 0.12),
-    // buffing other elemental damage, check if that particular conditional is enabled
-    equal(condReactNodes[ele], 1, 0.12)
+  greaterEq(
+    input.artSet.ScrollOfTheHeroOfCinderCity,
+    4,
+    threshold(
+      equal(input.charEle, ele, 1),
+      1,
+      // buffing self elemental damage, check if any of the reactions are enabled
+      greaterEq(reactNodeOnCount, 1, 0.12),
+      // buffing other elemental damage, check if that particular conditional is enabled
+      equal(condReacts[ele], ele, 0.12)
+    )
   ),
 ])
 
@@ -56,17 +55,10 @@ const condNightsouls = objKeyMap(allElementKeys, (ele) =>
   condReadNode(condNightsoulPaths[ele])
 )
 
-const condNightsoulNodes = objKeyMap(allElementKeys, (triggerEle) =>
-  greaterEq(
-    input.artSet.ScrollOfTheHeroOfCinderCity,
-    4,
-    equal(condNightsouls[triggerEle], triggerEle, 1)
-  )
-)
 const reactAndNightsoulOnCount = sum(
   ...allElementKeys.map((ele) =>
     greaterEq(
-      equal(condReactNodes[ele], 1, equal(condNightsoulNodes[ele], 1, 1)),
+      equal(condReacts[ele], ele, equal(condNightsouls[ele], ele, 1)),
       1,
       1
     )
@@ -75,13 +67,17 @@ const reactAndNightsoulOnCount = sum(
 
 const condNightsoulBuffs = objKeyValMap(allElementKeys, (ele) => [
   `${ele}_dmg_`,
-  threshold(
-    equal(input.charEle, ele, 1),
-    1,
-    // buffing self elemental damage, check if any of the reactions are enabled
-    greaterEq(reactAndNightsoulOnCount, 1, 0.28),
-    // buffing other elemental damage, check if that particular conditional is enabled
-    equal(condNightsoulNodes[ele], 1, equal(condReactNodes[ele], 1, 0.28))
+  greaterEq(
+    input.artSet.ScrollOfTheHeroOfCinderCity,
+    4,
+    threshold(
+      equal(input.charEle, ele, 1),
+      1,
+      // buffing self elemental damage, check if any of the reactions are enabled
+      greaterEq(reactAndNightsoulOnCount, 1, 0.28),
+      // buffing other elemental damage, check if that particular conditional is enabled
+      equal(condNightsouls[ele], ele, equal(condReacts[ele], ele, 0.28))
+    )
   ),
 ])
 
@@ -143,7 +139,7 @@ const sheet: SetEffectSheet = {
         states: (data: UIData) =>
           objKeyMap(
             // Only show reactions that are already enabled
-            allElementKeys.filter((ele) => data.get(condReactNodes[ele]).value),
+            allElementKeys.filter((ele) => data.get(condReacts[ele]).value),
             (ele) => ({
               value: condNightsouls[ele],
               path: condNightsoulPaths[ele],

--- a/libs/gi/sheets/src/Artifacts/ScrollOfTheHeroOfCinderCity/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/ScrollOfTheHeroOfCinderCity/index.tsx
@@ -6,12 +6,12 @@ import {
 import type { UIData } from '@genshin-optimizer/gi/uidata'
 import type { Data } from '@genshin-optimizer/gi/wr'
 import {
+  compareEq,
   equal,
   greaterEq,
   infoMut,
   input,
   sum,
-  threshold,
 } from '@genshin-optimizer/gi/wr'
 import { condReadNode, st, stg } from '../../SheetUtil'
 import { ArtifactSheet, setHeaderTemplate } from '../ArtifactSheet'
@@ -36,9 +36,9 @@ const condReactBuffs = objKeyValMap(allElementKeys, (ele) => [
   greaterEq(
     input.artSet.ScrollOfTheHeroOfCinderCity,
     4,
-    threshold(
-      equal(input.charEle, ele, 1),
-      1,
+    compareEq(
+      input.charEle,
+      ele,
       // buffing self elemental damage, check if any of the reactions are enabled
       greaterEq(reactNodeOnCount, 1, 0.12),
       // buffing other elemental damage, check if that particular conditional is enabled
@@ -57,11 +57,7 @@ const condNightsouls = objKeyMap(allElementKeys, (ele) =>
 
 const reactAndNightsoulOnCount = sum(
   ...allElementKeys.map((ele) =>
-    greaterEq(
-      equal(condReacts[ele], ele, equal(condNightsouls[ele], ele, 1)),
-      1,
-      1
-    )
+    equal(condReacts[ele], ele, equal(condNightsouls[ele], ele, 1))
   )
 )
 
@@ -70,9 +66,9 @@ const condNightsoulBuffs = objKeyValMap(allElementKeys, (ele) => [
   greaterEq(
     input.artSet.ScrollOfTheHeroOfCinderCity,
     4,
-    threshold(
-      equal(input.charEle, ele, 1),
-      1,
+    compareEq(
+      input.charEle,
+      ele,
       // buffing self elemental damage, check if any of the reactions are enabled
       greaterEq(reactAndNightsoulOnCount, 1, 0.28),
       // buffing other elemental damage, check if that particular conditional is enabled


### PR DESCRIPTION
## Describe your changes

* Fix crash caused by putting the artifact set count check in the innermost layer of the nodes instead of outermost
* Also simplified some of the logic

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Create a TC build with Scroll 4p and optimize
Don't crash

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
