### PR TITLE
ZO: minor M3 opt UI update

### DIFF
--- a/libs/zzz/consts/src/common.ts
+++ b/libs/zzz/consts/src/common.ts
@@ -98,6 +98,7 @@ export const statKeyTextMap: Partial<Record<string, string>> = {
   crit_dmg_: 'CRIT DMG',
   enerRegen_: 'Energy Regen',
   enerRegen: 'Energy Regen',
+  base_enerRegen: 'Base Energy Regen',
   impact_: 'Impact',
   impact: 'Impact',
   daze_: 'Daze',

--- a/libs/zzz/db/src/Database/DataManagers/CharacterDataManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterDataManager.ts
@@ -99,7 +99,8 @@ export class CharacterDataManager extends DataManager<
       (val, k) => typeof val === 'number' && !!val && k !== 'enemyDefRed'
     )
 
-    if (!allFormulaKeys.includes(formulaKey)) formulaKey = allFormulaKeys[0]
+    if (formulaKey && !allFormulaKeys.includes(formulaKey))
+      formulaKey = undefined
 
     if (typeof constraints !== 'object') constraints = {}
     constraints = objFilter(
@@ -318,8 +319,8 @@ export class CharacterDataManager extends DataManager<
 export function initialCharacterData(key: CharacterKey): ICachedCharacter {
   return {
     key,
-    level: 1,
-    core: 0,
+    level: 60,
+    core: 6,
     wengineKey: allWengineKeys[0],
     wengineLvl: 60,
     wenginePhase: 1,
@@ -327,7 +328,7 @@ export function initialCharacterData(key: CharacterKey): ICachedCharacter {
       // in percent
       enemyDef: 953, // default enemy DEF
     },
-    formulaKey: allFormulaKeys[0],
+    formulaKey: undefined,
     constraints: {}, // in percent
     useEquipped: false,
     slot4: [...discSlotToMainStatKeys['4']],

--- a/libs/zzz/db/src/Interfaces/IZZZChracter.ts
+++ b/libs/zzz/db/src/Interfaces/IZZZChracter.ts
@@ -17,7 +17,7 @@ export interface ICharMeta {
 
 export interface IDbCharacter extends ICharacter {
   stats: Stats
-  formulaKey: FormulaKey
+  formulaKey?: FormulaKey
   constraints: Constraints
   useEquipped: boolean
   setFilter2: DiscSetKey[]

--- a/libs/zzz/page-optimize/src/Optimize.tsx
+++ b/libs/zzz/page-optimize/src/Optimize.tsx
@@ -128,7 +128,7 @@ export default function OptimizeWrapper({
   useEffect(() => () => cancelToken.current(), [])
 
   const onOptimize = useCallback(async () => {
-    if (!character||!formulaKey) return
+    if (!character || !formulaKey) return
     const { setFilter2, setFilter4 } = character
     const cancelled = new Promise<void>((r) => (cancelToken.current = r))
     setResults([])
@@ -257,7 +257,7 @@ export default function OptimizeWrapper({
               onClick={optimizing ? onCancel : onOptimize}
               color={optimizing ? 'error' : 'success'}
               startIcon={optimizing ? <CloseIcon /> : <TrendingUpIcon />}
-              disabled={!totalPermutations || !character}
+              disabled={!formulaKey || !totalPermutations || !character}
             >
               {optimizing ? t('cancel') : t('optimize')}
             </Button>

--- a/libs/zzz/page-optimize/src/Optimize.tsx
+++ b/libs/zzz/page-optimize/src/Optimize.tsx
@@ -50,7 +50,7 @@ export default function OptimizeWrapper({
   baseStats,
   setResults,
 }: {
-  formulaKey: FormulaKey
+  formulaKey?: FormulaKey
   location: LocationKey
   baseStats: Stats
   setResults: (builds: BuildResult[]) => void
@@ -128,7 +128,7 @@ export default function OptimizeWrapper({
   useEffect(() => () => cancelToken.current(), [])
 
   const onOptimize = useCallback(async () => {
-    if (!character) return
+    if (!character||!formulaKey) return
     const { setFilter2, setFilter4 } = character
     const cancelled = new Promise<void>((r) => (cancelToken.current = r))
     setResults([])

--- a/libs/zzz/page-optimize/src/OptimizeTargetSelector.tsx
+++ b/libs/zzz/page-optimize/src/OptimizeTargetSelector.tsx
@@ -9,17 +9,22 @@ export function OptimizeTargetSelector({
   setFormulaKey,
 }: {
   disabled?: boolean
-  formulaKey: FormulaKey
+  formulaKey?: FormulaKey
   setFormulaKey: (key: FormulaKey) => void
 }) {
   return (
     <DropdownButton
       disabled={disabled}
       fullWidth
+      color={formulaKey ? 'success' : 'warning'}
       title={
-        <span>
-          Optimize Target: <strong>{formulaKeyTextMap[formulaKey]}</strong>
-        </span>
+        formulaKey ? (
+          <span>
+            Optimize Target: <strong>{formulaKeyTextMap[formulaKey]}</strong>
+          </span>
+        ) : (
+          'Select an Optimization Target'
+        )
       }
       sx={{ flexGrow: 1 }}
     >

--- a/libs/zzz/page-optimize/src/index.tsx
+++ b/libs/zzz/page-optimize/src/index.tsx
@@ -16,7 +16,6 @@ import type { DiscSlotKey, FormulaKey } from '@genshin-optimizer/zzz/consts'
 import {
   allCoreKeysWithNone,
   allDiscSlotKeys,
-  allFormulaKeys,
   wengineSheets,
   type LocationKey,
 } from '@genshin-optimizer/zzz/consts'
@@ -182,7 +181,7 @@ export default function PageOptimize() {
             setResults={setBuilds}
             baseStats={baseStats}
             location={locationKey}
-            formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
+            formulaKey={character?.formulaKey}
           />,
         ],
         [
@@ -362,7 +361,7 @@ function CharacterSection({
               {characterStats && <StatsDisplay stats={characterStats} />}
               <OptimizeTargetSelector
                 disabled={!character}
-                formulaKey={character?.formulaKey ?? allFormulaKeys[0]}
+                formulaKey={character?.formulaKey}
                 setFormulaKey={setFormulaKey}
               />
             </Stack>

--- a/libs/zzz/page-optimize/tsconfig.json
+++ b/libs/zzz/page-optimize/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "jsxImportSource": "@emotion/react"
+    "jsxImportSource": "@emotion/react",
+    "exactOptionalPropertyTypes": false
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
## Describe your changes
- Empty Opt Target by default, use warning color when it is empty, to prevent people from using the default initial atk target.
- Default characters to lvl 60/F core

## Issue or discord link

- Resolves #2802

## Testing/validation

![image](https://github.com/user-attachments/assets/1d644263-3744-437e-86a3-cf5a1817da90)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new descriptive label for energy regeneration, enhancing stat information display.

- **Refactor**
  - Updated default character settings so new profiles start at higher level and core values.
  - Improved the optimization target selection interface with a clear prompt and visual cues (including button state changes) when no target is chosen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->