### PR TITLE
ZO add advanced Set Filters

### DIFF
--- a/libs/common/util/src/lib/object.ts
+++ b/libs/common/util/src/lib/object.ts
@@ -247,3 +247,26 @@ export function objFindValue<K extends string, V extends string>(
 ): K | undefined {
   return Object.keys(obj).find((k) => obj[k as K] === value) as K | undefined
 }
+
+/**
+ * Returns a new object that is the sum of `a` and `b`
+ */
+export function objSum(
+  a: Record<string, number>,
+  b: Record<string, number>
+): Record<string, number> {
+  const sum = { ...a }
+  for (const k in b) sum[k] = (sum[k] ?? 0) + b[k]
+  return sum
+}
+
+/**
+ * Apply obj `add` to the `base` object
+ */
+export function objSumInPlace(
+  base: Record<string, number>,
+  add: Record<string, number>
+): Record<string, number> {
+  for (const k in add) base[k] = (base[k] ?? 0) + add[k]
+  return base
+}

--- a/libs/zzz/db/src/Database/DataManagers/CharacterDataManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterDataManager.ts
@@ -3,11 +3,13 @@ import { clamp, objFilter, validateArr } from '@genshin-optimizer/common/util'
 import type {
   CharacterKey,
   DiscMainStatKey,
+  DiscSetKey,
   FormulaKey,
   WengineKey,
 } from '@genshin-optimizer/zzz/consts'
 import {
   allCharacterKeys,
+  allDiscSetKeys,
   allFormulaKeys,
   allWengineKeys,
   discSlotToMainStatKeys,
@@ -32,6 +34,8 @@ export type CharacterData = {
   slot6: DiscMainStatKey[]
   levelLow: number
   levelHigh: number
+  setFilter2: DiscSetKey[]
+  setFilter4: DiscSetKey[]
 }
 
 function initialCharacterData(key: CharacterKey): CharacterData {
@@ -53,6 +57,8 @@ function initialCharacterData(key: CharacterKey): CharacterData {
     slot6: [...discSlotToMainStatKeys['6']],
     levelLow: 15,
     levelHigh: 15,
+    setFilter2: [],
+    setFilter4: [],
   }
 }
 export class CharacterDataManager extends DataManager<
@@ -81,6 +87,8 @@ export class CharacterDataManager extends DataManager<
       slot6,
       levelLow,
       levelHigh,
+      setFilter2,
+      setFilter4,
     } = obj as CharacterData
 
     if (!allCharacterKeys.includes(characterKey)) return undefined // non-recoverable
@@ -122,6 +130,10 @@ export class CharacterDataManager extends DataManager<
 
     if (typeof levelHigh !== 'number') levelHigh = 15
     levelHigh = clamp(levelHigh, 0, 15)
+
+    setFilter2 = validateArr(setFilter2, allDiscSetKeys, [])
+    setFilter4 = validateArr(setFilter4, allDiscSetKeys, [])
+
     const char: CharacterData = {
       key: characterKey,
       level,
@@ -137,6 +149,8 @@ export class CharacterDataManager extends DataManager<
       slot6,
       levelLow,
       levelHigh,
+      setFilter2,
+      setFilter4,
     }
     return char
   }

--- a/libs/zzz/page-optimize/src/BuildsDisplay.tsx
+++ b/libs/zzz/page-optimize/src/BuildsDisplay.tsx
@@ -4,7 +4,7 @@ import type { LocationKey } from '@genshin-optimizer/zzz/consts'
 import type { Stats } from '@genshin-optimizer/zzz/db'
 import { useDatabaseContext, useDisc } from '@genshin-optimizer/zzz/db-ui'
 import type { BuildResult } from '@genshin-optimizer/zzz/solver'
-import { convertDiscToStats, getSum } from '@genshin-optimizer/zzz/solver'
+import { applyCalc, convertDiscToStats } from '@genshin-optimizer/zzz/solver'
 import { DiscCard } from '@genshin-optimizer/zzz/ui'
 import { Box, Button, CardContent, Stack, Typography } from '@mui/material'
 import { useCallback, useMemo } from 'react'
@@ -48,7 +48,7 @@ function Build({
   const { database } = useDatabaseContext()
   const sum = useMemo(
     () =>
-      getSum(
+      applyCalc(
         baseStats,
         Object.values(build.discIds)
           .map((d) => database.discs.get(d))

--- a/libs/zzz/page-optimize/src/CharacterContext.ts
+++ b/libs/zzz/page-optimize/src/CharacterContext.ts
@@ -1,0 +1,10 @@
+import type { CharacterData } from '@genshin-optimizer/zzz/db'
+import { createContext, useContext } from 'react'
+
+export const CharacterContext = createContext(
+  undefined as CharacterData | undefined
+)
+
+export function useCharacterContext() {
+  return useContext(CharacterContext)
+}

--- a/libs/zzz/page-optimize/src/LevelFilter.tsx
+++ b/libs/zzz/page-optimize/src/LevelFilter.tsx
@@ -18,7 +18,8 @@ export const LevelFilter = memo(function LevelFilter({
     <CardThemed bgt="light">
       <CardContent sx={{ display: 'flex', gap: 1 }}>
         <Typography sx={{ fontWeight: 'bold' }}>
-          Artifact Level Filter
+          Disc Level Filter
+          {/* TODO: Translate */}
           {/* {t('levelFilter')} */}
         </Typography>
       </CardContent>

--- a/libs/zzz/page-optimize/src/SetFilter.tsx
+++ b/libs/zzz/page-optimize/src/SetFilter.tsx
@@ -1,0 +1,246 @@
+import { useBoolState } from '@genshin-optimizer/common/react-util'
+import {
+  CardThemed,
+  DropdownButton,
+  ModalWrapper,
+} from '@genshin-optimizer/common/ui'
+import { toggleInArr } from '@genshin-optimizer/common/util'
+import type { DiscSetKey } from '@genshin-optimizer/zzz/consts'
+import { allDiscSetKeys } from '@genshin-optimizer/zzz/consts'
+import { useDatabaseContext } from '@genshin-optimizer/zzz/db-ui'
+import { DiscSetName } from '@genshin-optimizer/zzz/ui'
+import CloseIcon from '@mui/icons-material/Close'
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  CardContent,
+  CardHeader,
+  Divider,
+  Grid,
+  IconButton,
+  MenuItem,
+  Typography,
+} from '@mui/material'
+import { useCharacterContext } from './CharacterContext'
+
+export function SetFilter({ disabled = false }: { disabled?: boolean }) {
+  const { database } = useDatabaseContext()
+  const [open, onOpen, onClose] = useBoolState()
+  const character = useCharacterContext()
+  const {
+    setFilter2 = [],
+    setFilter4 = [],
+    key: characterKey,
+  } = character ?? {}
+  return (
+    <CardThemed bgt="light">
+      <ModalWrapper open={open} onClose={onClose}>
+        <AdvSetFilterCard onClose={onClose} />
+      </ModalWrapper>
+      <CardContent sx={{ display: 'flex', gap: 1 }}>
+        <Box
+          sx={{ flexGrow: 1, display: 'flex', gap: 1, flexDirection: 'column' }}
+        >
+          {setFilter4.length <= 1 ? (
+            <DropdownButton
+              disabled={disabled}
+              title={
+                setFilter4[0] ? (
+                  <span>
+                    Force 4-Set:{' '}
+                    <strong>
+                      <DiscSetName setKey={setFilter4[0]} />
+                    </strong>
+                  </span>
+                ) : (
+                  'Select to force 4-Set'
+                )
+              }
+              sx={{ flexGrow: 1 }}
+            >
+              <MenuItem
+                onClick={() =>
+                  characterKey &&
+                  database.chars.set(characterKey, {
+                    setFilter4: [],
+                  })
+                }
+              >
+                No 4-Set
+              </MenuItem>
+
+              {allDiscSetKeys.map((d) => (
+                <MenuItem
+                  key={d}
+                  onClick={() =>
+                    characterKey &&
+                    database.chars.set(characterKey, {
+                      setFilter4: [d],
+                    })
+                  }
+                >
+                  <DiscSetName setKey={d} />
+                </MenuItem>
+              ))}
+            </DropdownButton>
+          ) : (
+            <Typography>{setFilter4.length} Disc Set 4p selected</Typography>
+          )}
+
+          {setFilter2.length <= 1 ? (
+            <DropdownButton
+              disabled={disabled}
+              title={
+                setFilter2[0] ? (
+                  <span>
+                    Force 2-Set:{' '}
+                    <strong>
+                      <DiscSetName setKey={setFilter2[0]} />
+                    </strong>
+                  </span>
+                ) : (
+                  'Select to force 2-Set'
+                )
+              }
+              sx={{ flexGrow: 1 }}
+            >
+              <MenuItem
+                onClick={() =>
+                  characterKey &&
+                  database.chars.set(characterKey, {
+                    setFilter2: [],
+                  })
+                }
+              >
+                No 2-Set
+              </MenuItem>
+
+              {allDiscSetKeys.map((d) => (
+                <MenuItem
+                  key={d}
+                  onClick={() =>
+                    characterKey &&
+                    database.chars.set(characterKey, {
+                      setFilter2: [d],
+                    })
+                  }
+                >
+                  <DiscSetName setKey={d} />
+                </MenuItem>
+              ))}
+            </DropdownButton>
+          ) : (
+            <Typography>{setFilter2.length} Disc Set 2p selected</Typography>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'stretch' }}>
+          <Button disabled={disabled} onClick={onOpen} color="info">
+            Advanced Set-Filter Config
+          </Button>
+        </Box>
+      </CardContent>
+    </CardThemed>
+  )
+}
+function AdvSetFilterCard({ onClose }: { onClose: () => void }) {
+  const { database } = useDatabaseContext()
+  const character = useCharacterContext()
+  const {
+    setFilter2 = [],
+    setFilter4 = [],
+    key: characterKey,
+  } = character ?? {}
+  return (
+    <CardThemed>
+      <CardHeader
+        title="Advanced Set-Filter Config"
+        action={
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        }
+      />
+      <Divider />
+      <CardContent>
+        <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+          <Button
+            disabled={!setFilter4.length}
+            onClick={() =>
+              characterKey &&
+              database.chars.set(characterKey, { setFilter4: [] })
+            }
+          >
+            Reset 4p filter
+          </Button>
+          <Button
+            disabled={!setFilter2.length}
+            onClick={() =>
+              characterKey &&
+              database.chars.set(characterKey, { setFilter2: [] })
+            }
+          >
+            Reset 2p filter
+          </Button>
+        </Box>
+        <Grid container spacing={1}>
+          {allDiscSetKeys.map((d) => (
+            <Grid item key={d} xs={1} md={2} lg={3}>
+              <AdvSetFilterDiscCard setKey={d} />
+            </Grid>
+          ))}
+        </Grid>
+      </CardContent>
+    </CardThemed>
+  )
+}
+function AdvSetFilterDiscCard({ setKey }: { setKey: DiscSetKey }) {
+  const { database } = useDatabaseContext()
+  const character = useCharacterContext()
+  const {
+    setFilter2 = [],
+    setFilter4 = [],
+    key: characterKey,
+  } = character ?? {}
+  return (
+    <CardThemed bgt="light">
+      <CardHeader title={<DiscSetName setKey={setKey} />} />
+      <ButtonGroup fullWidth>
+        <Button
+          color={
+            !setFilter4.length || setFilter4.includes(setKey)
+              ? 'success'
+              : 'secondary'
+          }
+          onClick={() =>
+            characterKey &&
+            database.chars.set(characterKey, {
+              setFilter4: setFilter4.length
+                ? toggleInArr([...setFilter4], setKey)
+                : [setKey],
+            })
+          }
+        >
+          Allow 4p
+        </Button>
+        <Button
+          color={
+            !setFilter2.length || setFilter2.includes(setKey)
+              ? 'success'
+              : 'secondary'
+          }
+          onClick={() =>
+            characterKey &&
+            database.chars.set(characterKey, {
+              setFilter2: setFilter2.length
+                ? toggleInArr([...setFilter2], setKey)
+                : [setKey],
+            })
+          }
+        >
+          Allow 2p
+        </Button>
+      </ButtonGroup>
+    </CardThemed>
+  )
+}

--- a/libs/zzz/page-optimize/src/SetFilter.tsx
+++ b/libs/zzz/page-optimize/src/SetFilter.tsx
@@ -20,7 +20,6 @@ import {
   Grid,
   IconButton,
   MenuItem,
-  Typography,
 } from '@mui/material'
 import { useCharacterContext } from './CharacterContext'
 
@@ -85,7 +84,11 @@ export function SetFilter({ disabled = false }: { disabled?: boolean }) {
               ))}
             </DropdownButton>
           ) : (
-            <Typography>{setFilter4.length} Disc Set 4p selected</Typography>
+            <Button disabled>
+              <span>
+                <strong>{setFilter4.length}</strong> Disc 4p-set Selected
+              </span>
+            </Button>
           )}
 
           {setFilter2.length <= 1 ? (
@@ -131,7 +134,11 @@ export function SetFilter({ disabled = false }: { disabled?: boolean }) {
               ))}
             </DropdownButton>
           ) : (
-            <Typography>{setFilter2.length} Disc Set 2p selected</Typography>
+            <Button disabled>
+              <span>
+                <strong>{setFilter2.length}</strong> Disc 2p-set Selected
+              </span>
+            </Button>
           )}
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'stretch' }}>

--- a/libs/zzz/page-optimize/src/index.tsx
+++ b/libs/zzz/page-optimize/src/index.tsx
@@ -32,6 +32,7 @@ import { Stack } from '@mui/system'
 import { useCallback, useMemo, useState } from 'react'
 import BaseStatCard from './BaseStatCard'
 import { BuildsDisplay } from './BuildsDisplay'
+import { CharacterContext } from './CharacterContext'
 import OptimizeWrapper from './Optimize'
 import { OptimizeTargetSelector } from './OptimizeTargetSelector'
 import { StatsDisplay } from './StatsDisplay'
@@ -82,116 +83,124 @@ export default function PageOptimize() {
   )
 
   return (
-    <Box display="flex" flexDirection="column" gap={1} my={1}>
-      <CardThemed>
-        <CardContent>
-          <Stack spacing={1}>
-            <Typography variant="h6">Character</Typography>
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              <LocationAutocomplete
-                locKey={locationKey}
-                setLocKey={(lk) => {
-                  setLocationKey(lk)
-                  setBuilds([])
-                }}
-                sx={{ flexGrow: 1 }}
-                autoFocus
-              />
+    <CharacterContext.Provider value={character}>
+      <Box display="flex" flexDirection="column" gap={1} my={1}>
+        <CardThemed>
+          <CardContent>
+            <Stack spacing={1}>
+              <Typography variant="h6">Character</Typography>
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                <LocationAutocomplete
+                  locKey={locationKey}
+                  setLocKey={(lk) => {
+                    setLocationKey(lk)
+                    setBuilds([])
+                  }}
+                  sx={{ flexGrow: 1 }}
+                  autoFocus
+                />
 
-              <NumberInputLazy
-                disabled={!character}
-                value={character?.level ?? 60}
-                onChange={(l) =>
-                  l !== undefined &&
-                  character &&
-                  database.chars.set(character.key, { level: l })
-                }
-                size="small"
-                inputProps={{
-                  sx: { width: '2ch' },
-                  max: 60,
-                  min: 1,
-                }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">Lv.</InputAdornment>
-                  ),
-                }}
-              />
+                <NumberInputLazy
+                  disabled={!character}
+                  value={character?.level ?? 60}
+                  onChange={(l) =>
+                    l !== undefined &&
+                    character &&
+                    database.chars.set(character.key, { level: l })
+                  }
+                  size="small"
+                  inputProps={{
+                    sx: { width: '2ch' },
+                    max: 60,
+                    min: 1,
+                  }}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">Lv.</InputAdornment>
+                    ),
+                  }}
+                />
 
-              <DropdownButton
-                title={`Core: ${allCoreKeysWithNone[character?.core ?? 0]}`}
+                <DropdownButton
+                  title={`Core: ${allCoreKeysWithNone[character?.core ?? 0]}`}
+                  disabled={!character}
+                >
+                  {allCoreKeysWithNone.map((n, i) => (
+                    <MenuItem
+                      key={n}
+                      onClick={() =>
+                        character &&
+                        database.chars.set(character.key, { core: i })
+                      }
+                    >
+                      {n}
+                    </MenuItem>
+                  ))}
+                </DropdownButton>
+              </Box>
+              {characterStats && (
+                <StatsDisplay stats={characterStats} showBase />
+              )}
+              <OptimizeTargetSelector
                 disabled={!character}
-              >
-                {allCoreKeysWithNone.map((n, i) => (
-                  <MenuItem
-                    key={n}
-                    onClick={() =>
-                      character &&
-                      database.chars.set(character.key, { core: i })
-                    }
-                  >
-                    {n}
-                  </MenuItem>
-                ))}
-              </DropdownButton>
-            </Box>
-            {characterStats && <StatsDisplay stats={characterStats} showBase />}
-            <OptimizeTargetSelector
-              disabled={!character}
-              formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
-              setFormulaKey={setFormulaKey}
-            />
-            <Typography variant="h6">Wengine</Typography>
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              <WengineAutocomplete
-                disabled={!character}
-                wkey={character?.wengineKey ?? ''}
-                setWKey={(wk) =>
-                  wk &&
-                  character &&
-                  database.chars.set(character.key, { wengineKey: wk })
-                }
-                sx={{ flexGrow: 1 }}
-                autoFocus
+                formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
+                setFormulaKey={setFormulaKey}
               />
-              <NumberInputLazy
-                disabled={!character}
-                value={character?.wengineLvl ?? 60}
-                onChange={(l) =>
-                  l !== undefined &&
-                  character &&
-                  database.chars.set(character.key, { wengineLvl: l })
-                }
-                size="small"
-                inputProps={{
-                  sx: { width: '2ch' },
-                  max: 60,
-                  min: 1,
-                }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">Lv.</InputAdornment>
-                  ),
-                }}
-              />
-            </Box>
-            {wengineStats && <StatsDisplay stats={wengineStats} showBase />}
-          </Stack>
-        </CardContent>
-      </CardThemed>
-      <BaseStatCard
-        locationKey={locationKey}
-        baseStats={character?.stats ?? {}}
-        setBaseStats={setStats}
-      />
-      <OptimizeWrapper
-        setResults={setBuilds}
-        baseStats={baseStats}
-        location={locationKey}
-        formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
-      />
-      <BuildsDisplay builds={builds} stats={baseStats} location={locationKey} />
-    </Box>
+              <Typography variant="h6">Wengine</Typography>
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                <WengineAutocomplete
+                  disabled={!character}
+                  wkey={character?.wengineKey ?? ''}
+                  setWKey={(wk) =>
+                    wk &&
+                    character &&
+                    database.chars.set(character.key, { wengineKey: wk })
+                  }
+                  sx={{ flexGrow: 1 }}
+                  autoFocus
+                />
+                <NumberInputLazy
+                  disabled={!character}
+                  value={character?.wengineLvl ?? 60}
+                  onChange={(l) =>
+                    l !== undefined &&
+                    character &&
+                    database.chars.set(character.key, { wengineLvl: l })
+                  }
+                  size="small"
+                  inputProps={{
+                    sx: { width: '2ch' },
+                    max: 60,
+                    min: 1,
+                  }}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">Lv.</InputAdornment>
+                    ),
+                  }}
+                />
+              </Box>
+              {wengineStats && <StatsDisplay stats={wengineStats} showBase />}
+            </Stack>
+          </CardContent>
+        </CardThemed>
+        <BaseStatCard
+          locationKey={locationKey}
+          baseStats={character?.stats ?? {}}
+          setBaseStats={setStats}
+        />
+        <OptimizeWrapper
+          setResults={setBuilds}
+          baseStats={baseStats}
+          location={locationKey}
+          formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
+        />
+        <BuildsDisplay
+          builds={builds}
+          stats={baseStats}
+          location={locationKey}
+        />
+      </Box>
+    </CharacterContext.Provider>
   )
 }

--- a/libs/zzz/solver/src/calc.ts
+++ b/libs/zzz/solver/src/calc.ts
@@ -42,7 +42,7 @@ export function passSetFilter(
       const k = key as DiscSetKey
       const val = setCount[k]!
       if (val === 1) return false // Rainbow
-      if (val >= 2 && val < 4 && !filter4.includes(k)) return false
+      if (val >= 2 && val < 4 && !filter2.includes(k)) return false
     }
   }
   return true

--- a/libs/zzz/solver/src/childWorker.ts
+++ b/libs/zzz/solver/src/childWorker.ts
@@ -13,7 +13,7 @@ let discStatsBySlot: Record<DiscSlotKey, DiscStats[]>
 let constraints: Constraints
 let baseStats: Stats
 let formulaKey: FormulaKey
-let SetFilter2p: DiscSetKey[]
+let setFilter2p: DiscSetKey[]
 let setFilter4p: DiscSetKey[]
 
 export interface ChildCommandInit {
@@ -91,7 +91,7 @@ async function init({
   discStatsBySlot = discs
   constraints = initCons
   formulaKey = fk
-  SetFilter2p = setFilter2
+  setFilter2p = setFilter2
   setFilter4p = setFilter4
 
   // Let parent know we are ready to optimize
@@ -158,7 +158,7 @@ async function start() {
 
     const discs = [d1, d2, d3, d4, d5, d6]
     // 1. Filter using set filter
-    if (!passSetFilter(discs, SetFilter2p, setFilter4p)) {
+    if (!passSetFilter(discs, setFilter2p, setFilter4p)) {
       // Skip early due to failing set filter
       skipped++
       continue

--- a/libs/zzz/solver/src/childWorker.ts
+++ b/libs/zzz/solver/src/childWorker.ts
@@ -1,6 +1,10 @@
-import type { DiscSlotKey, FormulaKey } from '@genshin-optimizer/zzz/consts'
+import type {
+  DiscSetKey,
+  DiscSlotKey,
+  FormulaKey,
+} from '@genshin-optimizer/zzz/consts'
 import type { Constraints, Stats } from '@genshin-optimizer/zzz/db'
-import { calcFormula, getSum } from './calc'
+import { applyCalc, calcFormula, passSetFilter } from './calc'
 import type { BuildResult, DiscStats } from './common'
 import { MAX_BUILDS } from './common'
 
@@ -9,6 +13,8 @@ let discStatsBySlot: Record<DiscSlotKey, DiscStats[]>
 let constraints: Constraints
 let baseStats: Stats
 let formulaKey: FormulaKey
+let SetFilter2p: DiscSetKey[]
+let setFilter4p: DiscSetKey[]
 
 export interface ChildCommandInit {
   command: 'init'
@@ -16,6 +22,8 @@ export interface ChildCommandInit {
   discStatsBySlot: Record<DiscSlotKey, DiscStats[]>
   constraints: Constraints
   formulaKey: FormulaKey
+  setFilter2: DiscSetKey[] // [] means rainbow
+  setFilter4: DiscSetKey[] // [] means rainbow
 }
 export interface ChildCommandStart {
   command: 'start'
@@ -76,11 +84,15 @@ async function init({
   discStatsBySlot: discs,
   constraints: initCons,
   formulaKey: fk,
+  setFilter2,
+  setFilter4,
 }: ChildCommandInit) {
   baseStats = bs
   discStatsBySlot = discs
   constraints = initCons
   formulaKey = fk
+  SetFilter2p = setFilter2
+  setFilter4p = setFilter4
 
   // Let parent know we are ready to optimize
   postMessage({ resultType: 'initialized' })
@@ -135,13 +147,32 @@ async function start() {
   }
   const constraintArr = Object.entries(constraints)
   for (const { d1, d2, d3, d4, d5, d6 } of generateCombinations()) {
-    const sum = getSum(baseStats, [d1, d2, d3, d4, d5, d6])
+    /**
+     * Calculation takes several steps:
+     * 1. `passSetFilter()` filtering 2/4p effects
+     * 2. `applyCalc()` sum up stats from base + discs + 2p effects
+     * 3. filter using constraints
+     * 4. `calcFormula()` calculate final value of target
+     * 5. return build with calculated value.
+     */
+
+    const discs = [d1, d2, d3, d4, d5, d6]
+    // 1. Filter using set filter
+    if (!passSetFilter(discs, SetFilter2p, setFilter4p)) {
+      // Skip early due to failing set filter
+      skipped++
+      continue
+    }
+    // 2. Calculate base stats.
+    const sum = applyCalc(baseStats, discs)
+    // 3Filter using constraints
     if (
       constraintArr.every(([k, { value, isMax }]) =>
         isMax ? sum[k] <= value : sum[k] >= value
       )
     ) {
       builds.push({
+        // 4. Calculate final value
         value: calcFormula(sum, formulaKey),
         discIds: {
           1: d1.id,

--- a/libs/zzz/solver/src/common.ts
+++ b/libs/zzz/solver/src/common.ts
@@ -1,3 +1,4 @@
+import type { DiscSetKey } from '@genshin-optimizer/zzz/consts'
 import {
   getDiscMainStatVal,
   getDiscSubStatBaseVal,
@@ -10,6 +11,7 @@ export const MAX_BUILDS = 50_000
 export type DiscStats = {
   id: string
   stats: Record<string, number>
+  setKey: DiscSetKey
 }
 
 export interface BuildResult {
@@ -38,7 +40,7 @@ export function convertDiscToStats(disc: ICachedDisc): DiscStats {
           getDiscSubStatBaseVal(key, rarity) * upgrades,
         ])
       ),
-      [setKey]: 1,
     },
+    setKey,
   }
 }

--- a/libs/zzz/solver/src/parentWorker.ts
+++ b/libs/zzz/solver/src/parentWorker.ts
@@ -1,5 +1,5 @@
 import { objKeyMap, range } from '@genshin-optimizer/common/util'
-import type { FormulaKey } from '@genshin-optimizer/zzz/consts'
+import type { DiscSetKey, FormulaKey } from '@genshin-optimizer/zzz/consts'
 import {
   allDiscSlotKeys,
   type DiscSlotKey,
@@ -16,6 +16,8 @@ export interface ParentCommandStart {
   command: 'start'
   baseStats: Stats
   constraints: Constraints
+  setFilter2: DiscSetKey[] // [] means rainbow
+  setFilter4: DiscSetKey[] // [] means rainbow
   // lightCones: ICachedLightCone[]
   discsBySlot: Record<DiscSlotKey, ICachedDisc[]>
   // detachedNodes: NumTagFree[]
@@ -81,6 +83,8 @@ async function start({
   baseStats,
   discsBySlot,
   constraints,
+  setFilter2,
+  setFilter4,
   numWorkers,
   formulaKey,
 }: ParentCommandStart) {
@@ -180,6 +184,8 @@ async function start({
           discStatsBySlot: chunkedDiscStatsBySlot[index],
           constraints,
           formulaKey,
+          setFilter2,
+          setFilter4,
         }
         worker.postMessage(message)
       })

--- a/libs/zzz/solver/src/solver.ts
+++ b/libs/zzz/solver/src/solver.ts
@@ -1,4 +1,8 @@
-import type { DiscSlotKey, FormulaKey } from '@genshin-optimizer/zzz/consts'
+import type {
+  DiscSetKey,
+  DiscSlotKey,
+  FormulaKey,
+} from '@genshin-optimizer/zzz/consts'
 import type { Constraints, ICachedDisc, Stats } from '@genshin-optimizer/zzz/db'
 import type { BuildResult } from './common'
 import type {
@@ -20,11 +24,15 @@ export class Solver {
   private numWorkers: number
   private setProgress: (progress: ProgressResult) => void
   private worker: Worker
+  private setFilter2: DiscSetKey[] // [] means rainbow
+  private setFilter4: DiscSetKey[] // [] means rainbow
 
   constructor(
     formulaKey: FormulaKey,
     baseStats: Stats,
     constraints: Constraints,
+    setFilter2: DiscSetKey[], // [] means rainbow
+    setFilter4: DiscSetKey[], // [] means rainbow
     discsBySlot: Record<DiscSlotKey, ICachedDisc[]>,
     numWorkers: number,
     setProgress: (progress: ProgressResult) => void
@@ -35,6 +43,8 @@ export class Solver {
     this.discsBySlot = discsBySlot
     this.numWorkers = numWorkers
     this.setProgress = setProgress
+    this.setFilter2 = setFilter2
+    this.setFilter4 = setFilter4
 
     // Spawn a parent worker to compile nodes, split/filter discs and spawn child workers for calculating results
     this.worker = new Worker(new URL('./parentWorker.ts', import.meta.url), {
@@ -70,6 +80,8 @@ export class Solver {
         constraints: this.constraints,
         numWorkers: this.numWorkers,
         formulaKey: this.formulaKey,
+        setFilter2: this.setFilter2,
+        setFilter4: this.setFilter4,
       }
       this.worker.postMessage(message)
     })


### PR DESCRIPTION
## Describe your changes
Adds a set filter:
- Default: `[]` any (any set/rainbow)
- User can quick select a set: `[setKey]` (disable rainbow, only builds with the set result)
- User can select multiple sets `[...setKey, ...]` (disable rainbow, only builds with those sets result)

Add a new stage in solver. Builds that fail the set filters gets eliminated. 
This should drastically increase build speed upon using the filter.
<!--- Provide a general summary of your changes -->

## Issue or discord link

- Resolves #2653

## Testing/validation
Using the "quick UI" to select a set
![image](https://github.com/user-attachments/assets/a5914ffa-5678-4f21-bc39-c9bf3806a1c1)
Using the "Advanced UI" to select multiple sets
![image](https://github.com/user-attachments/assets/1f8ac129-ea69-4cbc-bbb9-aa7a556ddb0f)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
