### PR TITLE
ZO: Rename additional to aftershock

### DIFF
--- a/libs/zzz/formula/src/data/util/listing.ts
+++ b/libs/zzz/formula/src/data/util/listing.ts
@@ -63,7 +63,7 @@ export const damageTypes = [
   'assistFollowUp',
   'anomaly',
   'disorder',
-  'additional',
+  'aftershock',
   'elemental',
 ] as const
 

--- a/libs/zzz/formula/src/data/util/read.ts
+++ b/libs/zzz/formula/src/data/util/read.ts
@@ -197,10 +197,10 @@ export class Read extends BaseRead<Tag> {
       super.with('damageType2', 'disorder'),
     ]
   }
-  get additional(): Read[] {
+  get aftershock(): Read[] {
     return [
-      super.with('damageType1', 'additional'),
-      super.with('damageType2', 'additional'),
+      super.with('damageType1', 'aftershock'),
+      super.with('damageType2', 'aftershock'),
     ]
   }
   get elemental(): Read[] {


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated damage type labels for improved clarity. The term “additional” has been replaced with “aftershock” in key areas of the application, ensuring consistency in damage categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->