### PR TITLE
Bugfixes for comparisons when editing an inactive build and team multi-select

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -288,18 +288,15 @@ export class TeamDataManager extends DataManager<
     return this.#getWeaponId(teamCharId, buildType, buildId)
   }
 
-  getEditWeaponId(
-    buildToEdit: string,
-    teamCharId: string,
-  ): string | undefined {
-    const editType = (buildToEdit === 'equipped') ? 'equipped' : 'real'
+  getEditWeaponId(buildToEdit: string, teamCharId: string): string | undefined {
+    const editType = buildToEdit === 'equipped' ? 'equipped' : 'real'
     return this.#getWeaponId(teamCharId, editType, buildToEdit)
   }
 
   #getWeaponId(
     teamCharId: string,
     buildType: BuildTypeKey,
-    buildId: string,
+    buildId: string
   ): string | undefined {
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return undefined
@@ -381,16 +378,16 @@ export class TeamDataManager extends DataManager<
 
   getEditArtifactIds(
     buildToEdit: string,
-    teamCharId: string,
+    teamCharId: string
   ): Record<ArtifactSlotKey, string | undefined> {
-    const editType = (buildToEdit === 'equipped') ? 'equipped' : 'real'
+    const editType = buildToEdit === 'equipped' ? 'equipped' : 'real'
     return this.#getArtifactIds(teamCharId, editType, buildToEdit)
   }
 
   #getArtifactIds(
     teamCharId: string,
     buildType: BuildTypeKey,
-    buildId: string,
+    buildId: string
   ): Record<ArtifactSlotKey, string | undefined> {
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return objKeyMap(allArtifactSlotKeys, () => undefined)

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -288,12 +288,12 @@ export class TeamDataManager extends DataManager<
     return this.#getWeaponId(teamCharId, buildType, buildId)
   }
 
-  getCompareWeaponId({
-    compareType,
-    compareBuildId,
-    teamCharId,
-  }: LoadoutDatum): string | undefined {
-    return this.#getWeaponId(teamCharId, compareType, compareBuildId)
+  getEditWeaponId(
+    buildToEdit: string,
+    teamCharId: string,
+  ): string | undefined {
+    const editType = (buildToEdit === 'equipped') ? 'equipped' : 'real'
+    return this.#getWeaponId(teamCharId, editType, buildToEdit)
   }
 
   #getWeaponId(
@@ -379,12 +379,12 @@ export class TeamDataManager extends DataManager<
     return this.#getArtifactIds(teamCharId, buildType, buildId)
   }
 
-  getCompareArtifactIds({
-    compareType,
-    compareBuildId,
-    teamCharId,
-  }: LoadoutDatum): Record<ArtifactSlotKey, string | undefined> {
-    return this.#getArtifactIds(teamCharId, compareType, compareBuildId)
+  getEditArtifactIds(
+    buildToEdit: string,
+    teamCharId: string,
+  ): Record<ArtifactSlotKey, string | undefined> {
+    const editType = (buildToEdit === 'equipped') ? 'equipped' : 'real'
+    return this.#getArtifactIds(teamCharId, editType, buildToEdit)
   }
 
   #getArtifactIds(

--- a/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/TeamDataManager.ts
@@ -285,6 +285,22 @@ export class TeamDataManager extends DataManager<
     buildId,
     teamCharId,
   }: LoadoutDatum): string | undefined {
+    return this.#getWeaponId(teamCharId, buildType, buildId)
+  }
+
+  getCompareWeaponId({
+    compareType,
+    compareBuildId,
+    teamCharId,
+  }: LoadoutDatum): string | undefined {
+    return this.#getWeaponId(teamCharId, compareType, compareBuildId)
+  }
+
+  #getWeaponId(
+    teamCharId: string,
+    buildType: BuildTypeKey,
+    buildId: string,
+  ): string | undefined {
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return undefined
     const { key: characterKey } = teamChar
@@ -302,6 +318,7 @@ export class TeamDataManager extends DataManager<
     }
     return undefined
   }
+
   /**
    *
    * @param teamCharId
@@ -350,14 +367,31 @@ export class TeamDataManager extends DataManager<
       }
     })
   }
+
   /**
    * Note: this doesnt return any artifacts(all undefined) when the current teamchar is using a TC Build.
    */
   getLoadoutArtifactIds({
-    teamCharId,
     buildType,
     buildId,
+    teamCharId,
   }: LoadoutDatum): Record<ArtifactSlotKey, string | undefined> {
+    return this.#getArtifactIds(teamCharId, buildType, buildId)
+  }
+
+  getCompareArtifactIds({
+    compareType,
+    compareBuildId,
+    teamCharId,
+  }: LoadoutDatum): Record<ArtifactSlotKey, string | undefined> {
+    return this.#getArtifactIds(teamCharId, compareType, compareBuildId)
+  }
+
+  #getArtifactIds(
+    teamCharId: string,
+    buildType: BuildTypeKey,
+    buildId: string,
+  ): Record<ArtifactSlotKey, string | undefined> {
     const teamChar = this.database.teamChars.get(teamCharId)
     if (!teamChar) return objKeyMap(allArtifactSlotKeys, () => undefined)
     const { key: characterKey } = teamChar
@@ -375,6 +409,7 @@ export class TeamDataManager extends DataManager<
     }
     return objKeyMap(allArtifactSlotKeys, () => undefined)
   }
+
   /**
    * Note: this doesnt return any artifacts(all undefined) when the current teamchar is using a TC Build.
    */

--- a/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
@@ -8,6 +8,7 @@ import {
   useDatabase,
   useEquippedInTeam,
 } from '@genshin-optimizer/gi/db-ui'
+import { BuildEditContext, type BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
 import {
   ArtifactCardNano,
@@ -27,7 +28,7 @@ import {
   IconButton,
   TextField,
 } from '@mui/material'
-import { useContext, useDeferredValue, useEffect, useState } from 'react'
+import { useContext, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export default function BuildReal({
@@ -217,10 +218,6 @@ function BuildEditor({
     const { name, description } = newBuild
     setName(name)
     setDesc(description)
-    database.teams.setLoadoutDatum(teamId, teamCharId, {
-      compareType: 'real',
-      compareBuildId: buildId,
-    })
   }, [database, buildId, teamId, teamCharId])
 
   useEffect(() => {
@@ -238,6 +235,11 @@ function BuildEditor({
     // Don't need to trigger when buildId is changed, only when the name is changed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [database, descDeferred])
+
+  const buildEditContextObj = useMemo(() =>
+    ({buildToEdit: buildId} as BuildEditContextObj)
+  , [buildId])
+
   return (
     <CardThemed>
       <CardHeader
@@ -266,19 +268,21 @@ function BuildEditor({
           minRows={2}
         />
         <Box>
-          <EquippedGrid
-            weaponTypeKey={weaponTypeKey}
-            weaponId={build.weaponId}
-            artifactIds={build.artifactIds}
-            setWeapon={(id: string) =>
-              database.builds.set(buildId, { weaponId: id })
-            }
-            setArtifact={(slotKey, id) =>
-              database.builds.set(buildId, (build) => {
-                build.artifactIds[slotKey] = id ? id : undefined
-              })
-            }
-          />
+          <BuildEditContext.Provider value={buildEditContextObj}>
+            <EquippedGrid
+              weaponTypeKey={weaponTypeKey}
+              weaponId={build.weaponId}
+              artifactIds={build.artifactIds}
+              setWeapon={(id: string) =>
+                database.builds.set(buildId, { weaponId: id })
+              }
+              setArtifact={(slotKey, id) =>
+                database.builds.set(buildId, (build) => {
+                  build.artifactIds[slotKey] = id ? id : undefined
+                })
+              }
+            />
+          </BuildEditContext.Provider>
         </Box>
       </CardContent>
     </CardThemed>

--- a/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
@@ -9,7 +9,6 @@ import {
   useEquippedInTeam,
 } from '@genshin-optimizer/gi/db-ui'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
-import type { BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import {
   ArtifactCardNano,
   BuildCard,
@@ -29,13 +28,7 @@ import {
   IconButton,
   TextField,
 } from '@mui/material'
-import {
-  useContext,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useContext, useDeferredValue, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export default function BuildReal({
@@ -116,12 +109,7 @@ export default function BuildReal({
   return (
     <>
       <ModalWrapper open={open} onClose={onClose}>
-        <BuildEditor
-          teamId={teamId}
-          teamCharId={teamCharId}
-          buildId={buildId}
-          onClose={onClose}
-        />
+        <BuildEditor buildId={buildId} onClose={onClose} />
       </ModalWrapper>
       <EquipBuildModal
         currentName={t`buildRealCard.copy.equipped`}
@@ -200,13 +188,9 @@ export default function BuildReal({
 }
 
 function BuildEditor({
-  teamId,
-  teamCharId,
   buildId,
   onClose,
 }: {
-  teamId: string
-  teamCharId: string
   buildId: string
   onClose: () => void
 }) {
@@ -230,7 +214,7 @@ function BuildEditor({
     const { name, description } = newBuild
     setName(name)
     setDesc(description)
-  }, [database, buildId, teamId, teamCharId])
+  }, [database, buildId])
 
   useEffect(() => {
     database.builds.set(buildId, (build) => {
@@ -247,11 +231,6 @@ function BuildEditor({
     // Don't need to trigger when buildId is changed, only when the name is changed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [database, descDeferred])
-
-  const buildEditContextObj = useMemo(
-    () => ({ buildToEdit: buildId } as BuildEditContextObj),
-    [buildId]
-  )
 
   return (
     <CardThemed>
@@ -281,7 +260,7 @@ function BuildEditor({
           minRows={2}
         />
         <Box>
-          <BuildEditContext.Provider value={buildEditContextObj}>
+          <BuildEditContext.Provider value={buildId}>
             <EquippedGrid
               weaponTypeKey={weaponTypeKey}
               weaponId={build.weaponId}

--- a/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
@@ -8,11 +8,12 @@ import {
   useDatabase,
   useEquippedInTeam,
 } from '@genshin-optimizer/gi/db-ui'
-import { BuildEditContext, type BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
+import type { BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import {
   ArtifactCardNano,
   BuildCard,
+  BuildEditContext,
   EquipBuildModal,
   EquippedGrid,
   TeammateEquippedAlert,
@@ -28,7 +29,13 @@ import {
   IconButton,
   TextField,
 } from '@mui/material'
-import { useContext, useDeferredValue, useEffect, useMemo, useState } from 'react'
+import {
+  useContext,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 export default function BuildReal({
@@ -109,7 +116,12 @@ export default function BuildReal({
   return (
     <>
       <ModalWrapper open={open} onClose={onClose}>
-        <BuildEditor teamId={teamId} teamCharId={teamCharId} buildId={buildId} onClose={onClose} />
+        <BuildEditor
+          teamId={teamId}
+          teamCharId={teamCharId}
+          buildId={buildId}
+          onClose={onClose}
+        />
       </ModalWrapper>
       <EquipBuildModal
         currentName={t`buildRealCard.copy.equipped`}
@@ -236,9 +248,10 @@ function BuildEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [database, descDeferred])
 
-  const buildEditContextObj = useMemo(() =>
-    ({buildToEdit: buildId} as BuildEditContextObj)
-  , [buildId])
+  const buildEditContextObj = useMemo(
+    () => ({ buildToEdit: buildId } as BuildEditContextObj),
+    [buildId]
+  )
 
   return (
     <CardThemed>

--- a/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Build/BuildReal.tsx
@@ -48,6 +48,7 @@ export default function BuildReal({
     character: { equippedWeapon, equippedArtifacts },
   } = useContext(CharacterContext)
   const database = useDatabase()
+
   const { name, description, weaponId, artifactIds } = useBuild(buildId)!
   const onActive = () =>
     database.teams.setLoadoutDatum(teamId, teamCharId, {
@@ -107,7 +108,7 @@ export default function BuildReal({
   return (
     <>
       <ModalWrapper open={open} onClose={onClose}>
-        <BuildEditor buildId={buildId} onClose={onClose} />
+        <BuildEditor teamId={teamId} teamCharId={teamCharId} buildId={buildId} onClose={onClose} />
       </ModalWrapper>
       <EquipBuildModal
         currentName={t`buildRealCard.copy.equipped`}
@@ -186,9 +187,13 @@ export default function BuildReal({
 }
 
 function BuildEditor({
+  teamId,
+  teamCharId,
   buildId,
   onClose,
 }: {
+  teamId: string
+  teamCharId: string
   buildId: string
   onClose: () => void
 }) {
@@ -212,7 +217,11 @@ function BuildEditor({
     const { name, description } = newBuild
     setName(name)
     setDesc(description)
-  }, [database, buildId])
+    database.teams.setLoadoutDatum(teamId, teamCharId, {
+      compareType: 'real',
+      compareBuildId: buildId,
+    })
+  }, [database, buildId, teamId, teamCharId])
 
   useEffect(() => {
     database.builds.set(buildId, (build) => {

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
@@ -9,10 +9,11 @@ import {
   TeamCharacterContext,
   useDatabase,
 } from '@genshin-optimizer/gi/db-ui'
-import { BuildEditContext, type BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import { dataSetEffects } from '@genshin-optimizer/gi/sheets'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
+import type { BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import {
+  BuildEditContext,
   DataContext,
   DocumentDisplay,
   EquippedGrid,
@@ -70,8 +71,8 @@ export default function EquipmentSection() {
   )
 
   const buildEditContextObj = useMemo(() => {
-    const buildToEdit = (buildType === 'equipped') ? 'equipped' : buildId
-    return ({buildToEdit} as BuildEditContextObj)
+    const buildToEdit = buildType === 'equipped' ? 'equipped' : buildId
+    return { buildToEdit } as BuildEditContextObj
   }, [buildId, buildType])
 
   return (

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
@@ -9,6 +9,7 @@ import {
   TeamCharacterContext,
   useDatabase,
 } from '@genshin-optimizer/gi/db-ui'
+import { BuildEditContext, type BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import { dataSetEffects } from '@genshin-optimizer/gi/sheets'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
 import {
@@ -67,6 +68,12 @@ export default function EquipmentSection() {
       ),
     [data]
   )
+
+  const buildEditContextObj = useMemo(() => {
+    const buildToEdit = (buildType === 'equipped') ? 'equipped' : buildId
+    return ({buildToEdit} as BuildEditContextObj)
+  }, [buildId, buildType])
+
   return (
     <Box>
       <Grid container spacing={1}>
@@ -84,31 +91,33 @@ export default function EquipmentSection() {
           </Grid>
         )}
         <Grid item xs={12} md={12} lg={9} xl={9}>
-          <EquippedGrid
-            weaponTypeKey={weaponTypeKey}
-            weaponId={weaponId}
-            artifactIds={artifactIds}
-            setWeapon={(id) => {
-              if (loadoutEquip) database.builds.set(buildId, { weaponId: id })
-              else
-                database.weapons.set(id, {
-                  location: charKeyToLocCharKey(characterKey),
-                })
-            }}
-            setArtifact={(slotKey, id) => {
-              if (loadoutEquip)
-                database.builds.set(buildId, (build) => {
-                  build.artifactIds[slotKey] = id ? id : undefined
-                })
-              else
-                id
-                  ? database.arts.set(id, {
-                      location: charKeyToLocCharKey(characterKey),
-                    })
-                  : artifactIds[slotKey] &&
-                    database.arts.set(artifactIds[slotKey], { location: '' })
-            }}
-          />
+          <BuildEditContext.Provider value={buildEditContextObj}>
+            <EquippedGrid
+              weaponTypeKey={weaponTypeKey}
+              weaponId={weaponId}
+              artifactIds={artifactIds}
+              setWeapon={(id) => {
+                if (loadoutEquip) database.builds.set(buildId, { weaponId: id })
+                else
+                  database.weapons.set(id, {
+                    location: charKeyToLocCharKey(characterKey),
+                  })
+              }}
+              setArtifact={(slotKey, id) => {
+                if (loadoutEquip)
+                  database.builds.set(buildId, (build) => {
+                    build.artifactIds[slotKey] = id ? id : undefined
+                  })
+                else
+                  id
+                    ? database.arts.set(id, {
+                        location: charKeyToLocCharKey(characterKey),
+                      })
+                    : artifactIds[slotKey] &&
+                      database.arts.set(artifactIds[slotKey], { location: '' })
+              }}
+            />
+          </BuildEditContext.Provider>
         </Grid>
         {!breakpoint && (
           <Grid item xs={12} md={12} xl={3} container spacing={1}>

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOverview/EquipmentSection.tsx
@@ -11,7 +11,6 @@ import {
 } from '@genshin-optimizer/gi/db-ui'
 import { dataSetEffects } from '@genshin-optimizer/gi/sheets'
 import { getCharStat } from '@genshin-optimizer/gi/stats'
-import type { BuildEditContextObj } from '@genshin-optimizer/gi/ui'
 import {
   BuildEditContext,
   DataContext,
@@ -70,10 +69,7 @@ export default function EquipmentSection() {
     [data]
   )
 
-  const buildEditContextObj = useMemo(() => {
-    const buildToEdit = buildType === 'equipped' ? 'equipped' : buildId
-    return { buildToEdit } as BuildEditContextObj
-  }, [buildId, buildType])
+  const editBuildId = buildType === 'equipped' ? 'equipped' : buildId
 
   return (
     <Box>
@@ -92,7 +88,7 @@ export default function EquipmentSection() {
           </Grid>
         )}
         <Grid item xs={12} md={12} lg={9} xl={9}>
-          <BuildEditContext.Provider value={buildEditContextObj}>
+          <BuildEditContext.Provider value={editBuildId}>
             <EquippedGrid
               weaponTypeKey={weaponTypeKey}
               weaponId={weaponId}

--- a/libs/gi/page-team/src/TeamSetting/index.tsx
+++ b/libs/gi/page-team/src/TeamSetting/index.tsx
@@ -155,12 +155,14 @@ function TeamEditor({
           }
         })
       } else if (
-        team.loadoutData[existingIndex]?.teamCharId !==
-        loadoutData[existingIndex]!.teamCharId
-      ) {
         // Only relevant during multi-selection when the teamChar at loadoutData[existingIndex] is moved to
         // selectedIndex due to inserting a different teamChar at existingIndex, but loadoutData[selectedIndex]
-        // is undefined. This condition should never be true during single selection.
+        // is undefined. Comparison needs to be done against the team data currently in the database
+        // to account for any changes made by selections that have already been processed. This condition should
+        // never be true during single selection.
+        database.teams.get(teamId)!.loadoutData[existingIndex]?.teamCharId !==
+        loadoutData[existingIndex]!.teamCharId
+      ) {
         database.teams.set(teamId, (team) => {
           team.loadoutData[selectedIndex] = loadoutData[existingIndex]
         })

--- a/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
+++ b/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
@@ -27,10 +27,13 @@ export function CompareBuildWrapper(props: WrapperProps) {
 function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
   const database = useDatabase()
   const { teamCharId } = useContext(TeamCharacterContext)
-  const {buildToEdit} = useContext(BuildEditContext)
+  const { buildToEdit } = useContext(BuildEditContext)
 
   const newArt = database.arts.get(artIdOrSlot ?? '')
-  const currentArtifactIds = database.teams.getEditArtifactIds(buildToEdit, teamCharId)
+  const currentArtifactIds = database.teams.getEditArtifactIds(
+    buildToEdit,
+    teamCharId
+  )
   const newArtifactIds = objMap(currentArtifactIds, (id, slot) =>
     slot === artIdOrSlot
       ? undefined
@@ -38,13 +41,15 @@ function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
       ? artIdOrSlot
       : id
   )
-  const currentWeaponId = database.teams.getEditWeaponId(buildToEdit, teamCharId)
+  const currentWeaponId = database.teams.getEditWeaponId(
+    buildToEdit,
+    teamCharId
+  )
   const newWeaponId = weaponId ?? currentWeaponId
   return (
     <EquipBuildModal
       currentName={
-        (buildToEdit !== '' &&
-          database.builds.get(buildToEdit)?.name) ||
+        (buildToEdit !== '' && database.builds.get(buildToEdit)?.name) ||
         'Equipped'
       }
       newWeaponId={newWeaponId}

--- a/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
+++ b/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
@@ -7,6 +7,7 @@ import {
 } from '@genshin-optimizer/gi/db-ui'
 import { useContext } from 'react'
 import { EquipBuildModal } from '.'
+import { BuildEditContext } from '../../context/BuildEditContext'
 
 type WrapperProps = {
   artIdOrSlot?: string | ArtifactSlotKey
@@ -25,10 +26,11 @@ export function CompareBuildWrapper(props: WrapperProps) {
 }
 function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
   const database = useDatabase()
-  const { loadoutDatum } = useContext(TeamCharacterContext)
+  const { teamCharId } = useContext(TeamCharacterContext)
+  const {buildToEdit} = useContext(BuildEditContext)
 
   const newArt = database.arts.get(artIdOrSlot ?? '')
-  const currentArtifactIds = database.teams.getCompareArtifactIds(loadoutDatum)
+  const currentArtifactIds = database.teams.getEditArtifactIds(buildToEdit, teamCharId)
   const newArtifactIds = objMap(currentArtifactIds, (id, slot) =>
     slot === artIdOrSlot
       ? undefined
@@ -36,13 +38,13 @@ function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
       ? artIdOrSlot
       : id
   )
-  const currentWeaponId = database.teams.getCompareWeaponId(loadoutDatum)
+  const currentWeaponId = database.teams.getEditWeaponId(buildToEdit, teamCharId)
   const newWeaponId = weaponId ?? currentWeaponId
   return (
     <EquipBuildModal
       currentName={
-        (loadoutDatum.compareType === 'real' &&
-          database.builds.get(loadoutDatum.compareBuildId)?.name) ||
+        (buildToEdit !== '' &&
+          database.builds.get(buildToEdit)?.name) ||
         'Equipped'
       }
       newWeaponId={newWeaponId}

--- a/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
+++ b/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
@@ -27,7 +27,7 @@ export function CompareBuildWrapper(props: WrapperProps) {
 function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
   const database = useDatabase()
   const { teamCharId } = useContext(TeamCharacterContext)
-  const { buildToEdit } = useContext(BuildEditContext)
+  const buildToEdit = useContext(BuildEditContext)
 
   const newArt = database.arts.get(artIdOrSlot ?? '')
   const currentArtifactIds = database.teams.getEditArtifactIds(
@@ -48,10 +48,7 @@ function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
   const newWeaponId = weaponId ?? currentWeaponId
   return (
     <EquipBuildModal
-      currentName={
-        (buildToEdit !== '' && database.builds.get(buildToEdit)?.name) ||
-        'Equipped'
-      }
+      currentName={database.builds.get(buildToEdit)?.name ?? 'Equipped'}
       newWeaponId={newWeaponId}
       currentWeaponId={currentWeaponId}
       newArtifactIds={newArtifactIds}

--- a/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
+++ b/libs/gi/ui/src/components/build/CompareBuildWrapper.tsx
@@ -28,7 +28,7 @@ function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
   const { loadoutDatum } = useContext(TeamCharacterContext)
 
   const newArt = database.arts.get(artIdOrSlot ?? '')
-  const currentArtifactIds = database.teams.getLoadoutArtifactIds(loadoutDatum)
+  const currentArtifactIds = database.teams.getCompareArtifactIds(loadoutDatum)
   const newArtifactIds = objMap(currentArtifactIds, (id, slot) =>
     slot === artIdOrSlot
       ? undefined
@@ -36,13 +36,13 @@ function TeamWrapper({ artIdOrSlot, weaponId, onHide, onEquip }: WrapperProps) {
       ? artIdOrSlot
       : id
   )
-  const currentWeaponId = database.teams.getLoadoutWeaponId(loadoutDatum)
+  const currentWeaponId = database.teams.getCompareWeaponId(loadoutDatum)
   const newWeaponId = weaponId ?? currentWeaponId
   return (
     <EquipBuildModal
       currentName={
-        (loadoutDatum.buildType === 'real' &&
-          database.builds.get(loadoutDatum.buildId)?.name) ||
+        (loadoutDatum.compareType === 'real' &&
+          database.builds.get(loadoutDatum.compareBuildId)?.name) ||
         'Equipped'
       }
       newWeaponId={newWeaponId}

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -22,7 +22,8 @@ import { Box, Button, Grid, IconButton, Typography } from '@mui/material'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { DataContext, SillyContext } from '../../../context'
+import { BuildEditContext, DataContext, SillyContext } from '../../../context'
+import type { BuildEditContextObj } from '../../../context'
 import { AddTeamInfo } from '../../AddTeamInfo'
 import { LevelSelect } from '../../LevelSelect'
 import {
@@ -181,26 +182,31 @@ function EquipmentSection() {
       ),
     [data]
   )
+
+  const buildEditContextObj = {buildToEdit: 'equipped'} as BuildEditContextObj
+
   return (
     <Box>
-      <EquippedGrid
-        weaponTypeKey={weaponTypeKey}
-        weaponId={weaponId}
-        artifactIds={artifactIds}
-        setWeapon={(id) => {
-          database.weapons.set(id, {
-            location: charKeyToLocCharKey(characterKey),
-          })
-        }}
-        setArtifact={(slotKey, id) => {
-          if (!id)
-            database.arts.set(equippedArtifacts[slotKey], { location: '' })
-          else
-            database.arts.set(id, {
+      <BuildEditContext.Provider value={buildEditContextObj}>
+        <EquippedGrid
+          weaponTypeKey={weaponTypeKey}
+          weaponId={weaponId}
+          artifactIds={artifactIds}
+          setWeapon={(id) => {
+            database.weapons.set(id, {
               location: charKeyToLocCharKey(characterKey),
             })
-        }}
-      />
+          }}
+          setArtifact={(slotKey, id) => {
+            if (!id)
+              database.arts.set(equippedArtifacts[slotKey], { location: '' })
+            else
+              database.arts.set(id, {
+                location: charKeyToLocCharKey(characterKey),
+              })
+          }}
+        />
+      </BuildEditContext.Provider>
     </Box>
   )
 }

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -22,7 +22,6 @@ import { Box, Button, Grid, IconButton, Typography } from '@mui/material'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import type { BuildEditContextObj } from '../../../context'
 import { BuildEditContext, DataContext, SillyContext } from '../../../context'
 import { AddTeamInfo } from '../../AddTeamInfo'
 import { LevelSelect } from '../../LevelSelect'
@@ -183,11 +182,9 @@ function EquipmentSection() {
     [data]
   )
 
-  const buildEditContextObj = { buildToEdit: 'equipped' } as BuildEditContextObj
-
   return (
     <Box>
-      <BuildEditContext.Provider value={buildEditContextObj}>
+      <BuildEditContext.Provider value={'equipped'}>
         <EquippedGrid
           weaponTypeKey={weaponTypeKey}
           weaponId={weaponId}

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -22,8 +22,8 @@ import { Box, Button, Grid, IconButton, Typography } from '@mui/material'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { BuildEditContext, DataContext, SillyContext } from '../../../context'
 import type { BuildEditContextObj } from '../../../context'
+import { BuildEditContext, DataContext, SillyContext } from '../../../context'
 import { AddTeamInfo } from '../../AddTeamInfo'
 import { LevelSelect } from '../../LevelSelect'
 import {
@@ -183,7 +183,7 @@ function EquipmentSection() {
     [data]
   )
 
-  const buildEditContextObj = {buildToEdit: 'equipped'} as BuildEditContextObj
+  const buildEditContextObj = { buildToEdit: 'equipped' } as BuildEditContextObj
 
   return (
     <Box>

--- a/libs/gi/ui/src/context/BuildEditContext.tsx
+++ b/libs/gi/ui/src/context/BuildEditContext.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { createContext } from 'react'
+
+export type BuildEditContextObj = {
+  buildToEdit: string
+  //setBuildIdToEdit: (buildId: string) => void
+}
+
+export const BuildEditContext = createContext({
+  buildToEdit: '',
+  //setBuildIdToEdit: () => {},
+} as BuildEditContextObj)

--- a/libs/gi/ui/src/context/BuildEditContext.tsx
+++ b/libs/gi/ui/src/context/BuildEditContext.tsx
@@ -1,12 +1,4 @@
 'use client'
 import { createContext } from 'react'
 
-export type BuildEditContextObj = {
-  buildToEdit: string
-  //setBuildIdToEdit: (buildId: string) => void
-}
-
-export const BuildEditContext = createContext({
-  buildToEdit: '',
-  //setBuildIdToEdit: () => {},
-} as BuildEditContextObj)
+export const BuildEditContext = createContext<string | 'equipped'>('equipped')

--- a/libs/gi/ui/src/context/index.ts
+++ b/libs/gi/ui/src/context/index.ts
@@ -1,3 +1,4 @@
+export * from './BuildEditContext'
 export * from './DataContext'
 export * from './FormulaDataContext'
 export * from './GraphContext'


### PR DESCRIPTION
## Describe your changes
**Fix for incorrect comparisons being displayed when trying to edit a build other than the current active build**
New file `BuildEditContext.tsx`:
- In order to display the correct comparisons for inactive builds, information regarding which build is currently being edited needs to be piped through to `CompareBuildWrapper` instead of always fetching `LoadoutDatum.buildId`, which always corresponds to the active build if the active build isn't the equipped build. `BuildEditContext` contains a single string set to either `"equipped"` (if the equipped build is being edited) or `LoadoutDatum.buildId` (if a non-equipped build is being edited). `CompareBuildWrapper` will then use this to fetch the weapon/artifact ids accordingly. This avoids needing to manually pipe this value through all the components on the build edit path.
- Export added to `gi/ui/src/context/index.ts`

`TeamDataManager.ts`:
- Added new methods `getEditWeaponId`/`getEditArtifactIds` - These determine the type of build being edited then pass that along with `teamCharId` and the `buildId` to the new private methods below to actually fetch the ids needed for comparison. Build types are deduced to always be either `'equipped'` or `'real'` as it makes no sense to edit a TC build in this context.
- Added private methods `getWeaponId` and `getArtifactIds` - These contain the code previously in `getLoadoutWeaponId` and `getLoadoutArtifactIds` to reduce code duplication.
- Modified `getLoadoutWeaponId`/`getLoadoutArtifactIds` to use the private methods above (functionality unchanged)

`BuildReal.tsx`, `EquipmentSection.tsx`, `character/editor/Content.tsx`:
All three of these locations now wrap their `EquippedGrid` component with `BuildEditContext.Provider` and provide either `buildId` or `"equipped"` as the value.

**Bonus bugfix: Teammate multi-select drops a character if that character was moved to a different slot from the first slot and the team is not full**
`TeamSetting/index.tsx`:
Changed the last conditional in `onSelect` to use `database.teams.get(teamId)` instead of `team` from earlier in the function - This ensures that changes applied so far to the team are accounted for when checking whether a character has been displaced from their old slot regardless of which slot it was, preventing conditional from being false in cases where a character has been moved but `loadoutData[selectedIndex]` is undefined.
<!--- Provide a general summary of your changes -->

## Issue or discord link
- Fixes #2466 <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->
- Fixes this bonus bug discovered while testing the comparison fix

https://github.com/user-attachments/assets/9012aeb2-a5c8-44da-ba56-40d97da91dc1

## Testing/validation
Build edit comparison fix:

https://github.com/user-attachments/assets/7a226a74-74db-4922-a0cd-726e190da4b9

https://github.com/user-attachments/assets/8bb382c1-d58a-4636-8930-0f5e5535f7fa

https://github.com/user-attachments/assets/3f69ba11-673a-454f-b976-16609cf6d64a

Team multi-select fix:

https://github.com/user-attachments/assets/19016ac0-9be2-4645-842d-c830e973b095


<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
