### PR TITLE
Make Build comparasion modal wider

### DIFF
--- a/libs/gi/ui/src/components/build/EquipBuildModal.tsx
+++ b/libs/gi/ui/src/components/build/EquipBuildModal.tsx
@@ -47,7 +47,11 @@ export function EquipBuildModal(props: Props & { show: boolean }) {
   const { show, onHide } = props
   /* TODO: Dialog Wanted to use a Dialog here, but was having some weird issues with closing out of it https://github.com/frzyc/genshin-optimizer/issues/1498*/
   return (
-    <ModalWrapper open={show} onClose={onHide}>
+    <ModalWrapper
+      open={show}
+      onClose={onHide}
+      containerProps={{ maxWidth: 'xl' }}
+    >
       <Content {...props} />
     </ModalWrapper>
   )


### PR DESCRIPTION
## Describe your changes

Build comparasion modal is usually smaller than the main UI, making their fields seem cramped. 
This PR seeks to increase the maximum width of the modal to be more consistent with the main UI.
![image](https://github.com/user-attachments/assets/7b0d93b8-b302-4543-a482-d7d360329d1b)


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
