### PR TITLE
Replace misread characters while parsing substat

### DIFF
--- a/libs/gi/art-scanner/src/lib/consts.ts
+++ b/libs/gi/art-scanner/src/lib/consts.ts
@@ -81,3 +81,10 @@ export const starColor = { r: 255, g: 204, b: 50 } // #FFCC32
 
 export const textColorLight = { r: 131, g: 131, b: 130 } // rgb(131, 131, 130)
 export const textColorDark = { r: 74, g: 81, b: 102 } // rgb(74, 81, 102)
+
+export const misreadCharactersInSubstatMap = [
+  {
+    pattern: /#/,
+    replacement: '+',
+  },
+]

--- a/libs/gi/art-scanner/src/lib/parse.ts
+++ b/libs/gi/art-scanner/src/lib/parse.ts
@@ -13,6 +13,7 @@ import {
   allSubstatKeys,
 } from '@genshin-optimizer/gi/consts'
 import type { ISubstat } from '@genshin-optimizer/gi/good'
+import { misreadCharactersInSubstatMap } from './consts'
 import { artSlotNames, statMap } from './enStringMap'
 
 /** small utility function used by most string parsing functions below */
@@ -96,6 +97,12 @@ export function parseSubstats(texts: string[]): ISubstat[] {
   const matches: ISubstat[] = []
   for (let text of texts) {
     text = text.replace(/^[\W]+/, '').replace(/\n/, '')
+    //Sometimes characters like `+` is misread as `#` in OCR
+    text = misreadCharactersInSubstatMap.reduce(
+      (replacedText, { pattern, replacement }) =>
+        replacedText.replace(pattern, replacement),
+      text
+    )
     //parse substats
     allSubstatKeys.forEach((key) => {
       const name = statMap[key]


### PR DESCRIPTION
## Describe your changes

The change aims to solve the issue where in substat image the OCR detects `+` as `#`. It adds a list of replacements and replaces the text according to that list. The list can be extended to add new replacements. As of now only # -> + replacement is added.

## Issue or discord link

- https://github.com/frzyc/genshin-optimizer/issues/2565

## Testing/validation

Did functional tested using screenshots provided in the issue. Sampled my own genshin artifacts.
![image](https://github.com/user-attachments/assets/11b46a9b-3789-45b2-aee5-5fee6e9c4add)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [X] I have commented my code in hard-to understand areas.
- [ ] ~~I have made corresponding changes to README or wiki.~~
- [ ] ~~For front-end changes, I have updated the corresponding English translations.~~
- [X] I have run `yarn run mini-ci` locally to validate format and lint. 
  - ` √  nx run gi-art-scanner:eslint:lint (14s)`
- [ ] ~~If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed~~
