### PR TITLE
Revert "Add non-stacking buff back to NO4 in a smarter way"

### DIFF
--- a/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/NoblesseOblige/index.tsx
@@ -1,13 +1,7 @@
 import type { ArtifactSetKey } from '@genshin-optimizer/gi/consts'
 import type { Data } from '@genshin-optimizer/gi/wr'
-import {
-  equalStr,
-  greaterEq,
-  greaterEqStr,
-  input,
-  percent,
-} from '@genshin-optimizer/gi/wr'
-import { cond, nonStackBuff, st, stg } from '../../SheetUtil'
+import { equal, greaterEq, input, percent } from '@genshin-optimizer/gi/wr'
+import { cond, st, stg } from '../../SheetUtil'
 import { ArtifactSheet, setHeaderTemplate } from '../ArtifactSheet'
 import type { SetEffectSheet } from '../IArtifactSheet'
 import { dataObjForArtifactSheet } from '../dataUtil'
@@ -18,12 +12,11 @@ const setHeader = setHeaderTemplate(key)
 const set2 = greaterEq(input.artSet.NoblesseOblige, 2, percent(0.2))
 
 const [condSet4Path, condSet4] = cond(key, 'set4')
-const set4TallyWrite = greaterEqStr(
+const set4 = greaterEq(
   input.artSet.NoblesseOblige,
   4,
-  equalStr(condSet4, 'on', input.charKey)
+  equal(condSet4, 'on', percent(0.2))
 )
-const [set4, set4Inactive] = nonStackBuff('no4', 'atk_', percent(0.2))
 
 export const data: Data = dataObjForArtifactSheet(key, {
   premod: {
@@ -32,9 +25,6 @@ export const data: Data = dataObjForArtifactSheet(key, {
   teamBuff: {
     premod: {
       atk_: set4,
-    },
-    nonStacking: {
-      no4: set4TallyWrite,
     },
   },
 })
@@ -54,9 +44,6 @@ const sheet: SetEffectSheet = {
             fields: [
               {
                 node: set4,
-              },
-              {
-                node: set4Inactive,
               },
               {
                 text: stg('duration'),

--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -5,20 +5,12 @@ import type {
   WeaponKey,
 } from '@genshin-optimizer/gi/consts'
 import { Translate } from '@genshin-optimizer/gi/i18n'
-import type {
-  Info,
-  NonStackBuff,
-  NumNode,
-  ReadNode,
-  StrNode,
-} from '@genshin-optimizer/gi/wr'
+import type { Info, NumNode, ReadNode, StrNode } from '@genshin-optimizer/gi/wr'
 import {
   customStringRead,
   equal,
   infoMut,
   input,
-  nonStacking,
-  unequal,
 } from '@genshin-optimizer/gi/wr'
 import type { ReactNode } from 'react'
 
@@ -86,20 +78,5 @@ export function activeCharBuff(
   return [
     infoMut(node, { ...info, isTeamBuff: true }),
     equal(input.activeCharKey, buffTargetKey, node),
-  ]
-}
-
-export function nonStackBuff(
-  buffName: NonStackBuff,
-  path: string,
-  buffNode: NumNode
-) {
-  return [
-    equal(nonStacking[buffName], input.charKey, buffNode),
-    unequal(nonStacking[buffName], input.charKey, buffNode, {
-      path,
-      isTeamBuff: true,
-      strikethrough: true,
-    }),
   ]
 }

--- a/libs/gi/ui/src/components/FieldDisplay.tsx
+++ b/libs/gi/ui/src/components/FieldDisplay.tsx
@@ -129,7 +129,7 @@ export function NodeFieldDisplay({
     [setFormulaData, data, calcRes]
   )
   if (!calcRes && !compareCalcRes) return null
-  const { multi, strikethrough } = calcRes?.info ?? compareCalcRes?.info ?? {}
+  const { multi } = calcRes?.info ?? compareCalcRes?.info ?? {}
 
   const multiDisplay = multi && <span>{multi}&#215;</span>
   const calcValue = calcRes?.value ?? 0
@@ -198,7 +198,6 @@ export function NodeFieldDisplay({
         gap: 1,
         boxShadow: emphasize ? '0px 0px 0px 2px red inset' : undefined,
         py: 0.25,
-        textDecoration: strikethrough ? 'line-through' : undefined,
       }}
       component={component}
     >

--- a/libs/gi/ui/src/util/getCalcDisplay.tsx
+++ b/libs/gi/ui/src/util/getCalcDisplay.tsx
@@ -13,7 +13,6 @@ import {
 import { Translate } from '@genshin-optimizer/gi/i18n'
 import type { CalcResult } from '@genshin-optimizer/gi/uidata'
 import type { Info, InfoExtra, KeyMapPrefix } from '@genshin-optimizer/gi/wr'
-import { Typography } from '@mui/material'
 import { useContext, type ReactNode } from 'react'
 import { SillyContext } from '../context'
 import { resolveInfo } from './resolveInfo'
@@ -221,15 +220,11 @@ function computeFormulaDisplay(
 
   components.filter((c) => c)
   result.formula = (
-    <Typography
-      sx={{
-        textDecoration: info.strikethrough ? 'line-through' : undefined,
-      }}
-    >
+    <>
       {components.map((x, i) => (
         <span key={i}>{x}</span>
       ))}
-    </Typography>
+    </>
   )
 
   return result

--- a/libs/gi/uidata/src/uiData.ts
+++ b/libs/gi/uidata/src/uiData.ts
@@ -29,7 +29,6 @@ import {
   deepNodeClone,
   input,
   mergeData,
-  nonStacking,
   resetData,
   setReadNodeKeys,
   tally,
@@ -538,8 +537,6 @@ export function uiDataForTeam(
     const newNode = customRead(path)
     if (path[0] === 'teamBuff' && path[1] === 'tally')
       newNode.accu = objPathValue(tally, path.slice(2))?.accu
-    if (path[0] === 'teamBuff' && path[1] === 'nonStacking')
-      newNode.accu = objPathValue(nonStacking, path.slice(2))?.accu
     layeredAssignment(customReadNodes, path, newNode)
     return newNode
   }

--- a/libs/gi/wr/src/api.ts
+++ b/libs/gi/wr/src/api.ts
@@ -21,7 +21,7 @@ import type {
 } from '@genshin-optimizer/gi/db'
 import type { ICharacter } from '@genshin-optimizer/gi/good'
 import { getMainStatValue } from '@genshin-optimizer/gi/util'
-import { input, nonStacking, tally } from './formula'
+import { input, tally } from './formula'
 import type { Data, Info, NumNode, ReadNode, StrNode } from './type'
 import { constant, data, infoMut, none, percent, prod, sum } from './utils'
 
@@ -41,7 +41,7 @@ export function inferInfoMut(data: Data, source?: Info['source']): Data {
         | undefined
       if (reference)
         x.info = { ...x.info, ...reference.info, prefix: undefined, source }
-      else if (path[0] !== 'tally' && path[0] !== 'nonStacking')
+      else if (path[0] !== 'tally')
         console.error(
           `Detect ${source} buff into non-existant key path ${path}`
         )
@@ -246,13 +246,7 @@ export function mergeData(data: Data[]): Data {
     if (data.length <= 1) return data[0]
     if (data[0].operation) {
       if (path[0] === 'teamBuff') path = path.slice(1)
-      const base =
-        path[0] === 'tally'
-          ? tally
-          : path[0] === 'nonStacking'
-          ? nonStacking
-          : input
-      if (path[0] === 'tally' || path[0] === 'nonStacking') path = path.slice(1)
+      const base = path[0] === 'tally' ? ((path = path.slice(1)), tally) : input
       /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
       let { accu, type } =
         (objPathValue(base, path) as ReadNode<number | string> | undefined) ??

--- a/libs/gi/wr/src/formula.ts
+++ b/libs/gi/wr/src/formula.ts
@@ -46,8 +46,6 @@ const asConst = true as const,
 
 const allElements = allElementWithPhyKeys
 const allTalents = ['auto', 'skill', 'burst'] as const
-const allNonstackBuffs = ['no4'] as const
-export type NonStackBuff = (typeof allNonstackBuffs)[number]
 const allMoves = [
   'normal',
   'charged',
@@ -589,11 +587,6 @@ const tally = {
   ele: sum(...allElements.map((ele) => min(_tally[ele], 1))),
 }
 
-const nonStacking = setReadNodeKeys(
-  objKeyMap(allNonstackBuffs, () => stringRead('small')),
-  ['nonStacking']
-)
-
 /**
  * List of `input` nodes, rearranged to conform to the needs of the
  * UI code. This is a separate list so that the evolution of the UIs
@@ -611,4 +604,4 @@ export const infusionNode = stringPrio(
   input.infusion.overridableSelf
 )
 
-export { common, customBonus, input, nonStacking, tally, target, uiInput }
+export { common, customBonus, input, tally, target, uiInput }

--- a/libs/gi/wr/src/type.d.ts
+++ b/libs/gi/wr/src/type.d.ts
@@ -9,7 +9,7 @@ import type {
   AmplifyingReactionsKey,
   TransformativeReactionsKey,
 } from '@genshin-optimizer/gi/keymap'
-import type { input, NonStackBuff, uiInput } from './formula'
+import type { input, uiInput } from './formula'
 
 export type NumNode =
   | ComputeNode
@@ -54,7 +54,6 @@ export type Info = {
   fixed?: number
   isTeamBuff?: boolean
   multi?: number
-  strikethrough?: boolean
 }
 export type Variant =
   | ElementWithPhyKey
@@ -180,10 +179,7 @@ interface DynamicNumInput<T = NumNode> {
     [key: string]: DisplaySub
   }
   conditional?: NodeData<T>
-  teamBuff?: Input & {
-    tally?: NodeData<NumNode>
-    nonStacking?: Record<NonStackBuff, StrNode>
-  }
+  teamBuff?: Input & { tally?: NodeData }
 }
 export interface NodeData<T = NumNode> {
   [key: string]: typeof key extends 'operation' ? never : NodeData<T> | T


### PR DESCRIPTION
Reverts frzyc/genshin-optimizer#2592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Removed non-stacking buff handling across multiple components
  - Simplified type definitions and import statements
  - Removed `strikethrough` property from display components

- **Code Cleanup**
  - Streamlined artifact set effect calculations
  - Reduced complexity in data processing functions
  - Eliminated unused type and constant definitions

These changes represent internal optimizations that do not directly impact end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->