### PR TITLE
Fix Chasca bugs in A4 and C2

### DIFF
--- a/libs/gi/sheets/src/Characters/Chasca/index.tsx
+++ b/libs/gi/sheets/src/Characters/Chasca/index.tsx
@@ -6,6 +6,7 @@ import {
   greaterEq,
   infoMut,
   input,
+  min,
   percent,
   prod,
   subscript,
@@ -98,8 +99,12 @@ const dm = {
   },
 } as const
 
-const phecElements = sum(
-  ...absorbableEle.map((ele) => greaterEq(tally[ele], 1, 1))
+const phecElements = min(
+  sum(
+    ...absorbableEle.map((ele) => greaterEq(tally[ele], 1, 1)),
+    greaterEq(input.constellation, 2, 1)
+  ),
+  3
 )
 const [condA1InMultitargetPath, condA1InMultitarget] = cond(
   key,
@@ -208,7 +213,7 @@ const dmgFormulas = {
             ...hitEle[eleKey],
             ...shiningAddl,
           },
-          undefined,
+          percent(dm.passive2.dmg),
           'skill'
         )
       )


### PR DESCRIPTION
## Describe your changes

* Fix Chasca A4 not using proper multiplier
* Fix Chasca C2 not increasing A1 dmg bonus

## Issue or discord link

- https://discord.com/channels/785153694478893126/1317803967626874900
- https://discord.com/channels/785153694478893126/1310833666381053962

## Testing/validation

![image](https://github.com/user-attachments/assets/637b71cf-5531-42b1-a29a-7148539d522b)

![image](https://github.com/user-attachments/assets/74761426-68bf-4fae-9ecb-b6b35e99e72a)
![image](https://github.com/user-attachments/assets/1d7237c7-7961-4d9b-b58e-10da5aaba379)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced damage calculations for the character Chasca, including updated formulas for skills and passives.
	- Implemented new conditions for determining maximum values related to character abilities.

- **Bug Fixes**
	- Corrected logic for damage output calculations, ensuring accurate representation of character abilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->