### PR TITLE
Pando: Add `pruneBottom` and update `reaffine` keys

### DIFF
--- a/libs/pando/engine/src/optimization/prune.spec.ts
+++ b/libs/pando/engine/src/optimization/prune.spec.ts
@@ -244,17 +244,35 @@ describe('state', () => {
           expect(m2.get('c1')?.[inc ? 'inc' : 'dec']).toEqual(false)
           expect(m2.get('c2')?.[inc ? 'dec' : 'inc']).toEqual(false)
 
-          const n3 = prod(sum(r0, -7), sum(r1, -11), sum(r2, -8))
+          const n3 = prod(sum(r0, -4), r1, r2) // r0 can be neg/zero/pos
           const m3 = getMonotonicity(flip(n3, inc))
           expect(m3.get('c0')?.[inc ? 'dec' : 'inc']).toEqual(false)
-          expect(m3.get('c1')?.[inc ? 'dec' : 'inc']).toEqual(false)
-          expect(m3.get('c2')?.[inc ? 'dec' : 'inc']).toEqual(false)
+          expect(m3.get('c1')).toEqual({ inc: false, dec: false })
+          expect(m3.get('c2')).toEqual({ inc: false, dec: false })
 
-          const n4 = prod(sum(r0, -4), r1, r2) // r0 can be neg/zero/pos
+          const n4 = prod(r0, r1, r2) // pos * pos * pos
           const m4 = getMonotonicity(flip(n4, inc))
-          expect(m4.get('c0')?.[inc ? 'dec' : 'inc']).toEqual(false)
-          expect(m4.get('c1')).toEqual({ inc: false, dec: false })
-          expect(m4.get('c2')).toEqual({ inc: false, dec: false })
+          expect(m4.get('c0')).toEqual({ inc, dec: !inc })
+          expect(m4.get('c1')).toEqual({ inc, dec: !inc })
+          expect(m4.get('c2')).toEqual({ inc, dec: !inc })
+
+          const n5 = prod(sum(r0, -7), r1, r2) // neg * pos * pos
+          const m5 = getMonotonicity(flip(n5, inc))
+          expect(m5.get('c0')).toEqual({ inc, dec: !inc })
+          expect(m5.get('c1')).toEqual({ inc: !inc, dec: inc })
+          expect(m5.get('c2')).toEqual({ inc: !inc, dec: inc })
+
+          const n6 = prod(sum(r0, -7), sum(r1, -11), r2) // neg * neg * pos
+          const m6 = getMonotonicity(flip(n6, inc))
+          expect(m6.get('c0')).toEqual({ inc: !inc, dec: inc })
+          expect(m6.get('c1')).toEqual({ inc: !inc, dec: inc })
+          expect(m6.get('c2')).toEqual({ inc, dec: !inc })
+
+          const n7 = prod(sum(r0, -7), sum(r1, -11), sum(r2, -9)) // neg * neg * neg
+          const m7 = getMonotonicity(flip(n7, inc))
+          expect(m7.get('c0')).toEqual({ inc, dec: !inc })
+          expect(m7.get('c1')).toEqual({ inc, dec: !inc })
+          expect(m7.get('c2')).toEqual({ inc, dec: !inc })
         })
     })
     // r0 < r2 < r1

--- a/libs/pando/engine/src/optimization/prune.ts
+++ b/libs/pando/engine/src/optimization/prune.ts
@@ -528,15 +528,14 @@ function getMonotonicities(
       }
       case 'prod': {
         const r = nodeRanges.get(node)!
-        const pos = r.min > 0
-        if (!pos && r.max >= 0) {
-          // unsupported zero-touching
+        if (r.min < 0 && r.max > 0) {
+          // unsupported zero-crossing
           node.x.forEach((n) => visit(n, true))
           node.x.forEach((n) => visit(n, false))
-        } else
-          node.x.forEach((n) =>
-            visit(n, (pos === inc) === nodeRanges.get(n)!.min > 0)
-          )
+        } else {
+          const absInc = inc === r.max > 0 // |node| is increasing in some regions
+          node.x.forEach((n) => visit(n, absInc === nodeRanges.get(n)!.max > 0))
+        }
         break
       }
       case 'match':

--- a/libs/pando/engine/src/tag/keys.ts
+++ b/libs/pando/engine/src/tag/keys.ts
@@ -62,7 +62,6 @@ export class TagMapKeys {
     let firstReplacedByte = this.tagLen
     for (const [category, value] of Object.entries(extra)) {
       const entry = this.data[category]!
-      if (!entry) console.error(category, entry)
       const {
         // Make sure `category` existed during compilation. Otherwise, it
         // would crash here, and this non-shaming text would be visible.


### PR DESCRIPTION
## Describe your changes

This PR adds `pruneBottom` which removes candidates that are guaranteed not to be in the `topN` builds. Additionally, it update reaffine keys from `c0`, `c1`, etc., to `!atk:1:atk_640.332` in debug mode, as well as deduplicate keys that have identical weights. 

## Issue or discord link

- https://discord.com/channels/785153694478893126/1189329506842984570/1344128588458229821

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced filtering process that now excludes less competitive options from top builds, improving overall performance.

- **Refactor**
  - Updated the evaluation logic for candidate assessment to ensure more reliable outcomes.
  - Improved parameter naming and error handling for better clarity.
  - Removed redundant logging to reduce unnecessary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->