### PR TITLE
GO: Sync traveler level across all elements

### DIFF
--- a/libs/gi/page-team/src/CharProfileCharEditor.tsx
+++ b/libs/gi/page-team/src/CharProfileCharEditor.tsx
@@ -4,6 +4,7 @@ import {
   ImgIcon,
   ModalWrapper,
 } from '@genshin-optimizer/common/ui'
+import { allTravelerKeys } from '@genshin-optimizer/gi/consts'
 import {
   CharacterContext,
   useDBMeta,
@@ -171,7 +172,13 @@ function Content({ onClose }: { onClose?: () => void }) {
                   warning={!!buildTc?.character}
                   level={level}
                   ascension={ascension}
-                  setBoth={(data) =>
+                  setBoth={(data) => {
+                    if (characterKey.includes('Traveler')) {
+                      allTravelerKeys.forEach((tkey) => {
+                        database.chars.set(tkey, data)
+                      })
+                    }
+
                     buildTc?.character
                       ? setBuildTc((buildTc) => {
                           if (buildTc.character)
@@ -181,7 +188,7 @@ function Content({ onClose }: { onClose?: () => void }) {
                             }
                         })
                       : database.chars.set(characterKey, data)
-                  }
+                  }}
                 />
               </CardThemed>
               <CardThemed bgt="light" sx={{ p: 1 }}>

--- a/libs/gi/page-team/src/CharProfileCharEditor.tsx
+++ b/libs/gi/page-team/src/CharProfileCharEditor.tsx
@@ -173,12 +173,6 @@ function Content({ onClose }: { onClose?: () => void }) {
                   level={level}
                   ascension={ascension}
                   setBoth={(data) => {
-                    if (allTravelerKeys.includes(characterKey)) {
-                      allTravelerKeys.forEach((tkey) => {
-                        database.chars.set(tkey, data)
-                      })
-                    }
-
                     buildTc?.character
                       ? setBuildTc((buildTc) => {
                           if (buildTc.character)
@@ -186,6 +180,10 @@ function Content({ onClose }: { onClose?: () => void }) {
                               ...buildTc.character,
                               ...data,
                             }
+                        })
+                      : allTravelerKeys.includes(characterKey)
+                      ? allTravelerKeys.forEach((tkey) => {
+                          database.chars.set(tkey, data)
                         })
                       : database.chars.set(characterKey, data)
                   }}

--- a/libs/gi/page-team/src/CharProfileCharEditor.tsx
+++ b/libs/gi/page-team/src/CharProfileCharEditor.tsx
@@ -181,7 +181,9 @@ function Content({ onClose }: { onClose?: () => void }) {
                               ...data,
                             }
                         })
-                      : allTravelerKeys.includes(characterKey)
+                      : allTravelerKeys.includes(
+                          characterKey as (typeof allTravelerKeys)[number]
+                        )
                       ? allTravelerKeys.forEach((tkey) => {
                           database.chars.set(tkey, data)
                         })

--- a/libs/gi/page-team/src/CharProfileCharEditor.tsx
+++ b/libs/gi/page-team/src/CharProfileCharEditor.tsx
@@ -173,7 +173,7 @@ function Content({ onClose }: { onClose?: () => void }) {
                   level={level}
                   ascension={ascension}
                   setBoth={(data) => {
-                    if (characterKey.includes('Traveler')) {
+                    if (allTravelerKeys.includes(characterKey)) {
                       allTravelerKeys.forEach((tkey) => {
                         database.chars.set(tkey, data)
                       })

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -101,7 +101,9 @@ export function Content({ onClose }: { onClose?: () => void }) {
                   level={character.level}
                   ascension={character.ascension}
                   setBoth={(data) => {
-                    allTravelerKeys.includes(characterKey)
+                    allTravelerKeys.includes(
+                      characterKey as (typeof allTravelerKeys)[number]
+                    )
                       ? allTravelerKeys.forEach((tkey) => {
                           database.chars.set(tkey, data)
                         })

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -101,13 +101,11 @@ export function Content({ onClose }: { onClose?: () => void }) {
                   level={character.level}
                   ascension={character.ascension}
                   setBoth={(data) => {
-                    if (allTravelerKeys.includes(characterKey)) {
-                      allTravelerKeys.forEach((tkey) => {
-                        database.chars.set(tkey, data)
-                      })
-                    } else {
-                      database.chars.set(characterKey, data)
-                    }
+                    allTravelerKeys.includes(characterKey)
+                      ? allTravelerKeys.forEach((tkey) => {
+                          database.chars.set(tkey, data)
+                        })
+                      : database.chars.set(characterKey, data)
                   }}
                 />
               </Box>

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -101,7 +101,7 @@ export function Content({ onClose }: { onClose?: () => void }) {
                   level={character.level}
                   ascension={character.ascension}
                   setBoth={(data) => {
-                    if (characterKey.includes('Traveler')) {
+                    if (allTravelerKeys.includes(characterKey)) {
                       allTravelerKeys.forEach((tkey) => {
                         database.chars.set(tkey, data)
                       })

--- a/libs/gi/ui/src/components/character/editor/Content.tsx
+++ b/libs/gi/ui/src/components/character/editor/Content.tsx
@@ -3,6 +3,7 @@ import { CardThemed, ImgIcon } from '@genshin-optimizer/common/ui'
 import { objKeyMap } from '@genshin-optimizer/common/util'
 import {
   allArtifactSlotKeys,
+  allTravelerKeys,
   charKeyToLocCharKey,
   charKeyToLocGenderedCharKey,
 } from '@genshin-optimizer/gi/consts'
@@ -99,7 +100,15 @@ export function Content({ onClose }: { onClose?: () => void }) {
                 <LevelSelect
                   level={character.level}
                   ascension={character.ascension}
-                  setBoth={(data) => database.chars.set(characterKey, data)}
+                  setBoth={(data) => {
+                    if (characterKey.includes('Traveler')) {
+                      allTravelerKeys.forEach((tkey) => {
+                        database.chars.set(tkey, data)
+                      })
+                    } else {
+                      database.chars.set(characterKey, data)
+                    }
+                  }}
                 />
               </Box>
               <CharacterCardStats bgt="light" />


### PR DESCRIPTION
## Describe your changes

Modified character 'setBoth' function arg on character level selects under pages for characters/ and teams/. Adjustment updates traveler levels of all elements if one traveler level is changed.

## Issue or discord link

-   Resolves #1279

## Testing/validation

Characters page level edit:
![characters](https://github.com/user-attachments/assets/0e2a513e-d8c3-4621-bf31-ed243a206aa9)

Teams page level edit:
![teams](https://github.com/user-attachments/assets/f53eb047-8f20-4134-84a5-bc335b199bf8)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced character update functionality: when a traveler character is selected, the system now applies updates across all traveler variants. This change streamlines the update process and ensures consistent data across related characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->