### PR TITLE
ZO: Fix disc sub editor range

### DIFF
--- a/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
+++ b/libs/zzz/ui/src/Disc/DiscEditor/SubstatInput.tsx
@@ -46,7 +46,7 @@ export default function SubstatInput({
 
   const marks = useMemo(
     () =>
-      range(1, discSubstatRollData[rarity].numUpgrades).map((i) => ({
+      range(1, discSubstatRollData[rarity].numUpgrades + 1).map((i) => ({
         value: i,
       })),
     [rarity]


### PR DESCRIPTION
## Describe your changes

![image](https://github.com/user-attachments/assets/bceb108a-693c-41a0-b50d-a7e8c62350ba)

## Issue or discord link

- Resolves #2740 

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The slider component now includes an additional mark, providing an expanded selection range for more precise adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->