### PR TITLE
Fix PR actions on forks

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -12,8 +12,8 @@ on:
         description: 'Name for the deployment. This will determine the URL. If you choose a name that is already deployed, it will overwrite that deployment.'
         type: string
         default: 'master'
-      repo_name:
-        description: 'Name of the repo to deploy to.'
+      repo_var_name:
+        description: 'Name of the variable on the repo that contains the repo to deploy to.'
         type: string
         required: true
       repo_deploy_secret_name:
@@ -78,7 +78,7 @@ jobs:
           echo ${{inputs.frontend_name}} > frontend_name
           echo ${{inputs.deployment_name}} > deployment_name
           echo ${{inputs.nested_deployments}} > nested_deployments
-          echo ${{inputs.repo_name}} > repo_name
+          echo ${{inputs.repo_var_name}} > repo_var_name
           echo ${{inputs.repo_deploy_secret_name}} > repo_deploy_secret_name
           echo $(git rev-parse HEAD) > ref
       - name: Archive build
@@ -90,6 +90,6 @@ jobs:
             frontend_name
             deployment_name
             nested_deployments
-            repo_name
+            repo_var_name
             repo_deploy_secret_name
             ref

--- a/.github/workflows/build-go-next-pr.yml
+++ b/.github/workflows/build-go-next-pr.yml
@@ -26,6 +26,6 @@ jobs:
     with:
       frontend_name: 'gi-frontend'
       deployment_name: ${{ github.event.number }}
-      repo_name: ${{ vars.PR_REPO }}
+      repo_var_name: 'PR_REPO'
       repo_deploy_secret_name: 'PR_REPO_SSH_KEY'
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/build-go-wr-pr.yml
+++ b/.github/workflows/build-go-wr-pr.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       frontend_name: 'frontend'
       deployment_name: ${{ github.event.number }}
-      repo_name: ${{ vars.PR_REPO }}
+      repo_var_name: 'PR_REPO'
       repo_deploy_secret_name: 'PR_REPO_SSH_KEY'
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/build-sro-pr.yml
+++ b/.github/workflows/build-sro-pr.yml
@@ -25,6 +25,6 @@ jobs:
     with:
       frontend_name: 'sr-frontend'
       deployment_name: ${{ github.event.number }}
-      repo_name: ${{ vars.PR_REPO }}
+      repo_var_name: 'PR_REPO'
       repo_deploy_secret_name: 'PR_REPO_SSH_KEY'
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/build-zo-pr.yml
+++ b/.github/workflows/build-zo-pr.yml
@@ -25,6 +25,6 @@ jobs:
     with:
       frontend_name: 'zzz-frontend'
       deployment_name: ${{ github.event.number }}
-      repo_name: ${{ vars.PR_REPO }}
+      repo_var_name: 'PR_REPO'
       repo_deploy_secret_name: 'PR_REPO_SSH_KEY'
       show_dev_components: ${{ contains(github.event.pull_request.labels.*.name, 'showDevComponents') }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -31,13 +31,13 @@ jobs:
           echo "deployment_name=$(cat frontend_build/deployment_name)" >> $GITHUB_OUTPUT
           echo "frontend_name=$(cat frontend_build/frontend_name)" >> $GITHUB_OUTPUT
           echo "nested_deployments=$(cat frontend_build/nested_deployments)" >> $GITHUB_OUTPUT
-          echo "repo_name=$(cat frontend_build/repo_name)" >> $GITHUB_OUTPUT
+          echo "repo_var_name=$(cat frontend_build/repo_var_name)" >> $GITHUB_OUTPUT
           echo "repo_deploy_secret_name=$(cat frontend_build/repo_deploy_secret_name)" >> $GITHUB_OUTPUT
           echo "ref=$(cat frontend_build/ref)" >> $GITHUB_OUTPUT
       - name: Checkout external gh-pages
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.vars.outputs.repo_name }}
+          repository: ${{ vars[steps.vars.outputs.repo_var_name] }}
           ssh-key: ${{ secrets[steps.vars.outputs.repo_deploy_secret_name] }}
           ref: gh-pages
           path: gh-pages
@@ -83,7 +83,7 @@ jobs:
         id: export-url
         # First line splits the full repo name (frzyc/genshin-optimizer) into $account (frzyc) and $repo (genshin-optimizer)
         run: |
-          IFS=/ read -r account repo <<< ${{ vars.pr_repo }}
+          IFS=/ read -r account repo <<< ${{ vars[steps.vars.outputs.repo_var_name] }}
           echo "url=Deployed ${{ steps.vars.outputs.ref }} to https://$account.github.io/$repo/${{ steps.vars.outputs.deployment_name }}/${{ steps.vars.outputs.frontend_name }} (Takes 3-5 minutes after this completes to be available)" >> $GITHUB_OUTPUT
       - name: Output date
         id: output-date2

--- a/.github/workflows/new-zo-release.yml
+++ b/.github/workflows/new-zo-release.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       frontend_name: 'zzz-frontend'
       deployment_name: ''
-      repo_name: ${{ vars.ZO_REPO}}
+      repo_var_name: 'ZO_REPO'
       repo_deploy_secret_name: 'ZO_REPO_SSH_KEY'
       show_dev_components: false
       nested_deployments: false


### PR DESCRIPTION
## Describe your changes

Fix PR deployments not working on forks because of their inability to access (public) variables.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations across multiple files
	- Renamed input parameter `repo_name` to `repo_var_name` in several workflow files
	- Standardized repository variable references in deployment and build workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->