### PR TITLE
ZO: amend disc set check in specific sheets

### DIFF
--- a/libs/zzz/formula/src/data/disc/sheets/ProtoPunk.ts
+++ b/libs/zzz/formula/src/data/disc/sheets/ProtoPunk.ts
@@ -19,7 +19,7 @@ const sheet = registerDisc(
   registerBuff(
     'set4_cond_def_assist_or_evasive_assist_dmg_',
     ownBuff.combat.common_dmg_.add(
-      cmpGE(discCount, 2, def_assist_or_evasive_assist.ifOn(0.15))
+      cmpGE(discCount, 4, def_assist_or_evasive_assist.ifOn(0.15))
     ),
     showCond4Set
   )

--- a/libs/zzz/formula/src/data/disc/sheets/ThunderMetal.ts
+++ b/libs/zzz/formula/src/data/disc/sheets/ThunderMetal.ts
@@ -18,7 +18,7 @@ const sheet = registerDisc(
   // Conditional buffs
   registerBuff(
     'set4_cond_enemy_shocked_atk_',
-    ownBuff.combat.atk_.add(cmpGE(discCount, 2, enemy_shocked.ifOn(0.28))),
+    ownBuff.combat.atk_.add(cmpGE(discCount, 4, enemy_shocked.ifOn(0.28))),
     showCond4Set
   )
 )

--- a/libs/zzz/formula/src/generators/gen-sheet/disc/__sheet__.ts.template
+++ b/libs/zzz/formula/src/generators/gen-sheet/disc/__sheet__.ts.template
@@ -32,7 +32,7 @@ const sheet = registerDisc(
   registerBuff(
     'set4_dmg_',
     ownBuff.combat.common_dmg_.add(
-      cmpGE(discCount, 2, boolConditional.ifOn(0.1))
+      cmpGE(discCount, 4, boolConditional.ifOn(0.1))
     ),
     showCond4Set
   ),


### PR DESCRIPTION
## Describe your changes

Some sheets were checking for 2p instead of 4p.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Gameplay Balancing**
  - Increased the resource threshold needed to activate certain buffs. Players will now need to accumulate more tokens before these effects are triggered, adding a new strategic layer to gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->