### PR TITLE
Fixes: Clear TC autocomplete on selection, Allow commas in number inp…

### DIFF
--- a/libs/common/ui/src/components/NumberInputLazy.tsx
+++ b/libs/common/ui/src/components/NumberInputLazy.tsx
@@ -23,9 +23,10 @@ export function NumberInputLazy({
   useEffect(() => {
     setValue(valueProp?.toString())
   }, [valueProp])
+  const normalizedValue = float ? value.replace(',', '.') : value
 
   const saveValue = () => {
-    let num = float ? parseFloat(value) : parseInt(value)
+    let num = float ? parseFloat(normalizedValue) : parseInt(normalizedValue)
     if (isNaN(num)) {
       num = 0
       setValue(num.toString())
@@ -48,7 +49,7 @@ export function NumberInputLazy({
   ) => {
     const val = event.target.value
 
-    if (val.match(float ? /[^0-9.-]/ : /[^0-9-]/)) {
+    if (val.match(float ? /[^0-9.,-]/ : /[^0-9-]/)) {
       return event.preventDefault()
     }
 

--- a/libs/common/ui/src/components/NumberInputLazy.tsx
+++ b/libs/common/ui/src/components/NumberInputLazy.tsx
@@ -23,9 +23,9 @@ export function NumberInputLazy({
   useEffect(() => {
     setValue(valueProp?.toString())
   }, [valueProp])
-  const normalizedValue = float ? value.replace(',', '.') : value
 
   const saveValue = () => {
+    const normalizedValue = float ? value.replace(',', '.') : value
     let num = float ? parseFloat(normalizedValue) : parseInt(normalizedValue)
     if (isNaN(num)) {
       num = 0

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabTheorycraft/ArtifactMainStatAndSetEditor/ArtifactSetsEditor.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabTheorycraft/ArtifactMainStatAndSetEditor/ArtifactSetsEditor.tsx
@@ -47,6 +47,7 @@ export function ArtifactSetsEditor({
           artSetKey={''}
           setArtSetKey={setSet}
           label={'New Artifact Set'}
+          blurOnSelect={true}
           getOptionDisabled={({ key }) =>
             Object.keys(artSet).includes(key as ArtifactSetKey) ||
             !key ||

--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -136,6 +136,8 @@ const InputInvis = styled('input')({
   display: 'none',
 })
 
+const LineBreak = styled('br')()
+
 function getDefaultSlotKey(
   artifactSet?: ArtifactSetKey
 ): Extract<ArtifactSlotKey, 'flower' | 'circlet'> {
@@ -649,6 +651,7 @@ export function ArtifactEditor({
                             >
                               {t('editor.uploadBtn')}
                             </Button>
+                            <LineBreak />
                           </label>
                         </Grid>
                         {shouldShowDevComponents && debugImgs && (
@@ -718,7 +721,6 @@ export function ArtifactEditor({
                 </CardThemed>
               )}
             </Grid>
-
             {/* Right column */}
             <Grid item xs={1} display="flex" flexDirection="column" gap={1}>
               {/* substat selections */}

--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -651,6 +651,7 @@ export function ArtifactEditor({
                             >
                               {t('editor.uploadBtn')}
                             </Button>
+                            {/* https://github.com/frzyc/genshin-optimizer/pull/2597 */}
                             <LineBreak />
                           </label>
                         </Grid>


### PR DESCRIPTION
…uts, Allow ctrl+v on artifact editor

## Describe your changes

- Artifact set Autocomplete on TC page will now clear after selecting an artifact set
- CTRL + V should work on the Artifact Editor modal regardless of where you click
- Allow commas in the number inputs.

## Issue or discord link

[- CTRL+V not working](https://discord.com/channels/785153694478893126/1327301891188850779)

## Testing/validation

- None

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced numeric input handling in the NumberInputLazy component to support more flexible number formats.
	- Added `blurOnSelect` property to ArtifactSetAutocomplete for improved interaction.
	- Introduced a line break in the artifact editor layout.

- **Style**
	- Added a new styled line break component in the artifact editor interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->