### PR TITLE
GO: Speed up some builds

### DIFF
--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/polyUB.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/polyUB.ts
@@ -329,6 +329,7 @@ function prodM(...monomials: Monomial[][]): Monomial[] {
   )
 }
 function foldLikeTerms(mon: Monomial[]): Monomial[] {
+  mon = mon.filter((m) => m.$k)
   mon.forEach((m) => m.terms.sort())
   mon.sort(({ terms: termsA }, { terms: termsB }) => {
     if (termsA.length !== termsB.length) return termsA.length - termsB.length


### PR DESCRIPTION
## Describe your changes

A significant number of entries have `$k==0`. Filtering first reduces the work done by the O(N log N) sort and the potentially quadratic loop

## Issue or discord link

Helps with #1155 

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced mathematical term processing by automatically excluding zero-value elements, leading to cleaner and more accurate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->