### PR TITLE
Misc: Minor adjustments to Pando debugging helpers

### DIFF
--- a/libs/common/ui/src/components/CodeBlock.tsx
+++ b/libs/common/ui/src/components/CodeBlock.tsx
@@ -1,5 +1,6 @@
 'use client'
-import { Box, styled } from '@mui/material'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { Box, IconButton, styled } from '@mui/material'
 
 const CodeArea = styled('code')(({ theme }) => ({
   '&:disabled': {
@@ -18,7 +19,7 @@ const CodeArea = styled('code')(({ theme }) => ({
   resize: 'none',
   color: theme.palette.info.light,
   background: theme.palette.contentDark.main,
-  'p::before': {
+  '.codeLine::before': {
     content: 'counter(lineNumber)',
     width: '2.5em',
     textAlign: 'right',
@@ -33,23 +34,39 @@ export function CodeBlock({ text }: { text: string }) {
   const lines = text.split(/\r\n|\r|\n/)
 
   return (
-    <Box display="flex" flexDirection="row" p={1}>
-      <CodeArea spellCheck="false" aria-label="Code Sample">
+    <Box display="flex" flexDirection="row" px={1} pb={1}>
+      <CodeArea
+        spellCheck="false"
+        aria-label="Code Sample"
+        sx={{ mt: 0, pt: 0 }}
+      >
+        <Box display="flex">
+          <Box sx={{ flexGrow: 1 }} />
+          <IconButton
+            size="small"
+            sx={{ opacity: 0.5, p: 0, mt: 1 }}
+            onClick={() => navigator.clipboard.writeText(text)}
+          >
+            <ContentCopyIcon fontSize="inherit" />
+          </IconButton>
+        </Box>{' '}
         {lines.map((l, index) => {
           const numSpaces = l.search(/\S/)
           return (
-            <p
+            <span
               key={index}
+              className="codeLine"
               style={{
                 counterIncrement: 'lineNumber',
                 margin: 0,
+                display: 'block',
                 // Makes it so wrapped lines start with some amount of indentation
                 paddingLeft: `${numSpaces * 7.5 + 20}px`,
                 textIndent: `-${numSpaces * 7.5 + 20}px`,
               }}
             >
               {l}
-            </p>
+            </span>
           )
         })}
       </CodeArea>

--- a/libs/game-opt/engine/src/calculator.ts
+++ b/libs/game-opt/engine/src/calculator.ts
@@ -39,7 +39,7 @@ export type PartialMeta<
   ops: CalcResult<number, PartialMeta<Src, Dst, Sheet, Op>>[]
 }
 export type Info<Member extends string, Sheet extends string> = {
-  conds: CondInfo<Member, Sheet>
+  conds: CondInfo<Member | 'All', Sheet>
 }
 
 const { arithmetic } = calculation
@@ -142,10 +142,10 @@ export class Calculator<
 
     if (tag.qt === 'cond') {
       const { src, dst, sheet, q } = tag
-      if (src && dst && sheet && q)
+      if (src && sheet && q)
         meta.conds = {
-          [dst]: { [src]: { [sheet!]: { [q!]: val } } },
-        } as CondInfo<Member, Sheet>
+          [dst ?? 'All']: { [src]: { [sheet!]: { [q!]: val } } },
+        } as CondInfo<Member | 'All', Sheet>
       dirty = true
     }
     Object.freeze(meta)
@@ -166,7 +166,7 @@ export class Calculator<
   }
   listCondFormulas(
     read: Read<Tag<Src, Dst, Sheet>, Src, Dst, Sheet>
-  ): CondInfo<Member, Sheet> {
+  ): CondInfo<Member | 'All', Sheet> {
     return this.listFormulas(read)
       .map((x) => this.compute(x).meta.conds)
       .reduce(mergeConds, {})
@@ -190,9 +190,9 @@ function extract<
 }
 
 function mergeConds<Member extends string, Sheet extends string>(
-  a: CondInfo<Member, Sheet>,
-  b: CondInfo<Member, Sheet>
-): CondInfo<Member, Sheet> {
+  a: CondInfo<Member | 'All', Sheet>,
+  b: CondInfo<Member | 'All', Sheet>
+): CondInfo<Member | 'All', Sheet> {
   return merge(a, b, (_, v) => (typeof v === 'number' ? v : undefined))
 }
 function merge<T extends Record<string, any>>(

--- a/libs/game-opt/formula-ui/src/DebugDisplay.tsx
+++ b/libs/game-opt/formula-ui/src/DebugDisplay.tsx
@@ -35,7 +35,7 @@ export function DebugListingsDisplay({
 
   const [expanded, setExpanded] = useState<string | false>(false)
   const handleChange =
-    (panel: string) => (event: SyntheticEvent, isExpanded: boolean) => {
+    (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
       setExpanded(isExpanded ? panel : false)
     }
 

--- a/libs/game-opt/formula-ui/src/DebugDisplay.tsx
+++ b/libs/game-opt/formula-ui/src/DebugDisplay.tsx
@@ -17,7 +17,8 @@ import {
   Typography,
 } from '@mui/material'
 import { Box, Stack } from '@mui/system'
-import { useContext } from 'react'
+import type { SyntheticEvent } from 'react'
+import { useContext, useState } from 'react'
 import { CalcContext, DebugReadContext, TagContext } from './context'
 import type { GenericRead } from './types'
 
@@ -32,10 +33,20 @@ export function DebugListingsDisplay({
   const calc = useContext(CalcContext)?.withTag(tag)
   const debugCalc = calc?.toDebug()
 
+  const [expanded, setExpanded] = useState<string | false>(false)
+  const handleChange =
+    (panel: string) => (event: SyntheticEvent, isExpanded: boolean) => {
+      setExpanded(isExpanded ? panel : false)
+    }
+
   return (
     <CardThemed bgt="dark">
       <CardContent>
-        <Accordion>
+        <Accordion
+          expanded={expanded === 'formulas'}
+          onChange={handleChange('formulas')}
+          slotProps={{ transition: { unmountOnExit: true } }}
+        >
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             All target listings
           </AccordionSummary>
@@ -43,6 +54,7 @@ export function DebugListingsDisplay({
             <Stack>
               {calc &&
                 debugCalc &&
+                expanded === 'formulas' &&
                 calc.listFormulas(formulasRead).map((read, index) => {
                   const computed = calc.compute(read)
                   const debugMeta = debugCalc.compute(read).meta
@@ -71,7 +83,11 @@ export function DebugListingsDisplay({
             </Stack>
           </AccordionDetails>
         </Accordion>
-        <Accordion>
+        <Accordion
+          expanded={expanded === 'buffs'}
+          onChange={handleChange('buffs')}
+          slotProps={{ transition: { unmountOnExit: true } }}
+        >
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             All target buffs
           </AccordionSummary>
@@ -79,6 +95,7 @@ export function DebugListingsDisplay({
             <Stack>
               {calc &&
                 debugCalc &&
+                expanded === 'buffs' &&
                 calc.listFormulas(buffsRead).map((read, index) => {
                   const computed = calc.compute(read)
                   const debugMeta = debugCalc.compute(read).meta


### PR DESCRIPTION
## Describe your changes

* Defer DebugDisplay to render only when the accordion is expanded, to speed up page loads/rerenders
* Fix issue with CodeBlock where copy-pasting from it had extra linebreaks
* Add a quick copy button to CodeBlock to copy everything
* Add 'All' `dst` support for meta.conds in game-opt

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Screenshot of new codeblock with copy button, and 'All' support in meta.conds
![image](https://github.com/user-attachments/assets/2440eb51-db10-4247-90e7-7751cf97d2ed)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated code blocks now display code lines clearly and include a copy-to-clipboard button for convenience.
  - The debug display now offers interactive accordion expansion for viewing detailed information.

- **Refactor**
  - Enhanced condition handling in game calculations to support a broader range of scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->