### PR TITLE
ZO Add option to clear 4/2p set

### DIFF
--- a/libs/zzz/page-optimize/src/Optimize.tsx
+++ b/libs/zzz/page-optimize/src/Optimize.tsx
@@ -333,6 +333,21 @@ function Set4Selector({
         }
         sx={{ flexGrow: 1 }}
       >
+        <MenuItem
+          onClick={() =>
+            setConstraints(
+              Object.fromEntries(
+                Object.entries(constraints).filter(
+                  ([k, { value }]) =>
+                    !(allDiscSetKeys.includes(k as DiscSetKey) && value === 4)
+                )
+              )
+            )
+          }
+        >
+          No 4-Set
+        </MenuItem>
+
         {allDiscSetKeys.map((d) => (
           <MenuItem
             key={d}
@@ -364,6 +379,20 @@ function Set4Selector({
         }
         sx={{ flexGrow: 1 }}
       >
+        <MenuItem
+          onClick={() =>
+            setConstraints(
+              Object.fromEntries(
+                Object.entries(constraints).filter(
+                  ([k, { value }]) =>
+                    !(allDiscSetKeys.includes(k as DiscSetKey) && value === 2)
+                )
+              )
+            )
+          }
+        >
+          No 2-Set
+        </MenuItem>
         {allDiscSetKeys.map((d) => (
           <MenuItem
             key={d}


### PR DESCRIPTION
## Describe your changes
Add option to remove the forced 4/2 sets in optimize.
![image](https://github.com/user-attachments/assets/55fc5efd-1de3-48b5-915b-abd05e5c369c)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added menu options to deselect 4-set and 2-set constraints in the optimization interface
	- Improved user flexibility by allowing easy removal of specific set requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->