### PR TITLE
ZO: fix BranchBladeSong not accounting final_anomMas

### DIFF
--- a/libs/zzz/consts/src/disc.ts
+++ b/libs/zzz/consts/src/disc.ts
@@ -326,7 +326,13 @@ export const disc4PeffectSheets: Partial<
     condMeta: allDiscCondKeys.BranchBladeSong,
     getStats: (conds, stats) => {
       const ret: Record<string, number> = {}
-      if (stats['anomMas'] >= 115) ret['crit_dmg_'] = 0.3
+      // Have to calculate the "final" here because there are no stages for calc
+      if (
+        (stats['anomMas_base'] ?? 0) * (1 + (stats['anomMas_'] ?? 0)) +
+          (stats['anomMas'] ?? 0) >=
+        115
+      )
+        ret['crit_dmg_'] = 0.3
       if (conds['BranchBladeSong']) ret['crit_'] = 0.12
       return ret
     },


### PR DESCRIPTION
## Describe your changes

Due to changes in anomMas, BranchBladeSong 4p passive was broken. this fixes the calcs.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the calculation for critical damage modifications by considering multiple parameter values, delivering more balanced and predictable outcomes for users in relevant effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->