### PR TITLE
Add Clorinde A1 buff to C1 and C6 hits

### DIFF
--- a/libs/gi/sheets/src/Characters/Clorinde/index.tsx
+++ b/libs/gi/sheets/src/Characters/Clorinde/index.tsx
@@ -192,9 +192,8 @@ const c6AfterSkill_critDMG_ = greaterEq(
   equal(condC6AfterSkill, 'on', dm.constellation6.critDMG_)
 )
 
-const electroHit = { hit: { ele: constant('electro') } }
-const skillHit = {
-  ...electroHit,
+const electroNormalHit = {
+  hit: { ele: constant('electro') },
   premod: { normal_dmgInc: a1Reactions_normal_dmgInc },
 }
 
@@ -213,7 +212,7 @@ const dmgFormulas = {
       'atk',
       dm.skill.normalDmg,
       'normal',
-      skillHit,
+      electroNormalHit,
       undefined,
       'skill'
     ),
@@ -221,7 +220,7 @@ const dmgFormulas = {
       'atk',
       dm.skill.piercingDmg,
       'normal',
-      skillHit,
+      electroNormalHit,
       undefined,
       'skill'
     ),
@@ -229,7 +228,7 @@ const dmgFormulas = {
       'atk',
       dm.skill.thrust1Dmg,
       'normal',
-      skillHit,
+      electroNormalHit,
       undefined,
       'skill'
     ),
@@ -237,7 +236,7 @@ const dmgFormulas = {
       'atk',
       dm.skill.thrust2Dmg,
       'normal',
-      skillHit,
+      electroNormalHit,
       undefined,
       'skill'
     ),
@@ -245,7 +244,7 @@ const dmgFormulas = {
       'atk',
       dm.skill.thrust3Dmg,
       'normal',
-      skillHit,
+      electroNormalHit,
       undefined,
       'skill'
     ),
@@ -265,7 +264,7 @@ const dmgFormulas = {
       customDmgNode(
         prod(percent(dm.constellation1.dmg), input.total.atk),
         'normal',
-        electroHit
+        electroNormalHit
       )
     ),
   },
@@ -276,7 +275,7 @@ const dmgFormulas = {
       customDmgNode(
         prod(percent(dm.constellation6.dmg), input.total.atk),
         'normal',
-        electroHit
+        electroNormalHit
       )
     ),
   },


### PR DESCRIPTION
## Describe your changes

Caused by that one time I narrowed down Clorinde A1 buff to not apply to her phys attacks. I blame shaiaz for this

## Issue or discord link

- https://discord.com/channels/785153694478893126/1294128852641124413

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
