### PR TITLE
ZO: Fix disc editor after reopen

### DIFF
--- a/libs/zzz/page-discs/src/index.tsx
+++ b/libs/zzz/page-discs/src/index.tsx
@@ -34,6 +34,7 @@ export default function PageDiscs() {
         show={show}
         onClose={onClose}
         onShow={onOpen}
+        cancelEdit={() => setDisc({})}
       />
       <DiscInventory onAdd={onAddNew} onEdit={onEdit} />
     </Box>


### PR DESCRIPTION
## Describe your changes

- Fix for when you edit a disc and try to reopen it

## Issue or discord link

- Resolves: #2830 

## Testing/validation

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a cancel edit option in the disc editing interface, allowing users to quickly clear their current disc data during editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->