### PR TITLE
Pando: Update `DebugCalculator`

### DIFF
--- a/libs/game-opt/engine/src/calculator.ts
+++ b/libs/game-opt/engine/src/calculator.ts
@@ -76,8 +76,7 @@ export class Calculator<
           [dst ?? 'All']: { [src]: { [sheet!]: { [q!]: val } } },
         })
     }
-    if (op === 'read')
-      [op, ex] = [ex ?? this.defaultAccu(tag!) ?? 'read', undefined]
+    if (op === 'read' && ex !== 'unique') [op, ex] = [ex, undefined]
     switch (op) {
       case 'sum':
       case 'prod':

--- a/libs/game-opt/engine/src/calculator.ts
+++ b/libs/game-opt/engine/src/calculator.ts
@@ -84,7 +84,7 @@ export class Calculator<
       case 'max':
       case 'sumfrac':
         if (x.length > 1) {
-          const empty = arithmetic[op]([], ex)
+          const empty = arithmetic[op]([])
           x = x.filter((x) => x.val !== empty)
         }
         if (x.length === 1) return wrap(x[0])

--- a/libs/game-opt/formula/src/debug.ts
+++ b/libs/game-opt/formula/src/debug.ts
@@ -1,18 +1,13 @@
 import type { DebugMeta } from '@genshin-optimizer/pando/engine'
 
 export function createFilterDebug(equipmentKeys: string[]) {
-  return (debug: DebugMeta) => !debugIsUnequippedEquipment(debug, equipmentKeys)
+  const sheets = new Set(equipmentKeys)
+  return (meta: DebugMeta): boolean => !useCounter(meta, sheets)
 }
 
-function debugIsUnequippedEquipment(debug: DebugMeta, equipmentKeys: string[]) {
-  if (!debug.formula || !debug.deps || debug.deps.length < 1) return false
-  const f = debug.formula
-  const disabledBuffForEquip =
-    f.includes('[0]') &&
-    f.includes('common.count') &&
-    equipmentKeys.some((key) => f.includes(key))
-  const depGathered0ForCount =
-    debug.deps[0].formula?.includes('gather 0 node') &&
-    debug.deps[0].formula?.includes('common.count')
-  return disabledBuffForEquip && depGathered0ForCount
+function useCounter(meta: DebugMeta, sheets: Set<string>): boolean {
+  const counter = meta.formula.match(/(\S+) (\S+) common.count/)
+  if (!counter) return false
+  const [, sheet, et] = counter
+  return et === 'own' && sheets.has(sheet)
 }

--- a/libs/game-opt/solver/src/debug.ts
+++ b/libs/game-opt/solver/src/debug.ts
@@ -1,0 +1,45 @@
+import type { AnyTagFree } from '@genshin-optimizer/pando/engine'
+import { DebugCalculator, mapBottomUp } from '@genshin-optimizer/pando/engine'
+import {
+  Calculator,
+  compileTagMapKeys,
+  compileTagMapValues,
+  constant,
+} from '@genshin-optimizer/pando/engine'
+import type { Candidate } from './common'
+
+export function debugMeta(
+  nodes: AnyTagFree[],
+  candidates: Candidate[][],
+  ids: Candidate['id'][],
+  dynTagCat: string
+): ReturnType<DebugCalculator['compute']>['meta'][] {
+  const build = candidates.map((cnds, i) => cnds.find((c) => c.id === ids[i])!)
+  const missingId = build.findIndex((c) => !c)
+  if (missingId !== -1)
+    throw new Error(`no candidate with id ${ids[missingId]}`)
+
+  const cats = new Set(build.flatMap((c) => Object.keys(c)))
+  nodes = mapBottomUp(nodes, (n) => {
+    if (n.op === 'read') {
+      cats.add(n.tag[dynTagCat]!)
+      return { ...n, ex: n.ex ?? 'sum' }
+    }
+    return n
+  })
+  const keys = compileTagMapKeys([{ category: dynTagCat, values: cats }])
+  const calc = new Calculator(
+    keys,
+    compileTagMapValues(
+      keys,
+      build.flatMap((c) =>
+        Object.entries(c).map(([cat, v]) => ({
+          tag: { [dynTagCat]: cat },
+          value: constant(v),
+        }))
+      )
+    )
+  )
+  const debugCalc = new DebugCalculator(calc)
+  return nodes.map((n) => debugCalc.compute(n).meta)
+}

--- a/libs/game-opt/solver/src/index.ts
+++ b/libs/game-opt/solver/src/index.ts
@@ -1,3 +1,4 @@
 export type { Candidate } from '@genshin-optimizer/pando/engine'
 export * from './common'
 export * from './solver'
+import type {} from './debug'

--- a/libs/gi/formula/src/example.test.ts
+++ b/libs/gi/formula/src/example.test.ts
@@ -235,8 +235,7 @@ describe('example', () => {
     const compiled = compile(
       detached,
       'q', // Tag category for object key
-      2, // Number of slots
-      {} // Initial values
+      2 // Number of slots
     )
 
     // Step 5: Calculate the value

--- a/libs/pando/engine/src/debug.ts
+++ b/libs/pando/engine/src/debug.ts
@@ -112,7 +112,7 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
     const op = n.op === 'read' ? n.ex : n.op
     const omitted: DebugMeta[] = []
     if (op! in arithmetic) {
-      const ignorable = arithmetic[op as keyof typeof arithmetic]([], undefined)
+      const ignorable = arithmetic[op as keyof typeof arithmetic]([])
       for (const arg of [...br, ...x])
         if (arg.val !== ignorable || this.filter(arg)) args.push(arg)
         else omitted.push(arg)

--- a/libs/pando/engine/src/debug.ts
+++ b/libs/pando/engine/src/debug.ts
@@ -1,26 +1,24 @@
-import type {
-  AnyNode,
-  BaseRead,
-  CalcResult,
-  PreRead,
-  ReRead,
-  TagCache,
-} from './node'
-import { Calculator as BaseCalculator, map } from './node'
-import type { Tag, TagMapEntries, TagMapEntry } from './tag'
+import type { AnyNode, BaseRead, CalcResult, PreRead, TagCache } from './node'
+import { Calculator as BaseCalculator } from './node'
+import { arithmetic } from './node/formula'
+import type { Tag } from './tag'
 
 type TagStr = (tag: Tag, ex?: any) => string
 type Predicate = (debug: DebugMeta) => boolean
 
-/** Sequence of entries matched by gathering, in reverse order (final entry first) */
-type ReadSeq = [TagMapEntry<AnyNode>, ...TagMapEntries<ReRead>]
-export type DebugMeta = {
-  readSeq?: ReadSeq
+export interface DebugMeta {
+  readSeq?: string
   formula: string
   deps: DebugMeta[]
+  omitted: DebugMeta[]
 
-  isRead: boolean
-  toJSON(): any
+  val: number | string
+  x: DebugMeta[]
+  br: DebugMeta[]
+
+  comp: string
+  pivot: boolean
+  toJSON: (this: DebugMeta) => any
 }
 export class DebugCalculator extends BaseCalculator<DebugMeta> {
   tagStr: TagStr
@@ -45,7 +43,8 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
   }
 
   override _gather(cache: TagCache<DebugMeta>): PreRead<DebugMeta> {
-    if (this.gathering.has(cache)) throw new Error(`Loop detected`)
+    if (this.gathering.has(cache))
+      throw new Error(`Loop detected for ${this.tagStr(cache.tag)}`)
     this.gathering.add(cache)
     const result = this.__gather(cache)
     this.gathering.delete(cache)
@@ -54,17 +53,17 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
 
   __gather(cache: TagCache<DebugMeta>): PreRead<DebugMeta> {
     if (cache.val) return cache.val
-
     const pre = this.nodes.entries(cache.id).flatMap(({ tag, value: n }) =>
       n.op === 'reread'
         ? this._gather(cache.with(n.tag)).pre.map((x) => {
-            const readSeq: ReadSeq = [...x.meta.readSeq!, { tag, value: n }]
+            const readSeq = `${this.tagStr(tag)} <= ${this.tagStr(n.tag)} : ${x.meta.readSeq}`
             return Object.freeze({ ...x, meta: { ...x.meta, readSeq } })
           })
         : [this.markGathered(cache.tag, tag, n, this._compute(n, cache))]
     )
     return (cache.val = { pre })
   }
+
   override _compute(
     n: AnyNode,
     cache: TagCache<DebugMeta>
@@ -72,98 +71,95 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
     try {
       return super._compute(n, cache)
     } catch (e) {
-      return {
+      return Object.freeze({
         val: NaN,
         meta: {
-          formula: `err: ${(e as any).message} in ${this.tagStr(
-            cache.tag
-          )}: ${nodeString(n, this.tagStr)}`,
+          formula: `${e}`,
           deps: [],
-          isRead: true,
-          toJSON: metaToJSON(this.tagStr),
+          omitted: [],
+
+          val: NaN,
+          x: [],
+          br: [],
+          comp: 'ERR',
+          pivot: true,
+          toJSON,
         },
-      }
+      })
     }
   }
 
   override markGathered(
-    _tag: Tag,
+    tag: Tag,
     entryTag: Tag,
-    n: AnyNode | undefined,
-    { val, meta }: CalcResult<number | string, DebugMeta>
+    _n: AnyNode | undefined,
+    result: CalcResult<number | string, DebugMeta>
   ): CalcResult<number | string, DebugMeta> {
-    meta = { ...meta, readSeq: [{ tag: entryTag!, value: n! }] }
-    return Object.freeze({ val, meta })
+    const readSeq = `${this.tagStr(entryTag)} <- ${this.tagStr(tag)}`
+    return { ...result, meta: { ...result.meta, readSeq, pivot: true } }
   }
   override computeMeta(
     n: AnyNode,
     val: number | string,
-    x: (CalcResult<number | string, DebugMeta> | undefined)[],
-    br: CalcResult<number | string, DebugMeta>[],
+    _x: (CalcResult<number | string, DebugMeta> | undefined)[],
+    _br: CalcResult<number | string, DebugMeta>[],
     tag: Tag | undefined
   ): DebugMeta {
-    if (typeof val !== 'number') val = `"${val}"`
-    else if (Math.round(val) === val) val = `${val}`
-    else val = val.toFixed(2)
-
-    const result: DebugMeta = {
-      formula: `[${val}] ${nodeString(n, this.tagStr)}`,
-      deps: [
-        ...x.map((x) => x?.meta).filter((x) => !!x),
-        ...br.map((br) => br.meta),
-      ].flatMap((x) => (x.isRead ? [x] : x.deps)),
-      isRead: n.op === 'read',
-      toJSON: metaToJSON(this.tagStr),
-    }
-    if (n.op === 'read') {
-      tag = Object.fromEntries(Object.entries(tag!).filter(([_, v]) => v))
-      result.deps = x.map((x) => x!.meta)
-      const oldDepCount = result.deps.length
-      result.deps = result.deps.filter(this.filter)
-      const filtered = oldDepCount - result.deps.length
-      result.formula = `gather ${
-        x.length
-      } node(s) (${filtered} filtered) for ${this.tagStr(n.tag)} (${this.tagStr(
-        tag
-      )})`
-    }
-    return result
-  }
-}
-
-export function nodeString(
-  node: AnyNode,
-  tagStr: TagStr = (t) => JSON.stringify(t)
-): string {
-  return map([node], (node, map: (n: AnyNode) => string) => {
-    const { op, tag, br, x } = node
-    let { ex } = node
-    if (op === 'const') return `${ex}`
-    if (op === 'read') return tagStr(tag, ex)
-    if (op === 'subscript') ex = undefined
-    const args: string[] = []
-    if (ex) args.push(JSON.stringify(ex))
-    if (tag) args.push(tagStr(tag))
-    args.push(...br.map(map), ...x.map(map))
-    return `${op}(` + args.join(', ') + ')'
-  })[0]
-}
-
-function metaToJSON(tagStr: TagStr): (this: DebugMeta) => any {
-  return function (this: DebugMeta): any {
-    const { readSeq, formula, deps } = this
-    let readStr
-    if (readSeq?.some((e) => !!e)) {
-      const [head, ...rem] = readSeq
-      let str = ''
-      for (let i = rem.length - 1; i >= 0; i--) {
-        if (rem[i]) {
-          const { tag: dst, value } = rem[i]
-          str += `${tagStr(dst)} <= ${tagStr(value.tag)} : `
-        } else str += '!! : '
+    let comp: string, formula: string | undefined
+    const x = _x.filter((n) => n!).map((n) => n!.meta)
+    const br = _br.map((n) => n.meta)
+    const args: DebugMeta[] = []
+    const op = n.op === 'read' ? n.ex : n.op
+    const omitted: DebugMeta[] = []
+    if (op! in arithmetic) {
+      const ignorable = arithmetic[op as keyof typeof arithmetic]([], undefined)
+      for (const arg of [...br, ...x])
+        if (arg.val !== ignorable || this.filter(arg)) args.push(arg)
+        else omitted.push(arg)
+    } else args.push(...br, ...x)
+    switch (n.op) {
+      case 'const':
+        comp = valStr(n.ex)
+        break
+      case 'read':
+        formula = `gather ${x.length} node(s)`
+        formula += ` matching ${this.tagStr(tag!, n.ex)}`
+        formula += ` (for ${this.tagStr(n.tag!)})`
+        if (omitted.length) formula += ` <${omitted.length} omitted>`
+        comp = `${this.tagStr(n.tag!)}`
+        break
+      default: {
+        const argStrs: string[] = []
+        if (n.ex && n.op !== 'subscript') argStrs.push(JSON.stringify(n.ex))
+        if (n.tag) argStrs.push(this.tagStr(n.tag))
+        argStrs.push(...args.map((m) => m.comp))
+        if (omitted.length) argStrs.push(`<${omitted.length} omitted>`)
+        comp = `${n.op}(` + argStrs.join(', ') + `)`
       }
-      readStr = str + (head ? `matches ${tagStr(head.tag)}` : '!!')
     }
-    return { ...(readStr && { readSeq: readStr }), formula, deps }
+    omitted.push(...args.flatMap((m) => (m.pivot ? [] : m.omitted)))
+    return Object.freeze({
+      formula: `[${valStr(val)}] ${formula ?? comp}`,
+      deps: [...new Set(args.flatMap((m) => (m.pivot ? [m] : m.deps)))],
+      omitted: [...new Set(omitted)],
+
+      val,
+      x,
+      br,
+      comp,
+      pivot: n.op === 'read',
+      toJSON,
+    })
   }
+}
+
+const valStr = (val: number | string) =>
+  typeof val === 'string' ? `"${val}"` : val.toString()
+function toJSON(this: DebugMeta) {
+  const { formula, readSeq, deps } = this
+  const result: any = { readSeq, formula, deps }
+  if (!result.readSeq) delete result.readSeq
+  if (!result.deps.length) delete result.deps
+  if (Object.keys(result).length === 1) return result.formula
+  return result
 }

--- a/libs/pando/engine/src/debug.ts
+++ b/libs/pando/engine/src/debug.ts
@@ -2,6 +2,7 @@ import type { AnyNode, BaseRead, CalcResult, PreRead, TagCache } from './node'
 import { Calculator as BaseCalculator } from './node'
 import { arithmetic } from './node/formula'
 import type { Tag } from './tag'
+import { tagString } from './util'
 
 type TagStr = (tag: Tag, ex?: any) => string
 type Predicate = (debug: DebugMeta) => boolean
@@ -28,7 +29,7 @@ export class DebugCalculator extends BaseCalculator<DebugMeta> {
 
   constructor(
     calc: BaseCalculator<any>,
-    tagStr: TagStr,
+    tagStr: TagStr = tagString,
     filter: Predicate = () => true
   ) {
     super(calc.cache.keys)

--- a/libs/pando/engine/src/node/calc.ts
+++ b/libs/pando/engine/src/node/calc.ts
@@ -129,6 +129,7 @@ export class Calculator<M = any> {
         const computed = this._gather(newCache)
         const { pre } = computed
         const ex = n.ex ?? this.defaultAccu(newCache.tag) ?? 'unique'
+        if (ex !== n.ex) n = { ...n, ex }
 
         if (computed[ex]) return computed[ex]
         if (isDebug('calc') && ex === 'unique' && pre.length !== 1)

--- a/libs/pando/engine/src/node/calc.ts
+++ b/libs/pando/engine/src/node/calc.ts
@@ -94,7 +94,7 @@ export class Calculator<M = any> {
       case 'max':
       case 'sumfrac': {
         const x = n.x.map((n) => this._compute(n, cache))
-        return finalize(arithmetic[op](getV(x), n.ex), x, [])
+        return finalize(arithmetic[op](getV(x)), x, [])
       }
       case 'thres':
       case 'match':
@@ -134,7 +134,7 @@ export class Calculator<M = any> {
         if (computed[ex]) return computed[ex]
         if (isDebug('calc') && ex === 'unique' && pre.length !== 1)
           throw new Error(`Ill-form read for ${tagString(newCache.tag)}`)
-        const val = arithmetic[ex](getV(pre) as number[], undefined)
+        const val = arithmetic[ex](getV(pre) as number[])
         return (computed[ex] = finalize(val, pre, [], newCache.tag))
       }
       case 'custom': {

--- a/libs/pando/engine/src/node/formula.ts
+++ b/libs/pando/engine/src/node/formula.ts
@@ -14,7 +14,7 @@ type Branching<Output> = Match<Output> | Threshold<Output> | Lookup<Output>
 
 export const arithmetic: Record<
   Arithmetics['op'] | 'unique',
-  (x: number[], ex: any) => number
+  (x: number[]) => number
 > = {
   sum: (x) => x.reduce((a, b) => a + b, 0),
   prod: (x) => x.reduce((a, b) => a * b, 1),
@@ -25,7 +25,7 @@ export const arithmetic: Record<
 }
 export const branching: Record<
   Branching<unknown>['op'],
-  (br: any[], ex: any) => number
+  (br: (number | string)[], ex: any) => number
 > = {
   match: ([v1, v2]) => (v1 === v2 ? 0 : 1),
   thres: ([v1, v2]) => (v1 >= v2 ? 0 : 1),

--- a/libs/pando/engine/src/node/transform.ts
+++ b/libs/pando/engine/src/node/transform.ts
@@ -65,16 +65,10 @@ export function detach(
   }
   function fold(
     x: NumTagFree[],
-    op: Exclude<keyof typeof arithmetic, 'unique'>,
-    ex: any
+    op: Exclude<keyof typeof arithmetic, 'unique'>
   ): NumTagFree {
     if (x.every((x) => x.op === 'const'))
-      return constant(
-        arithmetic[op](
-          x.map((x) => x.ex),
-          ex
-        )
-      )
+      return constant(arithmetic[op](x.map((x) => x.ex)))
     return { op, x, br: [] }
   }
 
@@ -91,7 +85,7 @@ export function detach(
         const ex = n.ex ?? calc.defaultAccu(newCache.tag) ?? 'unique'
         const x = detachRead(newCache, ex)
         if (ex === 'unique') return x[0] ?? constant(undefined as any)
-        return fold(x as NumTagFree[], ex, n.ex)
+        return fold(x as NumTagFree[], ex)
       }
       case 'sum':
       case 'prod':
@@ -99,7 +93,7 @@ export function detach(
       case 'max':
       case 'sumfrac': {
         const x = n.x.map((x) => map(x, cache))
-        return fold(x, op, n.ex)
+        return fold(x, op)
       }
       case 'thres':
       case 'match':
@@ -110,10 +104,8 @@ export function detach(
           map(br, cache)
         ) as unknown as Const<string>[]
         if (br.every((n) => n.op === 'const')) {
-          const branchID = branching[n.op](
-            br.map((br) => br.ex),
-            n.ex
-          )
+          const brV = br.map((br) => br.ex)
+          const branchID = branching[n.op](brV, n.ex)
           return map(n.x[branchID]!, cache)
         }
         return { ...n, x: n.x.map((x) => map(x, cache)), br } as AnyTagFree

--- a/libs/pando/engine/src/optimization/prune.spec.ts
+++ b/libs/pando/engine/src/optimization/prune.spec.ts
@@ -19,6 +19,7 @@ import { State, pruneBranches, pruneRange, reaffine } from './prune'
 const r0 = read({ q: 'c0' })
 const r1 = read({ q: 'c1' })
 const r2 = read({ q: 'c2' })
+const r4 = read({ q: 'c4' })
 
 addCustomOperation('sqrt', {
   range: ([r]) => {
@@ -47,6 +48,9 @@ describe('pruning', () => {
     const nodes = [
       prod(7, sum(r0, prod(3, r1), 6), sum(r0, r1, 2)),
       constant(11),
+      sum(r0, prod(3, 4, 5)),
+      sum(r0, sum(3, 4, 5)),
+      sum(r0, 77),
     ]
     const state = new State(nodes, [], candidates, 'q')
     state.progress = false
@@ -54,15 +58,21 @@ describe('pruning', () => {
     expect(state.progress).toBe(true)
     // Normally the reaffined keys are unspecified, but since the current
     // algorithm is deterministic, we can just run it and note the keys
-    // [c0, c1] = [c0 + 3c1, c0 + c1]
+    // [c0, c1, c4] = [c0 + 3c1, c0 + c1, c0]
     expect(state.candidates).toEqual([
       [
-        { id: 1, c0: 9, c1: 3 },
-        { id: 2, c0: 12, c1: 8 },
-        { id: 3, c0: 13, c1: 11 },
+        { id: 1, c0: 9, c1: 3, c4: 0 },
+        { id: 2, c0: 12, c1: 8, c4: 6 },
+        { id: 3, c0: 13, c1: 11, c4: 10 },
       ],
     ])
-    expect(state.nodes).toEqual([prod(7, sum(6, r0), sum(2, r1)), constant(11)])
+    expect(state.nodes).toEqual([
+      prod(7, sum(6, r0), sum(2, r1)),
+      constant(11),
+      sum(60, r4),
+      sum(12, r4),
+      sum(77, r4),
+    ])
   })
   test('pruneBranches', () => {
     const nodes = [

--- a/libs/pando/engine/src/optimization/prune.ts
+++ b/libs/pando/engine/src/optimization/prune.ts
@@ -433,10 +433,10 @@ function computeNodeRanges(
     ): Range {
       const calc = arithmetic[op]
       const vals = [
-        calc([x0.min, x1.min], undefined),
-        calc([x0.min, x1.max], undefined),
-        calc([x0.max, x1.min], undefined),
-        calc([x0.max, x1.max], undefined),
+        calc([x0.min, x1.min]),
+        calc([x0.min, x1.max]),
+        calc([x0.max, x1.min]),
+        calc([x0.max, x1.max]),
       ]
       return { min: Math.min(...vals), max: Math.max(...vals) }
     }

--- a/libs/pando/engine/src/optimization/simplify.ts
+++ b/libs/pando/engine/src/optimization/simplify.ts
@@ -52,13 +52,10 @@ export function combineConst<I extends OP>(n: AnyNode<I>[]): AnyNode<I>[] {
         const constX = n.x.filter((x) => x.op === 'const') as Const<number>[]
         if (constX.length > 1) {
           const varX = n.x.filter((x) => x.op !== 'const') as NumNode<I>[]
-          const constVal = arithmetic[op](
-            constX.map((x) => x.ex),
-            n.ex
-          )
+          const constVal = arithmetic[op](constX.map((x) => x.ex))
 
           // Vacuous const part; don't add the unnecessary const term
-          if (constVal === arithmetic[op]([], n.ex))
+          if (constVal === arithmetic[op]([]))
             return { ...n, x: varX } as NumNode<I>
           return { ...n, x: [constant(constVal), ...varX] } as NumNode<I>
         }

--- a/libs/zzz/formula/src/formula.test.ts
+++ b/libs/zzz/formula/src/formula.test.ts
@@ -1,5 +1,4 @@
 import { fail } from 'assert'
-import { prettify } from '@genshin-optimizer/common/util'
 import {
   compileTagMapValues,
   read,
@@ -238,23 +237,11 @@ describe('char+wengine test', () => {
       expect(calc.compute(anby.base.atk).val).toBeCloseTo(1134.797)
       expect(calc.compute(anby.final.atk).val).toBeCloseTo(1597.696912)
 
-      const debug = calc
-        .withTag({ src: 'Anby', dst: 'Anby' })
-        .toDebug()
-        .compute(read(formulas.Anby.standardDmgInst.tag, undefined))
-      console.log(prettify(debug))
-
       expect(
         calc
           .withTag({ src: 'Anby', dst: 'Anby' })
           .compute(read(formulas.Anby.standardDmgInst.tag, undefined)).val
       ).toBeCloseTo(expectedStandardDmg)
-
-      const debug2 = calc
-        .withTag({ src: 'Anby', dst: 'Anby' })
-        .toDebug()
-        .compute(read(formulas.Anby.anomalyDmgInst.tag, undefined))
-      console.log(prettify(debug2))
 
       expect(
         calc
@@ -342,7 +329,6 @@ describe('disc2p test', () => {
       compileTagMapValues(keys, data)
     ).withTag({ src: 'Anby', dst: 'Anby' })
     const anby = convert(ownTag, { et: 'own', src: 'Anby' })
-    console.log(prettify(calc.toDebug().compute(anby.final.atk)))
     expect(calc.compute(anby.final.atk).val).toBeCloseTo(195)
     expect(calc.compute(anby.final.crit_dmg_).val).toBeCloseTo(0.66)
   })


### PR DESCRIPTION
## Describe your changes

This PR updates `DebugCalculator` to allow for more detailed printing. Particularly, `meta` field now has a recursive `x` and `br`, so one can navigate `calcResult.x[0].br[1].br[2]` to print only a small portion of the calculation, including omitted parts.

Also add some more tests for #2886, and minor clean up.

## Issue or discord link

n/a

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced core processing logic and error handling for more consistent, reliable computation.
  - Streamlined diagnostic and evaluation routines for clearer feedback when reviewing outcomes.
  - Simplified function signatures and removed unnecessary parameters across various components for improved clarity and usability.
  - Introduced a new function for computing metadata from nodes and candidates.

- **Tests**
  - Updated test cases to reflect improved candidate handling and optimized computation results.
  - Removed extraneous debugging logs to provide cleaner, more focused test outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->