### PR TITLE
Improve optimization progress accuracy

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BuildAlert.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BuildAlert.tsx
@@ -55,7 +55,7 @@ export default function BuildAlert({
   let progress = undefined as undefined | number
 
   if (generatingBuilds) {
-    progress = (tested * 100) / unskipped
+    progress = ((tested + skipped) / total) * 100
     title = (
       <Typography>
         Generating and testing {testedString}

--- a/libs/gi/ui/src/components/character/BuildAlert.tsx
+++ b/libs/gi/ui/src/components/character/BuildAlert.tsx
@@ -69,7 +69,7 @@ export function BuildAlert({
   let progress = undefined as undefined | number
 
   if (generatingBuilds) {
-    progress = (tested * 100) / unskipped
+    progress = ((tested + skipped) / total) * 100
     title = (
       <Typography>
         Generating and testing {testedString}


### PR DESCRIPTION
## Describe your changes
Updated the progress bar when optimizing artifacts to better reflect the actual percentage of progress done.  
The new formula is based on the assumption that the amount of skipped builds remains proportional to the amount of tested builds, but also improves accuracy in cases where more builds are skipped closer to the end than the beginning, and cases where not too many more builds are skipped closer to the beginning than the end.  
In contrast, the previous formula essentially assumed all builds that were going to be skipped were skipped as soon as the generation started.

## Issue or discord link
https://discord.com/channels/785153694478893126/1296108919608971334

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)
- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated progress calculation in the Build Alert to include skipped builds, providing a more accurate representation of build status.
- **Bug Fixes**
	- Improved display of progress percentage in the Build Alert based on the new calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->