### PR TITLE
ZO: Add 4p conditional gates

### DIFF
--- a/libs/zzz/consts/src/disc.ts
+++ b/libs/zzz/consts/src/disc.ts
@@ -253,7 +253,7 @@ export const allDiscCondKeys = {
   },
   PolarMetalBasicOrDash: {
     key: 'PolarMetalBasicOrDash',
-    text: 'Optimizatinng for Basic Attack or Dash Attack',
+    text: 'Optimizing for Basic Attack or Dash Attack',
     min: 1,
     max: 1,
   },
@@ -271,7 +271,7 @@ export const allDiscCondKeys = {
   },
   PufferElectroUltimate: {
     key: 'PufferElectroUltimate',
-    text: 'Optimizatinng for Ultimate Damage',
+    text: 'Optimizing for Ultimate Damage',
     min: 1,
     max: 1,
   },

--- a/libs/zzz/consts/src/disc.ts
+++ b/libs/zzz/consts/src/disc.ts
@@ -251,6 +251,12 @@ export const allDiscCondKeys = {
     min: 1,
     max: 1,
   },
+  PolarMetalBasicOrDash: {
+    key: 'PolarMetalBasicOrDash',
+    text: 'Optimizatinng for Basic Attack or Dash Attack',
+    min: 1,
+    max: 1,
+  },
   PolarMetal: {
     key: 'PolarMetal',
     text: 'Whenever a squad member Freezes or Shatters an enemy',
@@ -260,6 +266,12 @@ export const allDiscCondKeys = {
   ProtoPunk: {
     key: 'ProtoPunk',
     text: 'When any squad member triggers a Defensive Assist or Evasive Assist',
+    min: 1,
+    max: 1,
+  },
+  PufferElectroUltimate: {
+    key: 'PufferElectroUltimate',
+    text: 'Optimizatinng for Ultimate Damage',
     min: 1,
     max: 1,
   },
@@ -376,8 +388,12 @@ export const disc4PeffectSheets: Partial<
     },
   },
   PolarMetal: {
-    condMeta: allDiscCondKeys.PolarMetal,
+    condMeta: [
+      allDiscCondKeys.PolarMetalBasicOrDash,
+      allDiscCondKeys.PolarMetal,
+    ],
     getStats: (conds) => {
+      if (!conds['PolarMetalBasicOrDash']) return {}
       const ret = { dmg_: 0.2 } // TODO: Increase the DMG of Basic Attack and Dash Attack by 20%
       if (conds['PolarMetal']) {
         objMultiplication(ret, 2)
@@ -393,9 +409,13 @@ export const disc4PeffectSheets: Partial<
     },
   },
   PufferElectro: {
-    condMeta: allDiscCondKeys.PufferElectro,
+    condMeta: [
+      allDiscCondKeys.PufferElectroUltimate,
+      allDiscCondKeys.PufferElectro,
+    ],
     getStats: (conds) => {
-      const ret: Record<string, number> = { dmg_: 0.2 } //Ultimate DMG increases by 20%
+      const ret: Record<string, number> = {}
+      if (conds['PufferElectroUltimate']) ret['dmg_'] = 0.2 //Ultimate DMG increases by 20%
       if (conds['PufferElectro']) ret['cond_atk_'] = 0.15 // Launching an Ultimate increases the equipper's ATK by 15%
       return ret
     },


### PR DESCRIPTION
## Describe your changes

Both Polar Metal and Puffer Electro gives dmg boost to specific moves, but are implemented as "general dmg bonus", which over values them in other optimization cases. Adding conditionals to gate them for optimization.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![image](https://github.com/user-attachments/assets/2fcf7c3c-cde7-46a3-a694-68bcc5e381b6)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced condition parameters for two elemental effects, providing more nuanced interactions.

- **Refactor**
  - Optimized the underlying logic to apply enhancements only when specific criteria are met, ensuring more accurate and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->