### PR TITLE
[XS][1648] Add noWrap to team name display in `TeamCharacterSelector`

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Content.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Content.tsx
@@ -191,7 +191,18 @@ function TabNav({
                 </Typography>
                 <Divider orientation="vertical" variant="middle" flexItem />
                 <CheckroomIcon />
-                {database.teams.getActiveBuildName(loadoutDatum)}
+                <Typography
+                  variant="h6"
+                  noWrap
+                  sx={{
+                    gap: 1,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textShadow: '#000 0 0 10px !important',
+                  }}
+                >
+                  {database.teams.getActiveBuildName(loadoutDatum)}
+                </Typography>
               </CardContent>
             </BootstrapTooltip>
           </CardActionArea>

--- a/libs/gi/page-team/src/CharacterDisplay/Content.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Content.tsx
@@ -173,24 +173,25 @@ function TabNav({
                   '&:hover': {
                     color: 'info.light',
                   },
+                  alignItems: 'center',
                 }}
               >
+                <PersonIcon />
                 <Typography
                   variant="h6"
+                  noWrap
                   sx={{
-                    display: 'flex',
                     gap: 1,
                     alignItems: 'center',
                     justifyContent: 'center',
                     textShadow: '#000 0 0 10px !important',
                   }}
                 >
-                  <PersonIcon />
                   <strong>{teamChar.name}</strong>
-                  <Divider orientation="vertical" variant="middle" flexItem />
-                  <CheckroomIcon />
-                  {database.teams.getActiveBuildName(loadoutDatum)}
                 </Typography>
+                <Divider orientation="vertical" variant="middle" flexItem />
+                <CheckroomIcon />
+                {database.teams.getActiveBuildName(loadoutDatum)}
               </CardContent>
             </BootstrapTooltip>
           </CardActionArea>

--- a/libs/gi/page-team/src/LoadoutDropdown.tsx
+++ b/libs/gi/page-team/src/LoadoutDropdown.tsx
@@ -105,10 +105,12 @@ export function LoadoutDropdown({
         title={
           <Box
             sx={{
-              display: 'flex',
               gap: 1,
               flexWrap: 'wrap',
               justifyContent: 'center',
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
             }}
           >
             {label ? (

--- a/libs/gi/page-team/src/TeamCharacterSelector.tsx
+++ b/libs/gi/page-team/src/TeamCharacterSelector.tsx
@@ -145,26 +145,18 @@ export default function TeamCharacterSelector({
           <CardContent
             sx={{
               display: 'flex',
+              alignItems: 'center',
               justifyContent: 'center',
               '&:hover': {
                 color: 'info.light',
               },
+              gap: 1,
+              textShadow: '#000 0 0 10px !important',
             }}
           >
-            <Typography
-              noWrap
-              variant="h5"
-              sx={{
-                display: 'flex',
-                gap: 1,
-                alignItems: 'center',
-                textShadow: '#000 0 0 10px !important',
-              }}
-            >
-              <TeamIcon />
-              <Typography noWrap variant="h5">
-                {team.name}
-              </Typography>
+            <TeamIcon />
+            <Typography noWrap variant="h5">
+              {team.name}
             </Typography>
           </CardContent>
         </BootstrapTooltip>

--- a/libs/gi/page-team/src/TeamCharacterSelector.tsx
+++ b/libs/gi/page-team/src/TeamCharacterSelector.tsx
@@ -124,7 +124,13 @@ export default function TeamCharacterSelector({
           placement="top"
           title={
             <Box>
-              <Box sx={{ display: 'flex', color: 'info.light', gap: 1 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  color: 'info.light',
+                  gap: 1,
+                }}
+              >
                 <BorderColorIcon />
                 <Typography>
                   <strong>{t`team.editNameDesc`}</strong>
@@ -146,17 +152,19 @@ export default function TeamCharacterSelector({
             }}
           >
             <Typography
+              noWrap
               variant="h5"
               sx={{
                 display: 'flex',
                 gap: 1,
                 alignItems: 'center',
-                justifyContent: 'center',
                 textShadow: '#000 0 0 10px !important',
               }}
             >
               <TeamIcon />
-              {team.name}
+              <Typography noWrap variant="h5">
+                {team.name}
+              </Typography>
             </Typography>
           </CardContent>
         </BootstrapTooltip>

--- a/libs/gi/ui/src/components/build/BuildCard.tsx
+++ b/libs/gi/ui/src/components/build/BuildCard.tsx
@@ -46,7 +46,11 @@ export function BuildCard({
   const clickableAreaContent = (
     <>
       <CardHeader
-        title={name}
+        title={
+          <Typography noWrap gutterBottom variant="h6">
+            {name}
+          </Typography>
+        }
         action={
           description && (
             <Tooltip title={<Typography>{description}</Typography>}>


### PR DESCRIPTION
## Describe your changes

My first PR in this repo. Not familiar with mUI so bear with me. I just added a noWrap to a typography element, then added a nested typography element (is this ok?). i needed a nested element in order to keep using flex on the parent element, as ellipses wrap only works for inline display

willing to add more to other relevant areas when i hear that this is an acceptable pattern for approach.

## Issue or discord link

https://github.com/frzyc/genshin-optimizer/issues/1648

## Testing/validation

https://github.com/user-attachments/assets/522260cc-66c6-4bab-ac69-b6a25a37fb75

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced styling and readability of the TeamCharacterSelector component.
	- Improved text wrapping for the team name display to prevent overflow.
	- Added a new Typography component to display the active build name alongside the character's name.
	- Updated dropdown button styling to handle long text with ellipsis.

- **Bug Fixes**
	- Adjusted properties to ensure the team name is displayed correctly without layout issues.

- **Refactor**
	- Streamlined the JSX structure for better clarity and maintainability.
	- Refined layout and styling of the LoadoutDropdown component for improved text handling.
	- Enhanced the BuildCard component's title styling for better presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->