### PR TITLE
fixing issue #2525: Finale of the Deep use wrong conditional string

### DIFF
--- a/libs/gi/sheets/src/Weapons/Sword/FinaleOfTheDeep/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Sword/FinaleOfTheDeep/index.tsx
@@ -61,7 +61,7 @@ const sheet: IWeaponSheet = {
       header: headerTemplate(key, st('conditional')),
       path: condAfterSkillPath,
       value: condAfterSkill,
-      name: st('hitOp.skill'),
+      name: st('afterUse.skill'),
       states: {
         on: {
           fields: [


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

changed afterUse.skill, not hitOp.skill

in 

genshin-optimizer/libs/gi/sheets/src/Weapons/Sword/FinaleOfTheDeep/index.tsx


## Issue or discord link

https://github.com/frzyc/genshin-optimizer/issues/2525

## Testing/validation
<img width="710" alt="SCR-20241107-qcee" src="https://github.com/user-attachments/assets/60da5691-7430-440d-9d2d-6f7b2b82e9ee">


<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ X] I have commented my code in hard-to understand areas.
- [ X] I have made corresponding changes to README or wiki.
- [ X] For front-end changes, I have updated the corresponding English translations.
- [ X] I have run `yarn run mini-ci` locally to validate format and lint.
- [ X] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label for the skill's conditional effect in the Finale of the Deep weapon module to enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->