### PR TITLE
ZO: Fix issue with editor crashing when selecting disc substats

### DIFF
--- a/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
+++ b/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
@@ -41,22 +41,9 @@ export default function SubstatInput({
   const { t } = useTranslation('disc')
   const { mainStatKey = '' } = disc ?? {}
   const { key, upgrades = 0 } = disc?.substats?.[index] ?? {}
-
-  // let error = '',
-  //   allowedRolls = 0
-
-  // if (disc?.rarity) {
-  //   // Account for the rolls it will need to fill all 4 substates, +1 for its base roll
-  //   const rarity = disc.rarity
-  //   const { numUpgrades, high } = discSubstatRollData[rarity]
-  //   const maxRollNum = numUpgrades + high - 3
-  //   allowedRolls = maxRollNum - value
-  // }
-
-  // if (allowedRolls < 0)
-  //   error =
-  //     error ||
-  //     t('editor.substat.error.noOverRoll', { value: allowedRolls + value })
+  const isDisabled =
+    index === 0 ||
+    (disc?.substats?.[index - 1] && disc.substats?.[index - 1].key)
 
   const marks = useMemo(
     () =>
@@ -76,7 +63,7 @@ export default function SubstatInput({
             t('editor.substat.substatFormat', { value: index + 1 })
           )
         }
-        disabled={!disc?.mainStatKey}
+        disabled={!disc?.mainStatKey || !isDisabled}
         color={key ? 'success' : 'primary'}
         sx={{ whiteSpace: 'nowrap', width: '13em' }}
       >

--- a/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
+++ b/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
@@ -41,9 +41,8 @@ export default function SubstatInput({
   const { t } = useTranslation('disc')
   const { mainStatKey = '' } = disc ?? {}
   const { key, upgrades = 0 } = disc?.substats?.[index] ?? {}
-  const isDisabled =
-    index === 0 ||
-    (disc?.substats?.[index - 1] && disc.substats?.[index - 1].key)
+  const isEnabled =
+    index === 0 || disc?.substats?.[index - 1]?.key !== undefined
 
   const marks = useMemo(
     () =>
@@ -63,7 +62,7 @@ export default function SubstatInput({
             t('editor.substat.substatFormat', { value: index + 1 })
           )
         }
-        disabled={!disc?.mainStatKey || !isDisabled}
+        disabled={!disc?.mainStatKey || !isEnabled}
         color={key ? 'success' : 'primary'}
         sx={{ whiteSpace: 'nowrap', width: '13em' }}
       >


### PR DESCRIPTION
## Describe your changes

- Users must select subs in a sequence

## Issue or discord link

- Resolves: #2760 

## Testing/validation

![image](https://github.com/user-attachments/assets/76468480-e699-438c-8fae-f4eb5f7302af)
![image](https://github.com/user-attachments/assets/2737e35d-6691-47de-a159-d739f672a573)

etc

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for dropdown behavior in disc customization inputs, ensuring options are automatically disabled when selections are incomplete, enhancing a smoother editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->