### PR TITLE
fix kinich charged attack multi

### DIFF
--- a/libs/gi/sheets/src/Characters/Kinich/index.tsx
+++ b/libs/gi/sheets/src/Characters/Kinich/index.tsx
@@ -207,7 +207,7 @@ const sheet: TalentSheet = {
         {
           node: infoMut(dmgFormulas.charged.dmg, {
             name: ct.chg(`auto.skillParams.4`),
-            multi: 4,
+            multi: 3,
           }),
         },
         {


### PR DESCRIPTION
## Describe your changes

Fixes Kinich's charged attack dmg multi being 4x instead of 3x, as stated in-game and from testing
![image](https://github.com/user-attachments/assets/1afc8d90-009f-45ec-b96f-03292aa05c9a)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
