### PR TITLE
Pando: Add `compileDiff`

### DIFF
--- a/libs/pando/engine/src/node/transform.ts
+++ b/libs/pando/engine/src/node/transform.ts
@@ -294,14 +294,17 @@ export function compileDiff(
         body += `,_0${out}=1`
         x.forEach((x, i) => (body += `,_${i + 1}${out}=_${i}${out}*${x}`))
         body += `,${dout}=`
-        body += dx.reduce((d, dx, i) => `(${d}*${x[i]}+${dx}*_${i}${out})`, '0')
+        // _{i}{out} = prefix product upto (but excluding) x[i]
+        // a_{i+1} = d/dx _{i+1}{out} = (d/dx _{i}{out}) * x[i] + dx[i] * _{i}{out}
+        body += dx.reduce((a, dx, i) => `(${a}*${x[i]}+${dx}*_${i}${out})`, '0')
         break
       case 'min':
       case 'max':
         body += `,${dout}=[${dx}][[${x}].indexOf(${out})]`
         break
       case 'sumfrac':
-        body += `,_${dout}=${x[0]}+${x[1]}`
+        // d/dx x/(x+c) = c/(x+c)^2, d/dc x/(x+c) = -x/(x+c)^2
+        body += `,_${dout}=${x[0]}+${x[1]}` // x + c
         body += `,${dout}=(${x[1]}*${dx[0]}-${x[0]}*${dx[1]})/_${dout}/_${dout}`
         break
       case 'match':

--- a/libs/pando/engine/src/node/transform.ts
+++ b/libs/pando/engine/src/node/transform.ts
@@ -253,7 +253,112 @@ export function compile(
   let body = `'use strict';const _=0` // making sure `const` has at least one entry
   for (const [name, f] of Object.entries(customOps))
     body += `,f${name}=${f.calc.toString()}`
-  const names = new Map<AnyNode, string>()
+  const { str, names } = compiledStr(n, dynTagCategory, slotCount, initial)
+  body += `${str};return [${n.map((n) => names.get(n)!)}]`
+  return new Function(`b`, body) as any
+}
+
+export function compileDiff(
+  n: AnyTagFree,
+  dynTagCategory: string,
+  diffTags: string[],
+  slotCount: number,
+  initial: Record<string, any>
+): (_: Record<string, any>[]) => any[] {
+  let body = `'use strict';const _=0` // making sure `const` has at least one entry
+  for (const [name, f] of Object.entries(customOps))
+    body += `,f${name}=${f.calc.toString()},g${name}=${f.diff?.toString()}`
+  const { str, names } = compiledStr([n], dynTagCategory, slotCount, initial)
+  body += `${str},diff=(t)=>{const _=0`
+  const discrete = new Set<AnyTagFree>() // values that must be discrete
+  traverse([n], (n, visit) => {
+    const { op } = n
+    n.x.forEach(visit)
+    n.br.forEach(visit)
+    const x = n.x.map((x) => names.get(x)!)
+    const br = n.br.map((n) => names.get(n)!)
+    const dx = n.x.map((x) => `d${names.get(x)}`)
+    const name = names.get(n)
+    const dName = `d${names.get(n)}`
+
+    switch (op) {
+      case 'const':
+        body += `,${dName}=0`
+        break
+      case 'sum':
+        body += `,${dName}=`
+        if (dx.length) body += dx.join('+')
+        else body += 0
+        break
+      case 'prod':
+        body += `,_0${dName}=0,_0${name}=1`
+        dx.forEach((dx, i) => {
+          body += `,_${i + 1}${dName}=_${i}${dName}*${x[i]}+${dx}*_${i}${name}`
+          body += `,_${i + 1}${name}=_${i}${name}*${x[i]}`
+        })
+        body += `,${dName}=_${dx.length}${dName}`
+        break
+      case 'min':
+      case 'max': {
+        const s = op === 'min' ? '>=' : '<='
+        body += `,_0${dName}=0,_0${name}=Infinity`
+        dx.forEach((dx, i) => {
+          body += `,_c${i}${dName}=_${i}${name}${s}${x[i]}`
+          body += `,_${i + 1}${dName}=_c${i}${dName}?${dx}:_${i}${dName}`
+          body += `,_${i + 1}${name}=_c${i}${dName}?${x[i]}:$_{i}${name}`
+        })
+        body += `,${dName}=_${dx.length}${dName}`
+        break
+      }
+      case 'sumfrac':
+        body += `,_${dName}=${x[0]}+${x[1]},`
+        body += `,${dName}=(${x[1]}*${dx[0]}-${x[0]}*${dx[1]})/_${dName}/_${dName}`
+        break
+      case 'match':
+        body += `,${dName}=${br[0]}===${br[1]}?${dx[0]}:${dx[1]}`
+        break
+      case 'thres':
+        body += `,${dName}=${br[0]}>=${br[1]}?${dx[0]}:${dx[1]}`
+        break
+      case 'subscript':
+        body += `,${dName}=0`
+        discrete.add(n.br[0])
+        break
+      case 'read': {
+        const key = n.tag[dynTagCategory]!
+        body += `,${dName}='${key}' === t ? 1 : 0`
+        break
+      }
+      case 'custom':
+        body += `,${dName}=g${n.ex}([${x}])`
+        break
+      case 'lookup':
+        // `JSON.stringify` on `Record<string, number>`
+        body += `,${dName}=([${dx}])[(${JSON.stringify(n.ex)})[${br[0]}] ?? 0]`
+        discrete.add(n.br[0])
+        break
+      default:
+        assertUnreachable(op)
+    }
+  })
+  if (discrete.size) {
+    body += `;if (${[...discrete].map((n) => `d${names.get(n)}`).join('||')})`
+    body += `throw new Error(\`'\${t}' must be discrete\`)`
+  }
+  body += `;return d${names.get(n)}}`
+  body += `;return [${diffTags.map((t) => `diff('${t}')`)}]`
+  console.log(body)
+  return new Function(`b`, body) as any
+}
+
+function compiledStr(
+  n: AnyTagFree[],
+  dynTagCategory: string,
+  slotCount: number,
+  initial: Record<string, any>
+): { str: string; names: Map<AnyTagFree, string> } {
+  let body = ''
+  const names = new Map<AnyTagFree, string>()
   traverse(n, (n, visit) => {
     const name = `x${names.size}`
     names.set(n, name)
@@ -266,7 +371,7 @@ export function compile(
 
     switch (op) {
       case 'const':
-        names.set(n, typeof n.ex !== 'string' ? `(${n.ex})` : `('${n.ex}')`)
+        body += `,${name}=` + (typeof n.ex !== 'string' ? n.ex : `'${n.ex}'`)
         break
       case 'sum':
       case 'prod':
@@ -297,7 +402,7 @@ export function compile(
           (_, i) => `(b[${i}]['${key}'] ?? 0)`
         )
         if (initial[key]) arr = [initial[key]!.toString(), ...arr]
-        body += `,${name}=${arr.join('+')}`
+        body += `,${name}=0+${arr.join('+')}`
         break
       }
       case 'custom':
@@ -311,6 +416,5 @@ export function compile(
         assertUnreachable(op)
     }
   })
-  body += `;return [${n.map((n) => names.get(n)!)}]`
-  return new Function(`b`, body) as any
+  return { str: body, names }
 }

--- a/libs/pando/engine/src/node/transform.ts
+++ b/libs/pando/engine/src/node/transform.ts
@@ -20,8 +20,8 @@ import type {
  */
 type OP = Exclude<TaggedOP, 'tag' | 'dtag' | 'vtag'>
 export type NumTagFree = NumNode<OP>
-type StrTagFree = StrNode<OP>
-type AnyTagFree = AnyNode<OP>
+export type StrTagFree = StrNode<OP>
+export type AnyTagFree = AnyNode<OP>
 
 /**
  * Apply all tag-related nodes from `n` calculation and replace `Read` nodes where
@@ -314,10 +314,9 @@ export function compileDiff(
         discrete.add(br[0])
         discrete.add(br[1])
         break
-      case 'read': {
+      case 'read':
         body += `,${dout}='${n.tag[dynTagCat]!}'===t?1:0`
         break
-      }
       case 'subscript':
         body += `,${dout}=0`
         discrete.add(br[0])
@@ -389,7 +388,7 @@ function compiledStr(
           (_, i) => `(b[${i}]['${key}'] ?? 0)`
         )
         if (initial[key]) arr = [initial[key]!.toString(), ...arr]
-        body += `,${out}=+(${arr.join('+')})`
+        body += `,${out}=+(${arr.join('+')}+0)`
         break
       }
       case 'subscript':

--- a/libs/pando/engine/src/optimization/prune.ts
+++ b/libs/pando/engine/src/optimization/prune.ts
@@ -34,7 +34,7 @@ type Monotonicities = Map<string, Monotonicity>
  *    The nodes must be in the order [minConstraints, other calc], and `minConstraint[0]` is
  *    the obj function.
  * @param candidates Components used to construct the builds. Keys in `component` except 'id' may be removed in the results.
- * @param cat Tag category used by `compile` in the actual computation
+ * @param dynTagCat Tag category used by `compile` in the actual computation
  * @param minimum Minimum values for min constraint nodes.
  * @param topN The number of top builds to keep.
  * @returns
@@ -46,11 +46,11 @@ type Monotonicities = Map<string, Monotonicity>
 export function prune<I extends OP>(
   nodes: NumNode<I>[],
   candidates: Component[][],
-  cat: string,
+  dynTagCat: string,
   minimum: number[],
   topN: number
 ): { nodes: NumNode<I>[]; candidates: Component[][]; minimum: number[] } {
-  const state = new State(nodes, minimum, candidates, cat)
+  const state = new State(nodes, minimum, candidates, dynTagCat)
   while (state.progress) {
     state.progress = false
     pruneBranches(state)

--- a/libs/pando/engine/src/util/custom.ts
+++ b/libs/pando/engine/src/util/custom.ts
@@ -18,6 +18,11 @@ export type CustomInfo = {
    * function or arrow expression with no external function call will suffice.
    */
   calc: (_: (number | string)[]) => number | string
+  /**
+   * The dual part of `calc(x + dx e)` where `e = sqrt(0), e !== 0`. This has the
+   * same declaration restriction as `calc`.
+   */
+  diff?: (x: number[], dx: number[]) => number
 }
 
 // This needs to be set only once at the beginning of the program.


### PR DESCRIPTION
## Describe your changes

This PR adds `compileDiff`, which compiles a node to its derivatives w.r.t. to the some tags (the list is supplied as an argument). Derivatives are calculated using automatic differentiation via dual number.

## Issue or discord link

n/a

## Testing/validation

New tests added

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced custom operations for numerical calculations and reverse string concatenation.
  - Added a new computation function to manage various arithmetic scenarios and error conditions.
  - Enabled optional mathematical differentiation support for custom operations.

- **Tests**
  - Expanded test coverage to validate arithmetic operations and branching logic reliably.

- **Refactor**
  - Streamlined type constraints and renamed parameters for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->