### PR TITLE
Bug Fix

### DIFF
--- a/libs/pando/engine/src/optimization/prune.ts
+++ b/libs/pando/engine/src/optimization/prune.ts
@@ -307,7 +307,7 @@ export function reaffine<ID>(state: State<OP, ID>) {
       case 'prod': {
         const idx = n.x.findIndex((n) => n.op !== 'const')
         if (n.x.find((n, i) => n.op !== 'const' && i !== idx)) return // multiple non-const terms
-        weight = { ...x[idx] }
+        weight = idx !== -1 ? { ...x[idx] } : { [offset]: 1 }
         const factor = x.reduce((f, w, i) => (i === idx ? f : f * w[offset]), 1)
         if (factor != 1) {
           Object.keys(weight).forEach((k) => (weight[k] *= factor))

--- a/libs/sr/solver/src/solver.ts
+++ b/libs/sr/solver/src/solver.ts
@@ -66,7 +66,9 @@ export function optimize(
     if (tag['et'] !== 'own') return undefined // Not applied (only) to self
 
     if (tag['sheet'] === 'dyn' && tag['qt'] === 'premod')
-      return { q: tag['q']! } // Relic stat bonus
+      if (tag.q === 'dmg_')
+        return { q: `${tag.elementalType}_dmg_` } // per-element dmg bonus
+      else return { q: tag['q']! } // Relic stat bonus
     if (tag['q'] === 'count' && relicSetKeys.has(tag['sheet'] as any))
       return { q: tag['sheet']! } // Relic set counter
     if (

--- a/libs/sr/solver/src/solver.ts
+++ b/libs/sr/solver/src/solver.ts
@@ -66,8 +66,7 @@ export function optimize(
     if (tag['et'] !== 'own') return undefined // Not applied (only) to self
 
     if (tag['sheet'] === 'dyn' && tag['qt'] === 'premod')
-      if (tag.q === 'dmg_')
-        return { q: `${tag.elementalType}_dmg_` } // per-element dmg bonus
+      if (tag.q === 'dmg_') return { q: `${tag.elementalType}_dmg_` }
       else return { q: tag['q']! } // Relic stat bonus
     if (tag['q'] === 'count' && relicSetKeys.has(tag['sheet'] as any))
       return { q: tag['sheet']! } // Relic set counter

--- a/libs/zzz/solver/src/index.ts
+++ b/libs/zzz/solver/src/index.ts
@@ -87,7 +87,9 @@ export function optimize(
     // dyn is added as a layer in `discTagMapNodeEntries`
     // only `initial` stats are in main/subs of discs.
     if (tag['sheet'] === 'dyn' && tag['qt'] === 'initial')
-      return { q: tag['q']! } // Disc stat bonus
+      if (tag.q === 'dmg_')
+        return { q: `${tag.attribute}_dmg_` } // per-attribute `dmg_` bonus
+      else return { q: tag['q']! } // Disc stat bonus
 
     // Disc set counter
     if (tag['q'] === 'count' && discSetKeys.has(tag['sheet'] as any))

--- a/libs/zzz/solver/src/index.ts
+++ b/libs/zzz/solver/src/index.ts
@@ -87,8 +87,7 @@ export function optimize(
     // dyn is added as a layer in `discTagMapNodeEntries`
     // only `initial` stats are in main/subs of discs.
     if (tag['sheet'] === 'dyn' && tag['qt'] === 'initial')
-      if (tag.q === 'dmg_')
-        return { q: `${tag.attribute}_dmg_` } // per-attribute `dmg_` bonus
+      if (tag.q === 'dmg_') return { q: `${tag.attribute}_dmg_` }
       else return { q: tag['q']! } // Disc stat bonus
 
     // Disc set counter


### PR DESCRIPTION
## Describe your changes

This PR fixes #2886, which are caused by two separate bugs. The first bug is the appearance of `NaN` when pruning constant-valued `prod` node (e.g. `prod(1, 2, 3)`), including ones introduced by other prunings.
The second bugs is the value mismatched between the solver and the UI, caused by detachment incorrectly detach elemental/attributed dmg bonus as `dmg_` instead of `<ele/attribute>_dmg_`.

## Issue or discord link

https://discord.com/channels/785153694478893126/1189329506842984570/1353184512430968862

## Testing/validation

Tested with the DB in #2886.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
