### PR TITLE
Fix Chasca/Mav bugs

### DIFF
--- a/libs/gi/sheets/src/Characters/Chasca/index.tsx
+++ b/libs/gi/sheets/src/Characters/Chasca/index.tsx
@@ -196,7 +196,7 @@ const dmgFormulas = {
         'atk',
         dm.skill.shellDmg,
         'charged',
-        { ...hitEle[ele], ...multiFireAddl },
+        hitEle[ele],
         percent(dm.passive2.dmg),
         'skill'
       )
@@ -209,10 +209,7 @@ const dmgFormulas = {
           'atk',
           dm.skill.shiningShellDmg,
           'charged',
-          {
-            ...hitEle[eleKey],
-            ...shiningAddl,
-          },
+          hitEle[eleKey],
           percent(dm.passive2.dmg),
           'skill'
         )

--- a/libs/gi/sheets/src/Characters/Mavuika/index.tsx
+++ b/libs/gi/sheets/src/Characters/Mavuika/index.tsx
@@ -128,7 +128,7 @@ const burstSpirit = lookup(
 const sunfell_dmgInc = infoMut(
   prod(
     input.total.atk,
-    subscript(input.total.skillIndex, dm.burst.sunfell_dmgInc, { unit: '%' }),
+    subscript(input.total.burstIndex, dm.burst.sunfell_dmgInc, { unit: '%' }),
     burstSpirit
   ),
   { path: 'burst_dmgInc' }
@@ -136,7 +136,7 @@ const sunfell_dmgInc = infoMut(
 const flameNormal_dmgInc = infoMut(
   prod(
     input.total.atk,
-    subscript(input.total.skillIndex, dm.burst.flameNormal_dmgInc, {
+    subscript(input.total.burstIndex, dm.burst.flameNormal_dmgInc, {
       unit: '%',
     }),
     burstSpirit
@@ -146,7 +146,7 @@ const flameNormal_dmgInc = infoMut(
 const flameCharged_dmgInc = infoMut(
   prod(
     input.total.atk,
-    subscript(input.total.skillIndex, dm.burst.flameCharged_dmgInc, {
+    subscript(input.total.burstIndex, dm.burst.flameCharged_dmgInc, {
       unit: '%',
     }),
     burstSpirit


### PR DESCRIPTION
## Describe your changes

* Fix Chasca A1 applying to A4 (verified this is correct behavior in-game)
* Fix Mav burst buff looking at skill level index

## Issue or discord link

- https://discord.com/channels/785153694478893126/1310833666381053962/1320459604567785614
- https://discord.com/channels/785153694478893126/1324288981260697660

## Testing/validation

Burst buff changes based on burst level now
![image](https://github.com/user-attachments/assets/e354b895-37db-4ea7-bf9d-d1ce1a7ae281)
![image](https://github.com/user-attachments/assets/2858f4df-3226-469e-b149-987015c6faa2)

Chasca A4 damage is unaffected by A1 toggle
![image](https://github.com/user-attachments/assets/0c75f89f-b320-4a72-b2e3-1d0b60c0b215)
![image](https://github.com/user-attachments/assets/ceb0e4c2-457e-4bbb-8d56-e0e550f54bc4)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated damage calculation logic for characters Chasca and Mavuika
  - Refined damage increment computations for burst-related abilities
  - Adjusted damage formula parameters to improve accuracy of character damage calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->