### PR TITLE
Aizm8/go/bugfix/t 2537 fix paste artifact upgrader

### DIFF
--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -401,10 +401,12 @@ export function ArtifactEditor({
   useEffect(() => {
     const pasteFunc = (e: Event) => {
       // Don't handle paste if targetting the edit team modal
-      const target = e.target as HTMLElement;
-      if (target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement) {
-        return;
+      const target = e.target as HTMLElement
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement
+      ) {
+        return
       }
 
       uploadFiles((e as ClipboardEvent).clipboardData?.files)

--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -399,8 +399,17 @@ export function ArtifactEditor({
   }, [queue, processedNum, scannedData])
 
   useEffect(() => {
-    const pasteFunc = (e: Event) =>
+    const pasteFunc = (e: Event) => {
+      // Don't handle paste if targetting the edit team modal
+      const target = e.target as HTMLElement;
+      if (target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
       uploadFiles((e as ClipboardEvent).clipboardData?.files)
+    }
+
     allowUpload && window.addEventListener('paste', pasteFunc)
     return () => {
       if (allowUpload) window.removeEventListener('paste', pasteFunc)


### PR DESCRIPTION
## Describe your changes

Fixed the paste issue by disabling the paste capture if HTMLInputElement or HTMLTextAreaElement are detected.

## Issue or discord link

- Resolves #2537

## Testing/validation

<!--- Add screenshots if possible -->
Pasting text into the edit team modal 
![image](https://github.com/user-attachments/assets/ff84aa67-9c01-4f1f-bbcc-c449ccdd7b4b)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved paste handling in the ArtifactEditor component to enhance user interactions by preventing paste events in input and textarea elements.

- **Bug Fixes**
	- Refined control flow for paste events to ensure appropriate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->