### PR TITLE
Remove submodule checkout for release build

### DIFF
--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -11,8 +11,6 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Describe your changes

It wasn't used since we changed to checking in all generated files
I am not sure why CI gen-file check doesn't fail when doing the sparse checkout of StarRailData. I assume it might be because of the cache being used? But it is possible that might break at some point

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
