### PR TITLE
ZO: add more options to bonus stats

### DIFF
--- a/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
@@ -26,7 +26,7 @@ export type SpecificDmgTypeKey = Exclude<
   'anomaly' | 'disorder' | 'aftershock' | 'elemental'
 >
 // Corresponds to damageTypes in libs\zzz\formula\src\data\util\listing.ts
-export const specificDmgTypeKeys = [
+export const specificDmgTypeKeys: SpecificDmgTypeKey[] = [
   'basic',
   'dash',
   'dodgeCounter',
@@ -38,7 +38,7 @@ export const specificDmgTypeKeys = [
   'defensiveAssist',
   'evasiveAssist',
   'assistFollowUp',
-] as SpecificDmgTypeKey[]
+] as const
 
 function isSpeicifcDmgTypeKey(key: string): key is SpecificDmgTypeKey {
   return specificDmgTypeKeys.includes(key as SpecificDmgTypeKey)

--- a/libs/zzz/db/src/Database/DataManagers/WengineDataManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/WengineDataManager.ts
@@ -149,8 +149,8 @@ export class WengineDataManager extends DataManager<
 export const initialWengine = (key: WengineKey): ICachedWengine => ({
   id: '',
   key,
-  level: 1,
-  modification: 0,
+  level: 60,
+  modification: 5,
   phase: 1,
   location: '',
   lock: false,

--- a/libs/zzz/formula-ui/src/components/TagDisplay.tsx
+++ b/libs/zzz/formula-ui/src/components/TagDisplay.tsx
@@ -38,7 +38,8 @@ const isExtraHandlingStats = (
   extraHandlingStats.includes(
     stat as 'hp' | 'hp_' | 'atk' | 'atk_' | 'def' | 'def_'
   )
-const qtMap = {
+// TODO: translation
+export const qtMap = {
   initial: 'Initial',
   combat: 'Combat',
   final: 'Final',

--- a/libs/zzz/formula-ui/src/components/TagDisplay.tsx
+++ b/libs/zzz/formula-ui/src/components/TagDisplay.tsx
@@ -7,6 +7,7 @@ import { StatIcon } from '@genshin-optimizer/zzz/svgicons'
 import { AttributeName, StatDisplay } from '@genshin-optimizer/zzz/ui'
 import { damageTypeKeysMap, getDmgType, getVariant, tagFieldMap } from '../char'
 import { getTagLabel } from '../util'
+import { qtMap } from './qtMap'
 export function TagDisplay({ tag }: { tag: Tag }) {
   return (
     <ColorText color={getVariant(tag)}>
@@ -38,13 +39,7 @@ const isExtraHandlingStats = (
   extraHandlingStats.includes(
     stat as 'hp' | 'hp_' | 'atk' | 'atk_' | 'def' | 'def_'
   )
-// TODO: translation
-export const qtMap = {
-  initial: 'Initial',
-  combat: 'Combat',
-  final: 'Final',
-  base: 'Base',
-}
+
 function TagStrDisplay({ tag }: { tag: Tag }) {
   const title = tagFieldMap.subset(tag)[0]?.title
   if (title) return title

--- a/libs/zzz/formula-ui/src/components/index.ts
+++ b/libs/zzz/formula-ui/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './TagDisplay'
+export * from './qtMap'

--- a/libs/zzz/formula-ui/src/components/qtMap.ts
+++ b/libs/zzz/formula-ui/src/components/qtMap.ts
@@ -1,0 +1,7 @@
+// TODO: translation
+export const qtMap = {
+  initial: 'Initial',
+  combat: 'Combat',
+  final: 'Final',
+  base: 'Base',
+}

--- a/libs/zzz/page-optimize-pando/src/CharStatsDisplay.tsx
+++ b/libs/zzz/page-optimize-pando/src/CharStatsDisplay.tsx
@@ -71,6 +71,7 @@ function StatLine({ read }: { read: Read<Tag> }) {
   const fText = computed && formulaText(computed)
 
   if (!computed) return null
+  const valDisplay = valueString(computed.val, getUnitStr(name ?? ''))
   return (
     <Box
       sx={{
@@ -88,12 +89,13 @@ function StatLine({ read }: { read: Read<Tag> }) {
       <Box sx={{ flexGrow: 1 }}>
         <TagDisplay tag={tag} />
       </Box>
-      {valueString(computed.val, getUnitStr(name ?? ''))}
+      {valDisplay}
       <BootstrapTooltip
         title={
           <Typography component="div">
             <Box sx={{ display: 'flex', gap: 1 }}>
               <FullTagDisplay tag={tag} />
+              <span>{valDisplay}</span>
             </Box>
             <Divider />
             <Box>{fText?.formula}</Box>

--- a/libs/zzz/page-optimize-pando/src/DmgTypeDropdown.tsx
+++ b/libs/zzz/page-optimize-pando/src/DmgTypeDropdown.tsx
@@ -1,0 +1,43 @@
+import { DropdownButton } from '@genshin-optimizer/common/ui'
+import type { DamageType } from '@genshin-optimizer/zzz/formula'
+import { damageTypeKeysMap } from '@genshin-optimizer/zzz/formula-ui'
+import { Box, MenuItem } from '@mui/material'
+
+export function DmgTypeDropdown<T extends DamageType>({
+  dmgType,
+  keys,
+  setDmgType,
+}: {
+  dmgType?: T
+  keys: T[]
+  setDmgType: (dmgType?: T) => void
+}) {
+  return (
+    <DropdownButton
+      title={
+        <Box sx={{ textWrap: 'nowrap' }}>
+          Dmg Type: {dmgType ? damageTypeKeysMap[dmgType] : 'Any'}
+        </Box>
+      }
+    >
+      <MenuItem
+        key={'any'}
+        selected={!dmgType}
+        disabled={!dmgType}
+        onClick={() => setDmgType()}
+      >
+        Any
+      </MenuItem>
+      {keys.map((k) => (
+        <MenuItem
+          key={k}
+          selected={dmgType === k}
+          disabled={dmgType === k}
+          onClick={() => setDmgType(k)}
+        >
+          {damageTypeKeysMap[k]}
+        </MenuItem>
+      ))}
+    </DropdownButton>
+  )
+}

--- a/libs/zzz/page-optimize-pando/src/Optimize/DiscFilter.tsx
+++ b/libs/zzz/page-optimize-pando/src/Optimize/DiscFilter.tsx
@@ -121,7 +121,7 @@ function DiscFilterModal({
               >
                 Use equipped Discs
               </Button>
-              <SetFilter disabled={disabled} />
+              <SetFilter discBySlot={discsBySlot} disabled={disabled} />
             </Stack>
           </Suspense>
         </CardContent>
@@ -194,7 +194,10 @@ function MainStatSelector({
   )
 }
 
-function SetFilter({ disabled }: { disabled?: boolean }) {
+function SetFilter({
+  discBySlot,
+  disabled,
+}: { discBySlot: Record<DiscSlotKey, ICachedDisc[]>; disabled?: boolean }) {
   const { database } = useDatabaseContext()
   const { optConfigId, optConfig } = useContext(OptConfigContext)
   const { setFilter2 = [], setFilter4 = [] } = optConfig
@@ -213,6 +216,7 @@ function SetFilter({ disabled }: { disabled?: boolean }) {
   )
   return (
     <DiscSetFilter
+      discBySlot={discBySlot}
       disabled={disabled}
       setFilter2={setFilter2}
       setFilter4={setFilter4}

--- a/libs/zzz/page-optimize-pando/src/SpecificDmgTypeSelector.tsx
+++ b/libs/zzz/page-optimize-pando/src/SpecificDmgTypeSelector.tsx
@@ -1,4 +1,3 @@
-import { DropdownButton } from '@genshin-optimizer/common/ui'
 import type { SpecificDmgTypeKey } from '@genshin-optimizer/zzz/db'
 import { specificDmgTypeKeys } from '@genshin-optimizer/zzz/db'
 import {
@@ -7,8 +6,9 @@ import {
   useDatabaseContext,
 } from '@genshin-optimizer/zzz/db-ui'
 import { damageTypeKeysMap } from '@genshin-optimizer/zzz/formula-ui'
-import { Box, Button, MenuItem } from '@mui/material'
+import { Button } from '@mui/material'
 import { useCallback } from 'react'
+import { DmgTypeDropdown } from './DmgTypeDropdown'
 
 export function SpecificDmgTypeSelector() {
   const { database } = useDatabaseContext()
@@ -22,8 +22,9 @@ export function SpecificDmgTypeSelector() {
   )
   if (targetName !== 'standardDmgInst') return null
   return (
-    <SpecificDmgTypeDropdown
+    <DmgTypeDropdown
       dmgType={targetDamageType1}
+      keys={specificDmgTypeKeys}
       setDmgType={setDmgType}
     />
   )
@@ -62,42 +63,5 @@ export function AfterShockToggleButton({
     >
       {damageTypeKeysMap.aftershock}
     </Button>
-  )
-}
-
-export function SpecificDmgTypeDropdown({
-  dmgType,
-  setDmgType,
-}: {
-  dmgType?: SpecificDmgTypeKey
-  setDmgType: (dmgType?: SpecificDmgTypeKey) => void
-}) {
-  return (
-    <DropdownButton
-      title={
-        <Box sx={{ textWrap: 'nowrap' }}>
-          Specific Dmg Type: {dmgType ? damageTypeKeysMap[dmgType] : 'None'}
-        </Box>
-      }
-    >
-      <MenuItem
-        key={'any'}
-        selected={!dmgType}
-        disabled={!dmgType}
-        onClick={() => setDmgType()}
-      >
-        Any
-      </MenuItem>
-      {specificDmgTypeKeys.map((k) => (
-        <MenuItem
-          key={k}
-          selected={dmgType === k}
-          disabled={dmgType === k}
-          onClick={() => setDmgType(k)}
-        >
-          {damageTypeKeysMap[k]}
-        </MenuItem>
-      ))}
-    </DropdownButton>
   )
 }


### PR DESCRIPTION
## Describe your changes

- Allow adding to base/initial stats
- Add more stats
- Refactor `DamageTypeDropdown`

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![image](https://github.com/user-attachments/assets/079b86c6-d4f7-4f91-8aa4-136fac1509ab)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new dropdown interface for selecting damage types, improving the user experience for managing bonus stats.
  - Added a quality selection dropdown that streamlines adjustments in bonus statistics.
  - Updated default engine settings to yield higher initial values.
  - Exported the `qtMap` constant for broader accessibility across modules.

- **Refactor**
  - Consolidated and modernized dropdown components for damage type and quality selections to ensure a more consistent, user-friendly interface.
  - Enhanced type safety and modularity within the components.
  - Removed the `SpecificDmgTypeDropdown` component, integrating its functionality into the new `DmgTypeDropdown`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->