### PR TITLE
Fix: Teams Page: Builds with 5 pieces from an artifact set don't get …

### DIFF
--- a/libs/gi/sheets/src/Characters/TravelerPyroF/pyro.tsx
+++ b/libs/gi/sheets/src/Characters/TravelerPyroF/pyro.tsx
@@ -125,7 +125,7 @@ export default function pyro(
         dm.skill.scorchingInstantDmg,
         'skill'
       ),
-      scorchingDmg: dmgNode('atk', dm.skill.scorchingInstantDmg, 'skill'),
+      scorchingDmg: dmgNode('atk', dm.skill.scorchingDmg, 'skill'),
     },
     burst: {
       dmg: dmgNode('atk', dm.burst.dmg, 'burst'),

--- a/libs/gi/ui/src/components/team/TeamCard.tsx
+++ b/libs/gi/ui/src/components/team/TeamCard.tsx
@@ -496,7 +496,7 @@ function ArtifactCard({ artifactData }: { artifactData: ArtifactData }) {
   const { setNum = {}, mains = {} } = artifactData
   const { t } = useTranslation('statKey_gen')
   const processedSetNum = Object.entries(setNum).filter(
-    ([, num]) => num === 2 || num === 4
+    ([, num]) => num === 2 || num === 4 || num === 5
   )
   return (
     <CardThemed

--- a/libs/gi/ui/src/components/team/TeamCard.tsx
+++ b/libs/gi/ui/src/components/team/TeamCard.tsx
@@ -495,9 +495,9 @@ function WeaponCard({ weapon }: { weapon: ICachedWeapon }) {
 function ArtifactCard({ artifactData }: { artifactData: ArtifactData }) {
   const { setNum = {}, mains = {} } = artifactData
   const { t } = useTranslation('statKey_gen')
-  const processedSetNum = Object.entries(setNum).filter(
-    ([, num]) => num === 2 || num === 4 || num === 5
-  )
+  const processedSetNum: [ArtifactSetKey, number][] = Object.entries(setNum)
+    .filter(([, num]) => num > 1)
+    .map(([set, num]) => [set, num < 4 ? 2 : 4])
   return (
     <CardThemed
       bgt="neutral600"


### PR DESCRIPTION
…the same icon as 4 piece builds

## Describe your changes

Added a simple condition so that we display 5 set artifacts
Fixed issue with Pyro traveler multiplier on skill

## Issue or discord link

https://discord.com/channels/785153694478893126/1332125362515218442
https://discord.com/channels/785153694478893126/1332328933538136104

## Testing/validation

![team page fix](https://github.com/user-attachments/assets/550fb758-8253-4f87-b037-b3747196c1f8)
![multiplier](https://github.com/user-attachments/assets/c8810ba5-d3f4-40aa-b43f-e7b56504a8e7)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended artifact set filtering to support a broader range of piece counts in the Team Card component.

- **Bug Fixes**
  - Corrected damage calculation source for scorching damage in the Traveler Pyro character.

- **Style**
  - Minor formatting adjustments to component properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->