### PR TITLE
Unify Pando's custom operation specification

### DIFF
--- a/libs/gi/formula/src/calculator.ts
+++ b/libs/gi/formula/src/calculator.ts
@@ -26,10 +26,6 @@ export type PartialMeta = {
 type Info = { conds: CondInfo }
 
 export class Calculator extends Base<CalcMeta> {
-  override computeCustom(val: any[], op: string): any {
-    if (op == 'res') return res(val[0])
-    return super.computeCustom(val, op)
-  }
   override computeMeta(
     { op, ex }: AnyNode,
     val: number | string,
@@ -128,11 +124,6 @@ export class Calculator extends Base<CalcMeta> {
   toDebug(): DebugCalculator {
     return new DebugCalculator(this, tagStr)
   }
-}
-export function res(x: number): number {
-  if (x >= 0.75) return 1 / (1 + 4 * x)
-  if (x >= 0) return 1 - x
-  return 1 - 0.5 * x
 }
 
 function extract<V>(

--- a/libs/gi/formula/src/example.test.ts
+++ b/libs/gi/formula/src/example.test.ts
@@ -238,13 +238,7 @@ describe('example', () => {
       detached,
       'q', // Tag category for object key
       2, // Number of slots
-      {}, // Initial values
-      // Header; includes custom formulas, such as `res`
-      `function res(res) {
-      if (res < 0) return 1 - res / 2
-      else if (res >= 0.75) return 1 / (res * 4 + 1)
-      return 1 - res
-    }`
+      {} // Initial values
     )
 
     // Step 5: Calculate the value

--- a/libs/gi/formula/src/index.ts
+++ b/libs/gi/formula/src/index.ts
@@ -27,7 +27,7 @@ export * from './util'
   }
   addCustomOperation('res', {
     range: ([r]) => ({ min: calc([r.max]), max: calc([r.min]) }),
-    tonicity: (_) => [{ inc: false, dec: true }],
+    monotonicity: (_) => [{ inc: false, dec: true }],
     calc,
   })
 }

--- a/libs/gi/formula/src/index.ts
+++ b/libs/gi/formula/src/index.ts
@@ -4,9 +4,9 @@ import type {
   TagMapEntries,
 } from '@genshin-optimizer/pando/engine'
 import {
+  addCustomOperation,
   compileTagMapValues,
   constant,
-  setCustomFormula,
 } from '@genshin-optimizer/pando/engine'
 import { Calculator } from './calculator'
 import { keys, values } from './data'
@@ -25,7 +25,7 @@ export * from './util'
     if (x >= 0) return 1 - x
     return 1 - 0.5 * x
   }
-  setCustomFormula('res', {
+  addCustomOperation('res', {
     range: ([r]) => ({ min: calc([r.max]), max: calc([r.min]) }),
     tonicity: (_) => [{ inc: false, dec: true }],
     calc,

--- a/libs/gi/formula/src/index.ts
+++ b/libs/gi/formula/src/index.ts
@@ -3,7 +3,11 @@ import type {
   ReRead,
   TagMapEntries,
 } from '@genshin-optimizer/pando/engine'
-import { compileTagMapValues, constant } from '@genshin-optimizer/pando/engine'
+import {
+  compileTagMapValues,
+  constant,
+  setCustomFormula,
+} from '@genshin-optimizer/pando/engine'
 import { Calculator } from './calculator'
 import { keys, values } from './data'
 export { Calculator } from './calculator'
@@ -12,6 +16,21 @@ export * from './data/util'
 export * from './formulaText'
 export * from './meta'
 export * from './util'
+
+{
+  // Hook the custom formula at once the beginning
+  const calc = (args: (number | string)[]): number => {
+    const x = args[0] as number
+    if (x >= 0.75) return 1 / (1 + 4 * x)
+    if (x >= 0) return 1 - x
+    return 1 - 0.5 * x
+  }
+  setCustomFormula('res', {
+    range: ([r]) => ({ min: calc([r.max]), max: calc([r.min]) }),
+    tonicity: (_) => [{ inc: false, dec: true }],
+    calc,
+  })
+}
 
 export function genshinCalculatorWithValues(extras: TagMapEntries<number>) {
   return genshinCalculatorWithEntries(

--- a/libs/pando/engine/README.md
+++ b/libs/pando/engine/README.md
@@ -122,5 +122,6 @@ Functions that are designed to be overriden by such subclasses include
     x: (CalcResult<number | string, M> | undefined)[],
     br: CalcResult<number | string, M>[],
     tag: Tag | undefined): M
-- computeCustom(args: (number | string)[], op: string): any
 ```
+
+For custom operations, add the appropriate information using `addCustomOperation` once at the start of the program.

--- a/libs/pando/engine/src/debug.ts
+++ b/libs/pando/engine/src/debug.ts
@@ -17,14 +17,12 @@ export type DebugMeta = {
 }
 export class DebugCalculator extends BaseCalculator<DebugMeta> {
   tagStr: TagStr
-  custom: typeof this.computeCustom
   gathering = new Set<TagCache<DebugMeta>>()
 
   constructor(calc: BaseCalculator<any>, tagStr: TagStr) {
     super(calc.cache.keys)
     this.nodes = calc.nodes
     this.tagStr = tagStr
-    this.custom = calc.computeCustom
     this.cache = this.cache.with(calc.cache.tag)
   }
   override withTag(_tag: Tag): this {
@@ -113,10 +111,6 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
       result.deps = x.map((x) => x!.meta)
     }
     return result
-  }
-
-  override computeCustom(args: (number | string)[], op: string): any {
-    return this.custom(args, op)
   }
 }
 

--- a/libs/pando/engine/src/index.ts
+++ b/libs/pando/engine/src/index.ts
@@ -1,4 +1,4 @@
 export * from './debug'
 export * from './node'
 export * from './tag'
-export { setDebugMode } from './util'
+export { addCustomOperation, setDebugMode } from './util'

--- a/libs/pando/engine/src/node/calc.ts
+++ b/libs/pando/engine/src/node/calc.ts
@@ -5,7 +5,13 @@ import {
   TagMapKeys,
   TagMapSubsetValues,
 } from '../tag'
-import { assertUnreachable, extract, isDebug, tagString } from '../util'
+import {
+  assertUnreachable,
+  customOps,
+  extract,
+  isDebug,
+  tagString,
+} from '../util'
 import { arithmetic, branching } from './formula'
 import type { AnyNode, BaseRead, NumNode, ReRead, StrNode } from './type'
 
@@ -131,7 +137,7 @@ export class Calculator<M = any> {
       }
       case 'custom': {
         const x = n.x.map((n) => this._compute(n, cache))
-        return finalize(this.computeCustom(getV(x), n.ex), x, [])
+        return finalize(customOps[n.ex].calc(getV(x)), x, [])
       }
       default:
         assertUnreachable(op)
@@ -144,9 +150,6 @@ export class Calculator<M = any> {
     result: CalcResult<number | string, M>
   ): CalcResult<number | string, M> {
     return result
-  }
-  computeCustom(_: (number | string)[], op: string): any {
-    throw new Error(`Unsupported custom node ${op} in Calculator`)
   }
   computeMeta(
     _n: AnyNode,

--- a/libs/pando/engine/src/node/optimization.ts
+++ b/libs/pando/engine/src/node/optimization.ts
@@ -355,7 +355,7 @@ export function compile(
   let i = 1,
     body = `'use strict';const x0=0` // making sure `const` has at least one entry
   for (const [name, f] of Object.entries(customOps))
-    body += `,${name}=${f.calc.toString()};`
+    body += `,${name}=${f.calc.toString()}`
   const names = new Map<AnyNode, string>()
   traverse(n, (n, visit) => {
     const name = `x${i++}`

--- a/libs/pando/engine/src/node/optimization.ts
+++ b/libs/pando/engine/src/node/optimization.ts
@@ -1,5 +1,5 @@
 import { type DedupTag, DedupTags, type Tag } from '../tag'
-import { assertUnreachable } from '../util'
+import { assertUnreachable, customOps } from '../util'
 import type { Calculator } from './calc'
 import { constant, read } from './construction'
 import { arithmetic, branching } from './formula'
@@ -332,32 +332,30 @@ export function compile(
   n: NumTagFree[],
   dynTagCategory: string,
   slotCount: number,
-  initial: Record<string, number>,
-  header?: string
+  initial: Record<string, number>
 ): (_: Record<string, number>[]) => number[]
 export function compile(
   n: StrTagFree[],
   dynTagCategory: string,
   slotCount: number,
-  initial: Record<string, string>,
-  header?: string
+  initial: Record<string, string>
 ): (_: Record<string, string>[]) => string[]
 export function compile(
   n: AnyTagFree[],
   dynTagCategory: string,
   slotCount: number,
-  initial: Record<string, any>,
-  header?: string
+  initial: Record<string, any>
 ): (_: Record<string, any>[]) => any[]
 export function compile(
   n: AnyTagFree[],
   dynTagCategory: string,
   slotCount: number,
-  initial: Record<string, any>,
-  header = ''
+  initial: Record<string, any>
 ): (_: Record<string, any>[]) => any[] {
   let i = 1,
-    body = `'use strict';` + header + ';const x0=0' // making sure `const` has at least one entry
+    body = `'use strict';const x0=0` // making sure `const` has at least one entry
+  for (const [name, f] of Object.entries(customOps))
+    body += `,${name}=${f.calc.toString()};`
   const names = new Map<AnyNode, string>()
   traverse(n, (n, visit) => {
     const name = `x${i++}`
@@ -406,7 +404,7 @@ export function compile(
         break
       }
       case 'custom':
-        body += `,${name}=${n.ex}(${argNames})`
+        body += `,${name}=${n.ex}([${argNames}])`
         break
       case 'lookup':
         // `JSON.stringify` on `Record<string, number>`

--- a/libs/pando/engine/src/util/custom.ts
+++ b/libs/pando/engine/src/util/custom.ts
@@ -4,14 +4,14 @@
  * regions, and decreasing in another. Setting both to `false` means
  * altering the argument does not change the value of the function.
  */
-export type Tonicity = { inc: boolean; dec: boolean }
+export type Monotonicity = { inc: boolean; dec: boolean }
 export type Range = { min: number; max: number }
 
 export type CustomInfo = {
   /** Given a range of each arguments, returns the range of the result */
   range: (r: Range[]) => Range
   /** Given the range of the arguments, returns whether the function is increasing/decreasing w.r.t. to each argument */
-  tonicity: (r: Range[]) => Tonicity[]
+  monotonicity: (r: Range[]) => Monotonicity[]
   /**
    * Actual computation of the custom node. `calc.toString` must be a valid
    * standalone function declaration if used with `compile`. Generally, a

--- a/libs/pando/engine/src/util/custom.ts
+++ b/libs/pando/engine/src/util/custom.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether the function is increasing/decreasing w.r.t. to an argument.
+ * Setting both to `true` means that the function is increasing in some
+ * regions, and decreasing in another. Setting both to `false` means
+ * altering the argument does not change the value of the function.
+ */
+export type Tonicity = { inc: boolean; dec: boolean }
+export type Range = { min: number; max: number }
+
+export type CustomInfo = {
+  /** Given a range of each arguments, returns the range of the result */
+  range: (r: Range[]) => Range
+  /** Given the range of the arguments, returns whether the function is increasing/decreasing w.r.t. to each argument */
+  tonicity: (r: Range[]) => Tonicity[]
+  /** Actual computation of the custom node */
+  calc: (_: (number | string)[]) => number | string
+}
+
+// This needs to be set only once at the beginning of the program.
+export const customOps: Record<string, CustomInfo> = {}

--- a/libs/pando/engine/src/util/custom.ts
+++ b/libs/pando/engine/src/util/custom.ts
@@ -1,8 +1,8 @@
 /**
- * Whether the function is increasing/decreasing w.r.t. to an argument.
- * Setting both to `true` means that the function is increasing in some
- * regions, and decreasing in another. Setting both to `false` means
- * altering the argument does not change the value of the function.
+ * Whether the function is `inc`reasing/`dec`reasing w.r.t. to an argument.
+ * Note that both `inc` and `dec` means the the function is constant w.r.t.
+ * the argument, while neither means that the argument affects the function
+ * result non-monotonically.
  */
 export type Monotonicity = { inc: boolean; dec: boolean }
 export type Range = { min: number; max: number }
@@ -10,7 +10,7 @@ export type Range = { min: number; max: number }
 export type CustomInfo = {
   /** Given a range of each arguments, returns the range of the result */
   range: (r: Range[]) => Range
-  /** Given the range of the arguments, returns whether the function is increasing/decreasing w.r.t. to each argument */
+  /** Given the arguments ranges, returns the monotonicity w.r.t. each argument */
   monotonicity: (r: Range[]) => Monotonicity[]
   /**
    * Actual computation of the custom node. `calc.toString` must be a valid

--- a/libs/pando/engine/src/util/custom.ts
+++ b/libs/pando/engine/src/util/custom.ts
@@ -12,7 +12,11 @@ export type CustomInfo = {
   range: (r: Range[]) => Range
   /** Given the range of the arguments, returns whether the function is increasing/decreasing w.r.t. to each argument */
   tonicity: (r: Range[]) => Tonicity[]
-  /** Actual computation of the custom node */
+  /**
+   * Actual computation of the custom node. `calc.toString` must be a valid
+   * standalone function declaration if used with `compile`. Generally, a
+   * function or arrow expression with no external function call will suffice.
+   */
   calc: (_: (number | string)[]) => number | string
 }
 

--- a/libs/pando/engine/src/util/index.ts
+++ b/libs/pando/engine/src/util/index.ts
@@ -1,4 +1,6 @@
 import type { Tag } from '../tag'
+import { customOps, type CustomInfo } from './custom'
+export * from './custom'
 
 type DebugMode = boolean
 
@@ -21,3 +23,8 @@ export const tagString = (record: Tag): string =>
 
 export const extract = <V, K extends keyof V>(arr: V[], key: K): V[K][] =>
   arr.map((v) => v[key])
+
+export function addCustomOperation(name: string, info: CustomInfo) {
+  if (name in customOps) throw new Error(`Already set custom formula: ${name}`)
+  customOps[name] = info
+}

--- a/libs/pando/engine/src/util/index.ts
+++ b/libs/pando/engine/src/util/index.ts
@@ -26,5 +26,8 @@ export const extract = <V, K extends keyof V>(arr: V[], key: K): V[K][] =>
 
 export function addCustomOperation(name: string, info: CustomInfo) {
   if (name in customOps) throw new Error(`Already set custom formula: ${name}`)
+  if (/^x\d+$/g.test(name))
+    // this `name` may collides with temp variables in `compile`
+    throw new Error(`Invalid custom operation name: ${name}`)
   customOps[name] = info
 }


### PR DESCRIPTION
## Describe your changes

The PR updates the process to specify custom operation. Perviously the custom operations need to be specified in multiple places (at `Calculator` and `compile`) and are generally un optimizable by the engine. This new approach allows for more information to pass into Pando, and unify the customization sites to only one `addCustomOperation`.

## Issue or discord link

n/a

## Testing/validation

Old tests are still passing

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [x] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined mechanism for registering custom operations, enhancing computation customization.
	- Added a new TypeScript type `Monotonicity` to indicate function behavior with respect to arguments.
	- Added a new function `addCustomOperation` for adding custom operations to the system.
- **Documentation**
	- Updated user guidance to incorporate the new approach for adding custom operations.
- **Refactor**
	- Replaced legacy custom computation handling with a modular and unified structure.
- **Tests**
	- Adjusted test cases to align with the refreshed custom operation registration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->