### PR TITLE
Add getInterpolateObject for relics and light cones

### DIFF
--- a/libs/pando/ui-sheet/src/components/DocumentDisplay.tsx
+++ b/libs/pando/ui-sheet/src/components/DocumentDisplay.tsx
@@ -5,7 +5,7 @@ import { evalIfFunc } from '@genshin-optimizer/common/util'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import { Box, Collapse } from '@mui/material'
 import { useContext, useState } from 'react'
-import { CalcContext } from '../context'
+import { CalcContext, TagContext } from '../context'
 import type { Document, FieldsDocument, TextDocument } from '../types'
 import { ConditionalsDisplay } from './ConditionalDisplay'
 import { FieldsDisplay } from './FieldDisplay'
@@ -66,8 +66,9 @@ function FieldsSectionDisplay({
 
 function TextSectionDisplay({ textDocument }: { textDocument: TextDocument }) {
   const calculator = useContext(CalcContext)
+  const tag = useContext(TagContext)
   if (!calculator) return null
-  return <div>{evalIfFunc(textDocument.text, calculator)}</div>
+  return <div>{evalIfFunc(textDocument.text, calculator.withTag(tag))}</div>
 }
 function TextSectionDisplayCollapse({
   textDocument,

--- a/libs/sr/formula-ui/src/char/sheets/RuanMei.tsx
+++ b/libs/sr/formula-ui/src/char/sheets/RuanMei.tsx
@@ -8,7 +8,10 @@ import {
   formulas,
   own,
 } from '@genshin-optimizer/sr/formula'
-import { getInterpolateObject, mappedStats } from '@genshin-optimizer/sr/stats'
+import {
+  getCharInterpolateObject,
+  mappedStats,
+} from '@genshin-optimizer/sr/stats'
 import { StatDisplay } from '@genshin-optimizer/sr/ui'
 import { trans } from '../../util'
 import type { TalentSheetElementKey } from '../consts'
@@ -35,7 +38,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
         text: (calculator) =>
           chg(
             `abilities.basic.0.fullDesc`,
-            getInterpolateObject(
+            getCharInterpolateObject(
               key,
               'basic',
               calculator.compute(own.char.basic).val
@@ -67,7 +70,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
         text: (calculator) =>
           chg(
             `abilities.skill.0.fullDesc`,
-            getInterpolateObject(
+            getCharInterpolateObject(
               key,
               'skill',
               calculator.compute(own.char.skill).val
@@ -116,7 +119,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
         text: (calculator) =>
           chg(
             `abilities.ult.0.fullDesc`,
-            getInterpolateObject(
+            getCharInterpolateObject(
               key,
               'ult',
               calculator.compute(own.char.ult).val
@@ -171,7 +174,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
         text: (calculator) =>
           chg(
             `abilities.talent.0.fullDesc`,
-            getInterpolateObject(
+            getCharInterpolateObject(
               key,
               'talent',
               calculator.compute(own.char.talent).val
@@ -222,7 +225,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.1.desc`, getInterpolateObject(key, 'eidolon', 1)),
+        text: chg(`ranks.1.desc`, getCharInterpolateObject(key, 'eidolon', 1)),
       },
       {
         type: 'fields',
@@ -243,7 +246,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.2.desc`, getInterpolateObject(key, 'eidolon', 2)),
+        text: chg(`ranks.2.desc`, getCharInterpolateObject(key, 'eidolon', 2)),
       },
       {
         type: 'fields',
@@ -263,7 +266,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.3.desc`, getInterpolateObject(key, 'eidolon', 3)),
+        text: chg(`ranks.3.desc`, getCharInterpolateObject(key, 'eidolon', 3)),
       },
       {
         type: 'fields',
@@ -289,7 +292,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.4.desc`, getInterpolateObject(key, 'eidolon', 4)),
+        text: chg(`ranks.4.desc`, getCharInterpolateObject(key, 'eidolon', 4)),
       },
       {
         type: 'conditional',
@@ -318,7 +321,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.5.desc`, getInterpolateObject(key, 'eidolon', 5)),
+        text: chg(`ranks.5.desc`, getCharInterpolateObject(key, 'eidolon', 5)),
       },
       {
         type: 'fields',
@@ -344,7 +347,7 @@ const sheet: UISheet<TalentSheetElementKey> = {
     documents: [
       {
         type: 'text',
-        text: chg(`ranks.6.desc`, getInterpolateObject(key, 'eidolon', 6)),
+        text: chg(`ranks.6.desc`, getCharInterpolateObject(key, 'eidolon', 6)),
       },
     ],
   },

--- a/libs/sr/formula-ui/src/lightCone/sheets/PastSelfInMirror.tsx
+++ b/libs/sr/formula-ui/src/lightCone/sheets/PastSelfInMirror.tsx
@@ -2,8 +2,11 @@ import { ImgIcon } from '@genshin-optimizer/common/ui'
 import type { UISheetElement } from '@genshin-optimizer/pando/ui-sheet'
 import { lightConeAsset } from '@genshin-optimizer/sr/assets'
 import type { LightConeKey } from '@genshin-optimizer/sr/consts'
-import { buffs, conditionals } from '@genshin-optimizer/sr/formula'
-import { mappedStats } from '@genshin-optimizer/sr/stats'
+import { buffs, conditionals, own } from '@genshin-optimizer/sr/formula'
+import {
+  getLightConeInterpolateObject,
+  mappedStats,
+} from '@genshin-optimizer/sr/stats'
 import { StatDisplay } from '@genshin-optimizer/sr/ui'
 import { trans } from '../../util'
 import { SuperImposeWrapper } from '../util'
@@ -15,13 +18,21 @@ const dm = mappedStats.lightCone[key]
 const icon = lightConeAsset(key, 'cover')
 const cond = conditionals[key]
 const buff = buffs[key]
+
 const sheet: UISheetElement = {
   title: chg('passive.name'),
   img: icon,
   documents: [
     {
       type: 'text',
-      text: chg('passive.description'), // TODO: getInterpolateObject for lightcone
+      text: (calc) =>
+        chg(
+          'passive.description',
+          getLightConeInterpolateObject(
+            key,
+            calc.compute(own.lightCone.superimpose).val
+          )
+        ),
     },
     {
       type: 'conditional',

--- a/libs/sr/formula-ui/src/relic/cavern/WatchmakerMasterOfDreamMachinations.tsx
+++ b/libs/sr/formula-ui/src/relic/cavern/WatchmakerMasterOfDreamMachinations.tsx
@@ -3,16 +3,21 @@ import type { UISheet } from '@genshin-optimizer/pando/ui-sheet'
 import { relicAsset } from '@genshin-optimizer/sr/assets'
 import type { RelicSetKey } from '@genshin-optimizer/sr/consts'
 import { buffs, conditionals } from '@genshin-optimizer/sr/formula'
-import { mappedStats } from '@genshin-optimizer/sr/stats'
+import {
+  getRelicInterpolateObject,
+  mappedStats,
+} from '@genshin-optimizer/sr/stats'
 import { StatDisplay } from '@genshin-optimizer/sr/ui'
 import { getDefaultRelicSlot } from '@genshin-optimizer/sr/util'
 import { trans } from '../../util'
+
 const key: RelicSetKey = 'WatchmakerMasterOfDreamMachinations'
 const [chg, _ch] = trans('relic', key)
 const dm = mappedStats.relic[key]
 const icon = relicAsset(key, getDefaultRelicSlot(key))
 const cond = conditionals[key]
 const buff = buffs[key]
+
 const sheet: UISheet<'2' | '4'> = {
   2: {
     title: '2-Set', // TODO: L10n
@@ -20,7 +25,7 @@ const sheet: UISheet<'2' | '4'> = {
     documents: [
       {
         type: 'text',
-        text: chg('setEffects.2'), // TODO: getInterpolateObject for relics
+        text: chg('setEffects.2', getRelicInterpolateObject(key, 2)),
       },
       {
         type: 'fields',
@@ -39,7 +44,7 @@ const sheet: UISheet<'2' | '4'> = {
     documents: [
       {
         type: 'text',
-        text: chg('setEffects.4'), // TODO: getInterpolateObject for relics
+        text: chg('setEffects.4', getRelicInterpolateObject(key, 4)),
       },
       {
         type: 'conditional',

--- a/libs/sr/stats/src/char.ts
+++ b/libs/sr/stats/src/char.ts
@@ -1,0 +1,75 @@
+import type { CharacterGenderedKey, StatBoostKey } from "@genshin-optimizer/sr/consts"
+import type { Rank } from "@genshin-optimizer/sr/dm"
+import { allStats } from "./allStats"
+
+export function getCharStat(ck: CharacterGenderedKey) {
+  return allStats.char[ck]
+}
+
+/**
+ * Creates an interpolation object for i18n'ing the datamined strings with the proper numeric values for character traces
+ * @param ck Character key
+ * @param skType Skill tree type
+ * @param skLevel Level of skill to lookup. If skType is 'eidolon', this is the eidolon to look up (1-6).
+ * @param skIndex (optional) Which skill to use from this skill tree type. For niche cases, like Firefly who has multiple 'basic's
+ * @returns Interpolation object to be fed to translate function
+ */
+export function getCharInterpolateObject(
+  ck: CharacterGenderedKey,
+  skType: 'basic' | 'skill' | 'ult' | 'talent' | 'technique' | 'eidolon',
+  skLevel: number,
+  skIndex = 0
+) {
+  if (skType === 'eidolon') {
+    return Object.fromEntries(
+      allStats.char[ck].rankMap[skLevel as Rank].params.map((param, index) => [
+        index + 1,
+        param,
+      ])
+    )
+  } else {
+    return Object.fromEntries(
+      allStats.char[ck].skillTree[skType].skillParamList[skIndex].map(
+        (skills, index) => [index + 1, skills[skLevel]]
+      )
+    )
+  }
+}
+
+export function getCharStatBoostStatKey(
+  ck: CharacterGenderedKey,
+  bonusStats: StatBoostKey | `${StatBoostKey}`
+) {
+  return getCharStatBoostStat(ck, bonusStats).statKey
+}
+
+export function getCharStatBoostStatValue(
+  ck: CharacterGenderedKey,
+  bonusStats: StatBoostKey | `${StatBoostKey}`
+) {
+  return getCharStatBoostStat(ck, bonusStats).value
+}
+
+export function getCharStatBoostStat(
+  ck: CharacterGenderedKey,
+  bonusStats: StatBoostKey | `${StatBoostKey}`
+) {
+  const boost = getCharStatBoost(ck, bonusStats)
+  const levels = boost.levels
+  if (!levels?.length) {
+    throw new Error(`No stat boost levels found for character ${ck}`)
+  }
+  const entries = Object.entries(levels[0].stats ?? {})
+  if (!entries.length) {
+    throw new Error(`No stats found in stat boost for character ${ck}`)
+  }
+  const [statKey, value] = entries[0]
+  return { statKey, value }
+}
+export function getCharStatBoost(
+  ck: CharacterGenderedKey,
+  bonusStats: StatBoostKey | `${StatBoostKey}`
+) {
+  const { skillTree } = getCharStat(ck)
+  return skillTree[`statBoost${bonusStats}`]
+}

--- a/libs/sr/stats/src/index.ts
+++ b/libs/sr/stats/src/index.ts
@@ -1,9 +1,3 @@
-import type {
-  CharacterGenderedKey,
-  LightConeKey,
-  StatBoostKey,
-} from '@genshin-optimizer/sr/consts'
-import type { Rank } from '@genshin-optimizer/sr/dm'
 import { allStats } from './allStats'
 import { mappedStats } from './mappedStats'
 
@@ -15,78 +9,6 @@ export type {
 } from './executors/gen-stats/executor'
 export { allStats, mappedStats }
 
-export function getCharStat(ck: CharacterGenderedKey) {
-  return allStats.char[ck]
-}
-
-/**
- * Creates an interpolation object for i18n'ing the datamined strings with the proper numeric values
- * @param ck Character key
- * @param skType Skill tree type
- * @param skLevel Level of skill to lookup. If skType is 'eidolon', this is the eidolon to look up (1-6).
- * @param skIndex (optional) Which skill to use from this skill tree type. For niche cases, like Firefly who has multiple 'basic's
- * @returns Interpolation object to be fed to translate function
- */
-export function getInterpolateObject(
-  ck: CharacterGenderedKey,
-  skType: 'basic' | 'skill' | 'ult' | 'talent' | 'technique' | 'eidolon',
-  skLevel: number,
-  skIndex = 0
-) {
-  if (skType === 'eidolon') {
-    return Object.fromEntries(
-      allStats.char[ck].rankMap[skLevel as Rank].params.map((param, index) => [
-        index + 1,
-        param,
-      ])
-    )
-  } else {
-    return Object.fromEntries(
-      allStats.char[ck].skillTree[skType].skillParamList[skIndex].map(
-        (skills, index) => [index + 1, skills[skLevel]]
-      )
-    )
-  }
-}
-
-export function getLightConeStat(lcKey: LightConeKey) {
-  return allStats.lightCone[lcKey]
-}
-
-export function getCharStatBoostStatKey(
-  ck: CharacterGenderedKey,
-  bonusStats: StatBoostKey | `${StatBoostKey}`
-) {
-  return getCharStatBoostStat(ck, bonusStats).statKey
-}
-
-export function getCharStatBoostStatValue(
-  ck: CharacterGenderedKey,
-  bonusStats: StatBoostKey | `${StatBoostKey}`
-) {
-  return getCharStatBoostStat(ck, bonusStats).value
-}
-
-export function getCharStatBoostStat(
-  ck: CharacterGenderedKey,
-  bonusStats: StatBoostKey | `${StatBoostKey}`
-) {
-  const boost = getCharStatBoost(ck, bonusStats)
-  const levels = boost.levels
-  if (!levels?.length) {
-    throw new Error(`No stat boost levels found for character ${ck}`)
-  }
-  const entries = Object.entries(levels[0].stats ?? {})
-  if (!entries.length) {
-    throw new Error(`No stats found in stat boost for character ${ck}`)
-  }
-  const [statKey, value] = entries[0]
-  return { statKey, value }
-}
-export function getCharStatBoost(
-  ck: CharacterGenderedKey,
-  bonusStats: StatBoostKey | `${StatBoostKey}`
-) {
-  const { skillTree } = getCharStat(ck)
-  return skillTree[`statBoost${bonusStats}`]
-}
+export * from './char'
+export * from './lightCone'
+export * from './relic'

--- a/libs/sr/stats/src/lightCone.ts
+++ b/libs/sr/stats/src/lightCone.ts
@@ -1,0 +1,23 @@
+import type { LightConeKey } from '@genshin-optimizer/sr/consts'
+import { allStats } from './allStats'
+
+export function getLightConeStat(lcKey: LightConeKey) {
+  return allStats.lightCone[lcKey]
+}
+
+/**
+ * Creates an interpolation object for i18n'ing the datamined strings with the proper numeric values for light cone passives
+ * @param lck Light cone key
+ * @param superimpose Superimposition to use
+ * @returns Interpolation object to be fed to translate function
+ */
+export function getLightConeInterpolateObject(
+  lck: LightConeKey,
+  superimpose: number
+) {
+  return Object.fromEntries(
+    allStats.lightCone[lck].superimpose.otherStats.map(
+      (superimposeParams, index) => [index + 1, superimposeParams[superimpose]]
+    )
+  )
+}

--- a/libs/sr/stats/src/relic.ts
+++ b/libs/sr/stats/src/relic.ts
@@ -1,0 +1,21 @@
+import { type RelicSetKey } from '@genshin-optimizer/sr/consts'
+import { allStats } from './allStats'
+
+export function getRelicStat(relicKey: RelicSetKey) {
+  return allStats.relic[relicKey]
+}
+
+/**
+ * Creates an interpolation object for i18n'ing the datamined strings with the proper numeric values for relic passives
+ * @param rk Relic set key
+ * @param numRequired Number of required relics for stats
+ * @returns Interpolation object to be fed to translate function
+ */
+export function getRelicInterpolateObject(rk: RelicSetKey, numRequired: 2 | 4) {
+  const setEffectIndex = numRequired === 2 ? 0 : 1
+  return Object.fromEntries(
+    allStats.relic[rk].setEffects[setEffectIndex].otherStats.map(
+      (param, index) => [index + 1, param]
+    )
+  )
+}


### PR DESCRIPTION
## Describe your changes

* Add getRelicInterpolateObject and getLightConeInterpolateObject for their respective passives
* Split sr-stats index.ts into char/relic/lightCone file for easier viewing

KNOWN ISSUE: Light cone interpolation looks at the current char's light cone superimpose for all light cone description interpolations, which isn't always correct.

## Issue or discord link

- Resolves #2542 

## Testing/validation

![image](https://github.com/user-attachments/assets/77bbf918-216f-4ea9-a23f-c85f78f7e27e)
![image](https://github.com/user-attachments/assets/21993dd3-98f5-494e-a85c-0f412541f1d6)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
