### PR TITLE
fix: Prayers set now defaults to circlet

### DIFF
--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -135,6 +135,17 @@ function artifactReducer(
 const InputInvis = styled('input')({
   display: 'none',
 })
+
+function getDefaultSlotKey(
+  artifactSet?: ArtifactSetKey
+): Extract<ArtifactSlotKey, 'flower' | 'circlet'> {
+  if (artifactSet?.startsWith('Prayers')) {
+    return 'circlet'
+  } else {
+    return 'flower'
+  }
+}
+
 export type ArtifactEditorProps = {
   artifactIdToEdit?: string
   cancelEdit: () => void
@@ -263,8 +274,11 @@ export function ArtifactEditor({
         // If we're updating an existing artifact, then slotKey should immediately be set to the artifact's slot.
         // Otherwise, if slot selection is disabled but a key has been provided in fixedSlotKey, we assign that
         // value (e.g. when creating a new artifact from the artifact swap UI). If neither, then we default to
-        // 'flower'.
-        newValue.slotKey = artifact?.slotKey ?? fixedSlotKey ?? 'flower'
+        // 'flower' for all sets and 'circlet' for Prayers Set (Which only have circlets).
+        newValue.slotKey =
+          artifact?.slotKey ??
+          fixedSlotKey ??
+          getDefaultSlotKey(newValue.setKey)
       }
       if (newValue.rarity) newValue.level = artifact?.level ?? 0
       if (newValue.level)


### PR DESCRIPTION
## Describe your changes

Added a function that returns `flower` for all sets and `circlet` for Prayers set
When update is triggered in `ArtifactSetAutocomplete` get the `slotKey` from the new value and return `flower` or `circlet` depending on the set

## Issue or discord link

Resolves #2437

## Testing/validation
Prayers defaults to Circlet
![image](https://github.com/user-attachments/assets/4519b565-3f91-4d1d-9c7a-fc3a455bf027)

Other sets defaults to Flower
![image](https://github.com/user-attachments/assets/54111aa1-7ee0-4b10-8f47-603d538d2d6f)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced artifact editing functionality with dynamic determination of default slot keys based on artifact set keys.
  
- **Bug Fixes**
	- Improved logic for setting default slot keys, replacing the previous static assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->