### PR TITLE
Add non-stacking buff back to NO4 in a smarter way

### DIFF
--- a/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
@@ -1,7 +1,13 @@
 import type { ArtifactSetKey } from '@genshin-optimizer/gi/consts'
 import type { Data } from '@genshin-optimizer/gi/wr'
-import { equal, greaterEq, input, percent } from '@genshin-optimizer/gi/wr'
-import { cond, st, stg } from '../../SheetUtil'
+import {
+  equalStr,
+  greaterEq,
+  greaterEqStr,
+  input,
+  percent,
+} from '@genshin-optimizer/gi/wr'
+import { cond, nonStackBuff, st, stg } from '../../SheetUtil'
 import { ArtifactSheet, setHeaderTemplate } from '../ArtifactSheet'
 import type { SetEffectSheet } from '../IArtifactSheet'
 import { dataObjForArtifactSheet } from '../dataUtil'
@@ -12,11 +18,12 @@ const setHeader = setHeaderTemplate(key)
 const set2 = greaterEq(input.artSet.NoblesseOblige, 2, percent(0.2))
 
 const [condSet4Path, condSet4] = cond(key, 'set4')
-const set4 = greaterEq(
+const set4TallyWrite = greaterEqStr(
   input.artSet.NoblesseOblige,
   4,
-  equal(condSet4, 'on', percent(0.2))
+  equalStr(condSet4, 'on', input.charKey)
 )
+const [set4, set4Inactive] = nonStackBuff('no4', 'atk_', percent(0.2))
 
 export const data: Data = dataObjForArtifactSheet(key, {
   premod: {
@@ -25,6 +32,9 @@ export const data: Data = dataObjForArtifactSheet(key, {
   teamBuff: {
     premod: {
       atk_: set4,
+    },
+    tally: {
+      no4: set4TallyWrite,
     },
   },
 })
@@ -44,6 +54,9 @@ const sheet: SetEffectSheet = {
             fields: [
               {
                 node: set4,
+              },
+              {
+                node: set4Inactive,
               },
               {
                 text: stg('duration'),

--- a/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
@@ -33,7 +33,7 @@ export const data: Data = dataObjForArtifactSheet(key, {
     premod: {
       atk_: set4,
     },
-    tally: {
+    nonStacking: {
       no4: set4TallyWrite,
     },
   },

--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -99,7 +99,7 @@ export function nonStackBuff(
     unequal(tally[buffName], input.charKey, buffNode, {
       path,
       isTeamBuff: true,
-      subVariant: 'strike',
+      strikethrough: true,
     }),
   ]
 }

--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -5,12 +5,20 @@ import type {
   WeaponKey,
 } from '@genshin-optimizer/gi/consts'
 import { Translate } from '@genshin-optimizer/gi/i18n'
-import type { Info, NumNode, ReadNode, StrNode } from '@genshin-optimizer/gi/wr'
+import type {
+  Info,
+  NonStackBuff,
+  NumNode,
+  ReadNode,
+  StrNode,
+} from '@genshin-optimizer/gi/wr'
 import {
   customStringRead,
   equal,
   infoMut,
   input,
+  tally,
+  unequal,
 } from '@genshin-optimizer/gi/wr'
 import type { ReactNode } from 'react'
 
@@ -78,5 +86,20 @@ export function activeCharBuff(
   return [
     infoMut(node, { ...info, isTeamBuff: true }),
     equal(input.activeCharKey, buffTargetKey, node),
+  ]
+}
+
+export function nonStackBuff(
+  buffName: NonStackBuff,
+  path: string,
+  buffNode: NumNode
+) {
+  return [
+    equal(tally[buffName], input.charKey, buffNode),
+    unequal(tally[buffName], input.charKey, buffNode, {
+      path,
+      isTeamBuff: true,
+      subVariant: 'strike',
+    }),
   ]
 }

--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -17,6 +17,7 @@ import {
   equal,
   infoMut,
   input,
+  nonStacking,
   tally,
   unequal,
 } from '@genshin-optimizer/gi/wr'
@@ -95,8 +96,8 @@ export function nonStackBuff(
   buffNode: NumNode
 ) {
   return [
-    equal(tally[buffName], input.charKey, buffNode),
-    unequal(tally[buffName], input.charKey, buffNode, {
+    equal(nonStacking[buffName], input.charKey, buffNode),
+    unequal(nonStacking[buffName], input.charKey, buffNode, {
       path,
       isTeamBuff: true,
       strikethrough: true,

--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -18,7 +18,6 @@ import {
   infoMut,
   input,
   nonStacking,
-  tally,
   unequal,
 } from '@genshin-optimizer/gi/wr'
 import type { ReactNode } from 'react'

--- a/libs/gi/ui/src/components/FieldDisplay.tsx
+++ b/libs/gi/ui/src/components/FieldDisplay.tsx
@@ -129,7 +129,7 @@ export function NodeFieldDisplay({
     [setFormulaData, data, calcRes]
   )
   if (!calcRes && !compareCalcRes) return null
-  const { multi } = calcRes?.info ?? compareCalcRes?.info ?? {}
+  const { multi, strikethrough } = calcRes?.info ?? compareCalcRes?.info ?? {}
 
   const multiDisplay = multi && <span>{multi}&#215;</span>
   const calcValue = calcRes?.value ?? 0
@@ -198,7 +198,7 @@ export function NodeFieldDisplay({
         gap: 1,
         boxShadow: emphasize ? '0px 0px 0px 2px red inset' : undefined,
         py: 0.25,
-        textDecoration: subVariant === 'strike' ? 'line-through' : undefined,
+        textDecoration: strikethrough ? 'line-through' : undefined,
       }}
       component={component}
     >

--- a/libs/gi/ui/src/components/FieldDisplay.tsx
+++ b/libs/gi/ui/src/components/FieldDisplay.tsx
@@ -198,6 +198,7 @@ export function NodeFieldDisplay({
         gap: 1,
         boxShadow: emphasize ? '0px 0px 0px 2px red inset' : undefined,
         py: 0.25,
+        textDecoration: subVariant === 'strike' ? 'line-through' : undefined,
       }}
       component={component}
     >

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -223,8 +223,7 @@ function computeFormulaDisplay(
   result.formula = (
     <Typography
       sx={{
-        textDecoration:
-          info.strikethrough ? 'line-through' : undefined,
+        textDecoration: info.strikethrough ? 'line-through' : undefined,
       }}
     >
       {components.map((x, i) => (

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -224,7 +224,7 @@ function computeFormulaDisplay(
     <Typography
       sx={{
         textDecoration:
-          info.subVariant === 'strike' ? 'line-through' : undefined,
+          info.strikethrough ? 'line-through' : undefined,
       }}
     >
       {components.map((x, i) => (

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -13,6 +13,7 @@ import {
 import { Translate } from '@genshin-optimizer/gi/i18n'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
 import type { Info, InfoExtra, KeyMapPrefix } from '@genshin-optimizer/gi/wr'
+import { Typography } from '@mui/material'
 import { useContext, type ReactNode } from 'react'
 import { SillyContext } from '../context'
 import { resolveInfo } from './resolveInfo'
@@ -220,11 +221,16 @@ function computeFormulaDisplay(
 
   components.filter((c) => c)
   result.formula = (
-    <>
+    <Typography
+      sx={{
+        textDecoration:
+          info.subVariant === 'strike' ? 'line-through' : undefined,
+      }}
+    >
       {components.map((x, i) => (
         <span key={i}>{x}</span>
       ))}
-    </>
+    </Typography>
   )
 
   return result

--- a/libs/gi/uidata/src/uiData.ts
+++ b/libs/gi/uidata/src/uiData.ts
@@ -29,6 +29,7 @@ import {
   deepNodeClone,
   input,
   mergeData,
+  nonStacking,
   resetData,
   setReadNodeKeys,
   tally,
@@ -537,6 +538,8 @@ export function uiDataForTeam(
     const newNode = customRead(path)
     if (path[0] === 'teamBuff' && path[1] === 'tally')
       newNode.accu = objPathValue(tally, path.slice(2))?.accu
+    if (path[0] === 'teamBuff' && path[1] === 'nonStacking')
+      newNode.accu = objPathValue(nonStacking, path.slice(2))?.accu
     layeredAssignment(customReadNodes, path, newNode)
     return newNode
   }

--- a/libs/gi/wr/src/api.ts
+++ b/libs/gi/wr/src/api.ts
@@ -21,7 +21,7 @@ import type {
 } from '@genshin-optimizer/gi/db'
 import type { ICharacter } from '@genshin-optimizer/gi/good'
 import { getMainStatValue } from '@genshin-optimizer/gi/util'
-import { input, tally } from './formula'
+import { input, nonStacking, tally } from './formula'
 import type { Data, Info, NumNode, ReadNode, StrNode } from './type'
 import { constant, data, infoMut, none, percent, prod, sum } from './utils'
 
@@ -41,7 +41,7 @@ export function inferInfoMut(data: Data, source?: Info['source']): Data {
         | undefined
       if (reference)
         x.info = { ...x.info, ...reference.info, prefix: undefined, source }
-      else if (path[0] !== 'tally')
+      else if (path[0] !== 'tally' && path[0] !== 'nonStacking')
         console.error(
           `Detect ${source} buff into non-existant key path ${path}`
         )
@@ -246,7 +246,13 @@ export function mergeData(data: Data[]): Data {
     if (data.length <= 1) return data[0]
     if (data[0].operation) {
       if (path[0] === 'teamBuff') path = path.slice(1)
-      const base = path[0] === 'tally' ? ((path = path.slice(1)), tally) : input
+      const base =
+        path[0] === 'tally'
+          ? tally
+          : path[0] === 'nonStacking'
+          ? nonStacking
+          : input
+      if (path[0] === 'tally' || path[0] === 'nonStacking') path = path.slice(1)
       /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
       let { accu, type } =
         (objPathValue(base, path) as ReadNode<number | string> | undefined) ??

--- a/libs/gi/wr/src/formula.ts
+++ b/libs/gi/wr/src/formula.ts
@@ -46,6 +46,8 @@ const asConst = true as const,
 
 const allElements = allElementWithPhyKeys
 const allTalents = ['auto', 'skill', 'burst'] as const
+const allNonstackBuffs = ['no4'] as const
+export type NonStackBuff = (typeof allNonstackBuffs)[number]
 const allMoves = [
   'normal',
   'charged',
@@ -578,6 +580,7 @@ const _tally = setReadNodeKeys(
   {
     ...objKeyMap([...allElements, ...allRegionKeys], (_) => read('add')),
     maxEleMas: read('max'),
+    ...objKeyMap(allNonstackBuffs, () => stringRead('small')),
   },
   ['tally']
 )

--- a/libs/gi/wr/src/formula.ts
+++ b/libs/gi/wr/src/formula.ts
@@ -580,7 +580,6 @@ const _tally = setReadNodeKeys(
   {
     ...objKeyMap([...allElements, ...allRegionKeys], (_) => read('add')),
     maxEleMas: read('max'),
-    ...objKeyMap(allNonstackBuffs, () => stringRead('small')),
   },
   ['tally']
 )
@@ -589,6 +588,11 @@ const tally = {
   // Special handling since it's not a `ReadNode`
   ele: sum(...allElements.map((ele) => min(_tally[ele], 1))),
 }
+
+const nonStacking = setReadNodeKeys(
+  objKeyMap(allNonstackBuffs, () => stringRead('small')),
+  ['nonStacking']
+)
 
 /**
  * List of `input` nodes, rearranged to conform to the needs of the
@@ -607,4 +611,4 @@ export const infusionNode = stringPrio(
   input.infusion.overridableSelf
 )
 
-export { common, customBonus, input, tally, target, uiInput }
+export { common, customBonus, input, nonStacking, tally, target, uiInput }

--- a/libs/gi/wr/src/type.d.ts
+++ b/libs/gi/wr/src/type.d.ts
@@ -9,7 +9,7 @@ import type {
   AmplifyingReactionsKey,
   TransformativeReactionsKey,
 } from '@genshin-optimizer/gi/keymap'
-import type { input, uiInput } from './formula'
+import type { input, NonStackBuff, uiInput } from './formula'
 
 export type NumNode =
   | ComputeNode
@@ -180,7 +180,10 @@ interface DynamicNumInput<T = NumNode> {
     [key: string]: DisplaySub
   }
   conditional?: NodeData<T>
-  teamBuff?: Input & { tally?: NodeData<NumNode | StrNode> }
+  teamBuff?: Input & {
+    tally?: NodeData<NumNode>
+    nonStacking?: Record<NonStackBuff, StrNode>
+  }
 }
 export interface NodeData<T = NumNode> {
   [key: string]: typeof key extends 'operation' ? never : NodeData<T> | T

--- a/libs/gi/wr/src/type.d.ts
+++ b/libs/gi/wr/src/type.d.ts
@@ -48,7 +48,7 @@ export type Info = {
   prefix?: KeyMapPrefix
   source?: CharacterSheetKey | WeaponKey | ArtifactSetKey
   variant?: InfoVariant
-  subVariant?: InfoVariant
+  subVariant?: InfoVariant | 'strike'
   asConst?: true
   pivot?: true
   fixed?: number
@@ -179,7 +179,7 @@ interface DynamicNumInput<T = NumNode> {
     [key: string]: DisplaySub
   }
   conditional?: NodeData<T>
-  teamBuff?: Input & { tally?: NodeData }
+  teamBuff?: Input & { tally?: NodeData<NumNode | StrNode> }
 }
 export interface NodeData<T = NumNode> {
   [key: string]: typeof key extends 'operation' ? never : NodeData<T> | T

--- a/libs/gi/wr/src/type.d.ts
+++ b/libs/gi/wr/src/type.d.ts
@@ -48,12 +48,13 @@ export type Info = {
   prefix?: KeyMapPrefix
   source?: CharacterSheetKey | WeaponKey | ArtifactSetKey
   variant?: InfoVariant
-  subVariant?: InfoVariant | 'strike'
+  subVariant?: InfoVariant
   asConst?: true
   pivot?: true
   fixed?: number
   isTeamBuff?: boolean
   multi?: number
+  strikethrough?: boolean
 }
 export type Variant =
   | ElementWithPhyKey


### PR DESCRIPTION
## Describe your changes

Update NO4 to use tally to create a non-stacking buff. Unlike other attempts, this still places the buff in the `teamBuff` namespace, so it renders as a teambuff in all ways that are expected.  
Additionally, it has a proper source defined as one of the characters who is actually providing the buff. When there are multiple sources, the one with the smallest string (I assume sorted alphabetically?) is chosen instead.  
It also renders a strikethrough on the buffs that were disabled to prevent stacking, for better feedback for the user

## Issue or discord link

- Partially resolves #361 

## Testing/validation
Optimized many scenarios around buff being enabled, disabled, enabled many times, etc on different characters. No errors or crashes were seen.

Mavuika is the only one with the buff enabled, 20% atk is given to everyone as expected
![image](https://github.com/user-attachments/assets/99f40399-b6e5-43bd-8e79-c638ef37f599)

Citlali activates the buff, now she is the primary source and Mavuika's is rendered with a strikethrough (to show it is disabled/not stacked). Everyone still receives only a 20% buff
![image](https://github.com/user-attachments/assets/bf960143-fdbf-4cad-ab25-7a41f0c184f5)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for non-stackable artifact set bonuses.
	- Enhanced text display with line-through styling for specific variants.

- **Improvements**
	- Updated type definitions to support more flexible buff and variant handling.
	- Refined artifact set bonus calculation logic.
	- Enhanced data handling capabilities for team buff calculations.

- **Technical Updates**
	- Expanded type safety for team buff and node data structures.
	- Improved error handling and logic clarity in data merging processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->