### PR TITLE
Fix: Citlali C2 buff not appearing in team settings for A1

### DIFF
--- a/libs/gi/sheets/src/Characters/Citlali/index.tsx
+++ b/libs/gi/sheets/src/Characters/Citlali/index.tsx
@@ -500,6 +500,7 @@ const sheet: TalentSheet = {
     }),
     ct.headerTem('constellation2', {
       canShow: equal(condA1NsFreezeMelt, 'on', 1),
+      teamBuff: true,
       fields: [
         {
           node: c2NsFreezeMelt_pyro_enemyRes_,


### PR DESCRIPTION
## Describe your changes

- Resolves issue with Citlali C2 buff not appearing in Team settings

## Issue or discord link

- https://discord.com/channels/785153694478893126/1335401702139891825

## Testing/validation

![image](https://github.com/user-attachments/assets/71c5136b-7cd9-4339-bbde-27fa38c584c0)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
