### PR TITLE
Lower opacity for common build pieces in swap menu

### DIFF
--- a/libs/gi/ui/src/components/build/EquipBuildModal.tsx
+++ b/libs/gi/ui/src/components/build/EquipBuildModal.tsx
@@ -94,6 +94,12 @@ function Content(props: Props) {
     setCopyCurrent(false)
     onHide()
   }
+
+  // conditionals for the changed artifact (opacity)
+  const isWeaponChanged = currentWeaponId !== newWeaponId
+  const isArtifactChanged = (slotKey: ArtifactSlotKey) =>
+    currentArtifactIds[slotKey] !== newArtifactIds[slotKey]
+
   return (
     <CardThemed>
       <CardHeader
@@ -183,7 +189,7 @@ function Content(props: Props) {
               columns={{ xs: 2, sm: 3, md: 4, lg: 6 }}
             >
               <Grid item xs={1}>
-                <CardThemed sx={{ height: '100%', maxHeight: '8em' }}>
+                <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isWeaponChanged ? 1 : 0.5 }}>
                   <WeaponCardNano
                     weaponId={currentWeaponId}
                     weaponTypeKey={weaponTypeKey}
@@ -193,7 +199,7 @@ function Content(props: Props) {
               </Grid>
               {Object.entries(currentArtifactIds).map(([slotKey, id]) => (
                 <Grid item key={id || slotKey} xs={1}>
-                  <CardThemed sx={{ height: '100%', maxHeight: '8em' }}>
+                  <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isArtifactChanged(slotKey as ArtifactSlotKey) ? 1 : 0.5 }}>
                     <ArtifactCardNano
                       artifactId={id}
                       slotKey={slotKey}
@@ -235,7 +241,7 @@ function Content(props: Props) {
               columns={{ xs: 2, sm: 3, md: 4, lg: 6 }}
             >
               <Grid item xs={1}>
-                <CardThemed sx={{ height: '100%', maxHeight: '8em' }}>
+                <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isWeaponChanged ? 1 : 0.5 }}>
                   <WeaponCardNano
                     weaponId={newWeaponId}
                     weaponTypeKey={weaponTypeKey}
@@ -245,7 +251,7 @@ function Content(props: Props) {
               </Grid>
               {Object.entries(newArtifactIds).map(([slotKey, id]) => (
                 <Grid item key={id || slotKey} xs={1}>
-                  <CardThemed sx={{ height: '100%', maxHeight: '8em' }}>
+                  <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isArtifactChanged(slotKey as ArtifactSlotKey) ? 1 : 0.5 }}>
                     <ArtifactCardNano
                       artifactId={id}
                       slotKey={slotKey}

--- a/libs/gi/ui/src/components/build/EquipBuildModal.tsx
+++ b/libs/gi/ui/src/components/build/EquipBuildModal.tsx
@@ -189,7 +189,13 @@ function Content(props: Props) {
               columns={{ xs: 2, sm: 3, md: 4, lg: 6 }}
             >
               <Grid item xs={1}>
-                <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isWeaponChanged ? 1 : 0.5 }}>
+                <CardThemed
+                  sx={{
+                    height: '100%',
+                    maxHeight: '8em',
+                    opacity: isWeaponChanged ? 1 : 0.5,
+                  }}
+                >
                   <WeaponCardNano
                     weaponId={currentWeaponId}
                     weaponTypeKey={weaponTypeKey}
@@ -199,7 +205,15 @@ function Content(props: Props) {
               </Grid>
               {Object.entries(currentArtifactIds).map(([slotKey, id]) => (
                 <Grid item key={id || slotKey} xs={1}>
-                  <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isArtifactChanged(slotKey as ArtifactSlotKey) ? 1 : 0.5 }}>
+                  <CardThemed
+                    sx={{
+                      height: '100%',
+                      maxHeight: '8em',
+                      opacity: isArtifactChanged(slotKey as ArtifactSlotKey)
+                        ? 1
+                        : 0.5,
+                    }}
+                  >
                     <ArtifactCardNano
                       artifactId={id}
                       slotKey={slotKey}
@@ -241,7 +255,13 @@ function Content(props: Props) {
               columns={{ xs: 2, sm: 3, md: 4, lg: 6 }}
             >
               <Grid item xs={1}>
-                <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isWeaponChanged ? 1 : 0.5 }}>
+                <CardThemed
+                  sx={{
+                    height: '100%',
+                    maxHeight: '8em',
+                    opacity: isWeaponChanged ? 1 : 0.5,
+                  }}
+                >
                   <WeaponCardNano
                     weaponId={newWeaponId}
                     weaponTypeKey={weaponTypeKey}
@@ -251,7 +271,15 @@ function Content(props: Props) {
               </Grid>
               {Object.entries(newArtifactIds).map(([slotKey, id]) => (
                 <Grid item key={id || slotKey} xs={1}>
-                  <CardThemed sx={{ height: '100%', maxHeight: '8em', opacity: isArtifactChanged(slotKey as ArtifactSlotKey) ? 1 : 0.5 }}>
+                  <CardThemed
+                    sx={{
+                      height: '100%',
+                      maxHeight: '8em',
+                      opacity: isArtifactChanged(slotKey as ArtifactSlotKey)
+                        ? 1
+                        : 0.5,
+                    }}
+                  >
                     <ArtifactCardNano
                       artifactId={id}
                       slotKey={slotKey}


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->
In the swap build piece menu, the opacity of common build pieces are lowered.
Added conditionals to check for the changed build piece, then added opacity statements to CardThemed elements.

## Issue or discord link

- Resolves #2336 

## Testing/validation

<!--- Add screenshots if possible -->
![image](https://github.com/user-attachments/assets/6596ac75-48a7-499f-a7eb-799410ac5ccf)
![image](https://github.com/user-attachments/assets/f85d13fb-e02a-47d8-8a86-de7b7158ac32)
![image](https://github.com/user-attachments/assets/ba41d3f2-db8c-4c76-b36a-0286452a6bbf)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
