### PR TITLE
GO: Fix Furina issue with Spiritbreath Thorn/Surging Blade DMG

### DIFF
--- a/libs/gi/sheets/src/Characters/Furina/index.tsx
+++ b/libs/gi/sheets/src/Characters/Furina/index.tsx
@@ -260,10 +260,23 @@ const c6Pneuma_plunging_impact_dmgInc = infoMut(
 const dmgFormulas = {
   normal: {
     ...Object.fromEntries(
-      dm.normal.hitArr.map((arr, i) => [i, dmgNode('atk', arr, 'normal')])
+      dm.normal.hitArr.map((arr, i) => [
+        i,
+        dmgNode('atk', arr, 'normal', {
+          premod: {
+            normal_dmgInc: sum(c6_normal_dmgInc, c6Pneuma_normal_dmgInc),
+          },
+        }),
+      ])
     ),
     thornBladeDmg: dmgNode('atk', dm.normal.bladeThornDmg, 'normal', {
-      hit: { ele: constant(getCharEle(key)) },
+      premod: {
+        normal_dmgInc: c6_normal_dmgInc,
+      },
+      hit: {
+        ele: constant(getCharEle(key)),
+        reaction: constant('none'),
+      },
     }),
   },
   charged: {
@@ -328,7 +341,6 @@ export const data = dataObjForCharacterSheet(key, dmgFormulas, {
     skillBoost: skillC5,
     burstBoost: burstC3,
     hp_: c2Overstack_hp_,
-    normal_dmgInc: sum(c6_normal_dmgInc, c6Pneuma_normal_dmgInc),
     charged_dmgInc: sum(c6_charged_dmgInc, c6Pneuma_charged_dmgInc),
     plunging_dmgInc: c6_plunging_dmgInc,
     plunging_impact_dmgInc: c6Pneuma_plunging_impact_dmgInc,


### PR DESCRIPTION
## Describe your changes

- Fix issue with Furina's Spiritbreath Thorn/Surging Blade DMG calculation while c6 is active

## Issue or discord link

- Resolves: #2733

## Testing/validation

![image](https://github.com/user-attachments/assets/49c7dfee-83a0-433e-a346-4bfb33b0d949)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved damage calculations for Furina’s normal and blade thorn attacks by incorporating additional in-game progression parameters. This update delivers more precise and balanced damage outputs during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->