### PR TITLE
Add probabilistic hit for Yanfei A4

### DIFF
--- a/libs/gi/localization/assets/locales/en/char_Yanfei.json
+++ b/libs/gi/localization/assets/locales/en/char_Yanfei.json
@@ -16,7 +16,8 @@
     "sealsConsumed": "Seals consumed by using a Charged Attack"
   },
   "passive2": {
-    "key": "Blazing Eye DMG"
+    "key": "Blazing Eye DMG",
+    "probabilisticSuffix": "(w/ Crit Rate Factored In)"
   },
   "c1": {
     "sealChargedStam_": "Charged Attack Stamina Consumption Decrease"


### PR DESCRIPTION
## Describe your changes

It's not really possible to optimize with Yanfei A4 in mind. With this change, a user can add this probabilistic hit for each charged attack they do to get an average damage value out of the A4. Not perfect, but better than nothing.
The probability follows the crit hit mode as well.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![image](https://github.com/user-attachments/assets/be5f2229-d8be-4522-a532-5be69a420ebb)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
