### PR TITLE
ZO: change statfilter symbols to min/max

### DIFF
--- a/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
+++ b/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
@@ -223,7 +223,7 @@ function StatFilterItem({
           />
         )}
         <Button onClick={() => setTargetisMax(!isMax)} size="small">
-          <strong>{isMax ? '<=' : '>='}</strong>
+          <strong>{isMax ? 'MAX' : 'MIN'}</strong>
         </Button>
 
         <NumberInputLazy


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

![image](https://github.com/user-attachments/assets/b9408f82-db15-44bd-a82f-51ef886de69f)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated a button on the filter section to display "MAX" for the active maximum state and "MIN" for the active minimum state, replacing the previous comparative symbols for clearer user communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->