### PR TITLE
Update final stat listing

### DIFF
--- a/libs/sr/formula/src/data/char/util.ts
+++ b/libs/sr/formula/src/data/char/util.ts
@@ -22,10 +22,10 @@ import {
   customHeal,
   customShield,
   getStatFromStatKey,
-  listingItem,
   own,
   ownBuff,
   percent,
+  reader,
   registerBuff,
   type TagMapNodeEntries,
 } from '../util'
@@ -204,24 +204,7 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
       },
       1
     ),
-    // Formula listings for stats
-    // TODO: Reorder this
-    ownBuff.listing.formulas.add(listingItem(own.final.hp)),
-    ownBuff.listing.formulas.add(listingItem(own.final.atk)),
-    ownBuff.listing.formulas.add(listingItem(own.final.def)),
-    ownBuff.listing.formulas.add(listingItem(own.final.spd)),
-    ownBuff.listing.formulas.add(listingItem(own.final.enerRegen_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.eff_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.eff_res_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.brEffect_)),
-    ownBuff.listing.formulas.add(listingItem(own.common.cappedCrit_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.crit_dmg_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.heal_)),
-    ownBuff.listing.formulas.add(
-      listingItem(own.final.dmg_[data_gen.damageType])
-    ),
-    ownBuff.listing.formulas.add(listingItem(own.final.dmg_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.weakness_)),
-    ownBuff.listing.formulas.add(listingItem(own.final.resPen_)),
+    // Listing in static sheet stats
+    ownBuff.listing.formulas.reread(reader.sheet('static')),
   ]
 }

--- a/libs/sr/formula/src/data/common/index.ts
+++ b/libs/sr/formula/src/data/common/index.ts
@@ -3,10 +3,12 @@ import type { TagMapNodeEntries } from '../util'
 import { own, ownBuff, percent, reader } from '../util'
 import dmg from './dmg'
 import prep from './prep'
+import sheet from './sheet'
 
 const data: TagMapNodeEntries = [
   ...dmg,
   ...prep,
+  ...sheet,
 
   reader.withTag({ sheet: 'iso', et: 'own' }).reread(reader.sheet('custom')),
   reader.withTag({ sheet: 'agg', et: 'own' }).reread(reader.sheet('custom')),

--- a/libs/sr/formula/src/data/common/sheet.ts
+++ b/libs/sr/formula/src/data/common/sheet.ts
@@ -1,0 +1,46 @@
+import type { AnyNode } from '@genshin-optimizer/pando/engine'
+import { dynTag } from '@genshin-optimizer/pando/engine'
+import type { TagMapNodeEntries } from '../util'
+import { listingItem, own, ownBuff, reader, register, tag } from '../util'
+
+const data: TagMapNodeEntries = register(
+  'static',
+  // Common stat in listing
+  // We can use for-loop to facilitate most of these entries,
+  // but since this also dictates the order in the listing,
+  // we manually call `registerStat` for more control.
+  registerStat('hp', own.final.hp),
+  registerStat('atk', own.final.atk),
+  registerStat('def', own.final.def),
+  registerStat('spd', own.final.spd),
+  registerStat('enerRegen_', own.final.enerRegen_),
+  registerStat('eff_', own.final.eff_),
+  registerStat('eff_res_', own.final.eff_res_),
+  registerStat('brEffect', own.final.brEffect_),
+  registerStat('crit', own.common.cappedCrit_),
+  registerStat('crit_dmg_', own.final.crit_dmg_),
+  registerStat('heal_', own.final.heal_),
+  registerStat(
+    'ele_dmg_',
+    dynTag(own.final.dmg_, { elementalType: own.char.ele })
+  ),
+  registerStat('dmg_', own.final.dmg_),
+  registerStat('weakness_', own.final.weakness_),
+  registerStat('resPen_', own.final.resPen_)
+)
+
+function registerStat(name: string, target: AnyNode): TagMapNodeEntries {
+  const formula = reader.withTag({
+    et: 'display',
+    qt: 'formula',
+    q: 'stat',
+    name,
+  })
+  const listing = ownBuff.listing.formulas
+  return [
+    listing.add(listingItem(formula)), // Add formula to listing
+    formula.add(tag(target, { name: null })), // Link formula to target
+  ]
+}
+
+export default data

--- a/libs/sr/formula/src/data/util/sheet.ts
+++ b/libs/sr/formula/src/data/util/sheet.ts
@@ -56,7 +56,7 @@ export function registerBuff(
   // Remove unused tags. We cannot use `sheet:null` here because
   // `namedReader` is also used as a `Tag` inside `listingItem`.
   const { sheet: _sheet, ...tag } = entry.tag
-  const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
+  const namedReader = reader.withTag({ ...tag, et: 'display', name })
   const listing = (team ? teamBuff : ownBuff).listing.buffs
   return [
     // Add this buff to listing listing
@@ -87,7 +87,7 @@ export function registerBuffFormula(
   // Remove unused tags. We cannot use `sheet:null` here because
   // `namedReader` is also used as a `Tag` inside `listingItem`.
   const { sheet: _sheet, ...tag } = entry.tag
-  const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
+  const namedReader = reader.withTag({ ...tag, et: 'display', name })
   const buffListing = (team ? teamBuff : ownBuff).listing.buffs
   const formulaListing = (team ? teamBuff : ownBuff).listing.formulas
   return [
@@ -108,7 +108,6 @@ function registerFormula(
   cond: string | StrNode,
   ...extra: TagMapNodeEntries
 ): TagMapNodeEntries {
-  reader.name(name) // register name:<name>
   const listing = (team ? teamBuff : ownBuff).listing.formulas
   return [
     listing.add(

--- a/libs/sr/formula/src/meta.ts
+++ b/libs/sr/formula/src/meta.ts
@@ -4582,6 +4582,173 @@ export const formulas = {
       },
     },
   },
+  static: {
+    atk: {
+      sheet: 'static',
+      name: 'atk',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'atk',
+      },
+    },
+    brEffect: {
+      sheet: 'static',
+      name: 'brEffect',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'brEffect',
+      },
+    },
+    crit: {
+      sheet: 'static',
+      name: 'crit',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'crit',
+      },
+    },
+    crit_dmg_: {
+      sheet: 'static',
+      name: 'crit_dmg_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'crit_dmg_',
+      },
+    },
+    def: {
+      sheet: 'static',
+      name: 'def',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'def',
+      },
+    },
+    dmg_: {
+      sheet: 'static',
+      name: 'dmg_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'dmg_',
+      },
+    },
+    eff_: {
+      sheet: 'static',
+      name: 'eff_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'eff_',
+      },
+    },
+    eff_res_: {
+      sheet: 'static',
+      name: 'eff_res_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'eff_res_',
+      },
+    },
+    ele_dmg_: {
+      sheet: 'static',
+      name: 'ele_dmg_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'ele_dmg_',
+      },
+    },
+    enerRegen_: {
+      sheet: 'static',
+      name: 'enerRegen_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'enerRegen_',
+      },
+    },
+    heal_: {
+      sheet: 'static',
+      name: 'heal_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'heal_',
+      },
+    },
+    hp: {
+      sheet: 'static',
+      name: 'hp',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'hp',
+      },
+    },
+    resPen_: {
+      sheet: 'static',
+      name: 'resPen_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'resPen_',
+      },
+    },
+    spd: {
+      sheet: 'static',
+      name: 'spd',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'spd',
+      },
+    },
+    weakness_: {
+      sheet: 'static',
+      name: 'weakness_',
+      tag: {
+        et: 'display',
+        qt: 'formula',
+        q: 'stat',
+        sheet: 'static',
+        name: 'weakness_',
+      },
+    },
+  },
 } as const
 export const buffs = {
   ASecretVow: {


### PR DESCRIPTION
## Describe your changes

This PR add interim read nodes between the formula listing and to final stats.
These interim read nodes give us more control on the tags for the formula listing, so we can now guarantee `sheet:name:` format across the board for all formula listing entries.

## Issue or discord link

https://discord.com/channels/785153694478893126/1189329506842984570/1289930124002594876

## Testing/validation

trust

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
