### PR TITLE
GO: Fix Iansan/Varesa bugs

### DIFF
--- a/libs/gi/localization/assets/locales/en/char_Varesa.json
+++ b/libs/gi/localization/assets/locales/en/char_Varesa.json
@@ -1,9 +1,11 @@
 {
   "fpLow": "Fiery Passion Low Plunge DMG",
   "fpHigh": "Fiery Passion High Plunge DMG",
+  "fpImpact_dmgInc": "Fiery Passion Plunging Impact DMG Increase",
   "a1RainbowCond": "Under the Rainbow Crash effect",
   "a1FpCond": "In the Fiery Passion state",
   "c1Text": "Passive Talent \"Tag-Team Triple Jump!\" enhanced",
+  "c1Effect": "Fiery Passion Plunging Impact DMG Increase from Passive 1 now applied to Volcano Kablam DMG",
   "c4DiligentCond": "Under the Diligent Refinement effect",
   "c4FpApexCond": "In either the Fiery Passion or Apex Drive state"
 }

--- a/libs/gi/sheets/src/Characters/Iansan/index.tsx
+++ b/libs/gi/sheets/src/Characters/Iansan/index.tsx
@@ -106,15 +106,19 @@ const burstNs = lookup(
   objKeyMap(burstNsArr, (ns) => constant(ns)),
   naught
 )
-const burstNs_atk = min(
-  threshold(
-    burstNs,
-    42,
-    prod(percent(dm.burst.highAtkConversion), input.premod.atk),
-    prod(percent(dm.burst.lowAtkConversionPerNs), burstNs, input.premod.atk)
+const burstNs_atkDisp = infoMut(
+  min(
+    threshold(
+      burstNs,
+      42,
+      prod(percent(dm.burst.highAtkConversion), input.premod.atk),
+      prod(percent(dm.burst.lowAtkConversionPerNs), burstNs, input.premod.atk)
+    ),
+    subscript(input.total.burstIndex, dm.burst.maxAtk)
   ),
-  subscript(input.total.burst, dm.burst.maxAtk)
+  { path: 'atk', isTeamBuff: true }
 )
+const burstNs_atk = equal(input.activeCharKey, target.charKey, burstNs_atkDisp)
 
 const [condA1PrecisePath, condA1Precise] = cond(key, 'a1Precise')
 const a1Precise_atk_ = greaterEq(
@@ -168,7 +172,7 @@ const dmgFormulas = {
   },
   burst: {
     skillDmg: dmgNode('atk', dm.burst.skillDmg, 'burst'),
-    burstNs_atk,
+    burstNs_atkDisp,
   },
   passive2: {
     heal: customHealNode(prod(percent(dm.passive2.heal), input.total.atk)),
@@ -316,7 +320,7 @@ const sheet: TalentSheet = {
             : st('points', { count: ns }),
         fields: [
           {
-            node: burstNs_atk,
+            node: burstNs_atkDisp,
           },
         ],
       })),
@@ -389,6 +393,7 @@ const sheet: TalentSheet = {
     ct.condTem('constellation6', {
       path: condC6ExtremePath,
       value: condC6Extreme,
+      teamBuff: true,
       name: ct.ch('c6Cond'),
       states: {
         on: {

--- a/libs/gi/sheets/src/Characters/Varesa/index.tsx
+++ b/libs/gi/sheets/src/Characters/Varesa/index.tsx
@@ -226,7 +226,7 @@ const dmgFormulas = {
   },
   skill: {
     rushDmg: dmgNode('atk', dm.skill.rushDmg, 'skill'),
-    fpRushDmg: dmgNode('atk', dm.skill.rushDmg, 'skill'),
+    fpRushDmg: dmgNode('atk', dm.skill.fpRushDmg, 'skill'),
   },
   burst: {
     kickDmg: dmgNode('atk', dm.burst.kickDmg, 'burst'),

--- a/libs/gi/sheets/src/Characters/Varesa/index.tsx
+++ b/libs/gi/sheets/src/Characters/Varesa/index.tsx
@@ -2,19 +2,17 @@ import { objKeyMap, objKeyValMap, range } from '@genshin-optimizer/common/util'
 import type { CharacterKey } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
 import {
-  compareEq,
   constant,
   equal,
   greaterEq,
   infoMut,
   input,
-  lessThan,
   lookup,
   min,
   naught,
   percent,
   prod,
-  sum,
+  threshold,
 } from '@genshin-optimizer/gi/wr'
 import { cond, st, stg } from '../../SheetUtil'
 import { CharacterSheet } from '../CharacterSheet'
@@ -113,7 +111,6 @@ const dm = {
 } as const
 
 const [condA1RainbowPath, condA1Rainbow] = cond(key, 'a1Rainbow')
-const [condA1FpPath, condA1Fp] = cond(key, 'a1Fp')
 const a1Rainbow_impact_dmgInc = greaterEq(
   input.asc,
   1,
@@ -121,13 +118,9 @@ const a1Rainbow_impact_dmgInc = greaterEq(
     condA1Rainbow,
     'on',
     prod(
-      // If in FP or > C1, give 180% of atk, otherwise 50%
-      compareEq(
-        greaterEq(
-          sum(equal(condA1Fp, 'on', 1), greaterEq(input.constellation, 1, 1)),
-          1,
-          1
-        ),
+      // If > C1, give 180% of atk, otherwise 50%
+      threshold(
+        input.constellation,
         1,
         percent(dm.passive1.fpImpact_dmgInc),
         percent(dm.passive1.impact_dmgInc)
@@ -136,6 +129,18 @@ const a1Rainbow_impact_dmgInc = greaterEq(
     )
   ),
   { path: 'plunging_impact_dmgInc' }
+)
+const a1Rainbow_fpImpact_dmgInc = infoMut(
+  greaterEq(
+    input.asc,
+    1,
+    equal(
+      condA1Rainbow,
+      'on',
+      prod(percent(dm.passive1.fpImpact_dmgInc), input.total.atk)
+    )
+  ),
+  { name: ct.ch('fpImpact_dmgInc') }
 )
 
 const [condA4NsBurstPath, condA4NsBurst] = cond(key, 'a4NsBurst')
@@ -185,6 +190,17 @@ const c6_plunging_critDMG_ = greaterEq(
 const c6_burst_critRate_ = { ...c6_plunging_critRate_ }
 const c6_burst_critDMG_ = { ...c6_plunging_critDMG_ }
 
+const nonFpPlungingAddl = {
+  premod: {
+    plunging_impact_dmgInc: a1Rainbow_impact_dmgInc,
+  },
+}
+const fpPlungingAddl = {
+  premod: {
+    plunging_impact_dmgInc: a1Rainbow_fpImpact_dmgInc,
+  },
+}
+
 const dmgFormulas = {
   normal: {
     ...Object.fromEntries(
@@ -202,9 +218,9 @@ const dmgFormulas = {
     fpDmg: dmgNode('atk', dm.fp.charged.dmg, 'charged'),
   },
   plunging: {
-    ...plungingDmgNodes('atk', dm.plunging),
+    ...plungingDmgNodes('atk', dm.plunging, nonFpPlungingAddl),
     ...objKeyValMap(
-      Object.entries(plungingDmgNodes('atk', dm.fp.plunging)),
+      Object.entries(plungingDmgNodes('atk', dm.fp.plunging, fpPlungingAddl)),
       ([k, v]) => [`fp${k}`, v]
     ),
   },
@@ -224,6 +240,11 @@ const dmgFormulas = {
           plunging_dmg_: c4FpApex_burst_dmg_,
           plunging_critRate_: c6_burst_critRate_,
           plunging_critDMG_: c6_burst_critDMG_,
+          plunging_impact_dmgInc: greaterEq(
+            input.constellation,
+            1,
+            a1Rainbow_fpImpact_dmgInc
+          ),
         },
       },
       undefined,
@@ -232,6 +253,7 @@ const dmgFormulas = {
   },
   passive1: {
     a1Rainbow_impact_dmgInc,
+    a1Rainbow_fpImpact_dmgInc,
   },
   constellation4: {
     c4Diligent_impact_dmgInc,
@@ -246,10 +268,7 @@ export const data = dataObjForCharacterSheet(key, dmgFormulas, {
     autoBoost: autoC5,
     burstBoost: burstC3,
     atk_: a4NsBurst_atk_,
-    plunging_impact_dmgInc: sum(
-      a1Rainbow_impact_dmgInc,
-      c4Diligent_impact_dmgInc
-    ),
+    plunging_impact_dmgInc: c4Diligent_impact_dmgInc,
     burst_dmg_: c4FpApex_burst_dmg_,
     burst_critRate_: c6_burst_critRate_,
     burst_critDMG_: c6_burst_critDMG_,
@@ -439,28 +458,12 @@ const sheet: TalentSheet = {
               node: a1Rainbow_impact_dmgInc,
             },
             {
+              node: a1Rainbow_fpImpact_dmgInc,
+            },
+            {
               text: stg('duration'),
               value: dm.passive1.duration,
               unit: 's',
-            },
-          ],
-        },
-      },
-    }),
-    ct.condTem('passive1', {
-      path: condA1FpPath,
-      value: condA1Fp,
-      canShow: greaterEq(
-        equal(condA1Rainbow, 'on', lessThan(input.constellation, 1, 1)),
-        1,
-        1
-      ),
-      name: ct.ch('a1FpCond'),
-      states: {
-        on: {
-          fields: [
-            {
-              text: ct.ch('a1FpText'),
             },
           ],
         },
@@ -493,6 +496,9 @@ const sheet: TalentSheet = {
       fields: [
         {
           text: ct.ch('c1Text'),
+        },
+        {
+          text: ct.ch('c1Effect'),
         },
       ],
     }),


### PR DESCRIPTION
## Describe your changes

* Change Iansan burst buff to active char only
* Change Iansan burst to index the buff properly
* Change Varesa P1/C1 interaction to properly match in-game (only buffing certain hits)

## Issue or discord link

- https://discord.com/channels/785153694478893126/1355556212061638738

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced ability descriptions for the Varesa character with additional detailed texts.
  - Improved display of burst attack values for the Iansan character, resulting in more accurate damage insights.
  - Refined damage calculation and presentation for Varesa, providing clearer differentiation between ability states.
  - Introduced new variables for damage increments based on character states, enhancing overall damage output capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->