### PR TITLE
ZO: Add show dupes modal

### DIFF
--- a/libs/zzz/page-discs/src/DupModal.tsx
+++ b/libs/zzz/page-discs/src/DupModal.tsx
@@ -1,0 +1,122 @@
+import { useForceUpdate } from '@genshin-optimizer/common/react-util'
+import { CardThemed, ModalWrapper } from '@genshin-optimizer/common/ui'
+import type { ICachedDisc } from '@genshin-optimizer/zzz/db'
+import { useDatabaseContext } from '@genshin-optimizer/zzz/db-ui'
+import { DiscCard } from '@genshin-optimizer/zzz/ui'
+import CloseIcon from '@mui/icons-material/Close'
+import DifferenceIcon from '@mui/icons-material/Difference'
+import {
+  Alert,
+  Box,
+  CardContent,
+  CardHeader,
+  Divider,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+export default function DupModal({
+  setDiscToEdit,
+  show,
+  onHide,
+}: {
+  setDiscToEdit: (id: string) => void
+  show: boolean
+  onHide: () => void
+}) {
+  const { t } = useTranslation('disc')
+  return (
+    <ModalWrapper open={show} onClose={onHide}>
+      <CardThemed>
+        <CardHeader
+          title={
+            <Typography
+              variant="h6"
+              flexGrow={1}
+              display="flex"
+              alignItems="center"
+            >
+              <DifferenceIcon sx={{ verticalAlign: 'text-top', mr: 1 }} />
+              {t('showDupes')}
+            </Typography>
+          }
+          action={
+            <IconButton onClick={onHide}>
+              <CloseIcon />
+            </IconButton>
+          }
+        />
+        <Divider />
+        <CardContent>
+          <DupContent setDiscToEdit={setDiscToEdit} />
+        </CardContent>
+      </CardThemed>
+    </ModalWrapper>
+  )
+}
+function DupContent({
+  setDiscToEdit,
+}: {
+  setDiscToEdit: (id: string) => void
+}) {
+  const { t } = useTranslation('disc')
+  const { database } = useDatabaseContext()
+  const [dbDirty, setDBDirty] = useForceUpdate()
+  useEffect(() => database.discs.followAny(setDBDirty), [setDBDirty, database])
+
+  const dupList = useMemo(() => {
+    const dups = dbDirty && ([] as ICachedDisc[][])
+    const discKeys = database.discs.keys
+
+    while (discKeys.length !== 0) {
+      const discKey = discKeys.shift()
+      if (!discKey) continue
+      const disc = database.discs.get(discKey)
+      if (!disc) continue
+      const { duplicated } = database.discs.findDups(disc, discKeys)
+      if (!duplicated.length) continue
+      const dupKeys = duplicated
+
+      dups.push(
+        [disc, ...dupKeys].sort((a) =>
+          (database.discs.get(a.location)?.location ?? '') ? -1 : 1
+        )
+      )
+    }
+    return dups
+  }, [database, dbDirty])
+  return (
+    <Stack spacing={2}>
+      {dupList.map((dups) => (
+        <CardThemed key={dups.join()} sx={{ overflowX: 'scroll' }}>
+          <CardContent sx={{ display: 'flex', gap: 1 }}>
+            {dups.map((dupDisc) => (
+              <Box key={dupDisc.id} sx={{ minWidth: 300 }}>
+                <DiscCard
+                  disc={dupDisc}
+                  setLocation={(location) =>
+                    database.discs.set(dupDisc.id, { location })
+                  }
+                  onLockToggle={() =>
+                    database.discs.set(dupDisc.id, ({ lock }) => ({
+                      lock: !lock,
+                    }))
+                  }
+                  onDelete={() => database.discs.remove(dupDisc.id)}
+                  onEdit={() => setDiscToEdit(dupDisc.id)}
+                />
+              </Box>
+            ))}
+          </CardContent>
+        </CardThemed>
+      ))}
+      {!dupList.length && (
+        <Alert variant="filled" severity="success">
+          {t('noDupAlert')}
+        </Alert>
+      )}
+    </Stack>
+  )
+}

--- a/libs/zzz/page-discs/src/index.tsx
+++ b/libs/zzz/page-discs/src/index.tsx
@@ -4,11 +4,13 @@ import { useDatabaseContext } from '@genshin-optimizer/zzz/db-ui'
 import { DiscEditor, DiscInventory } from '@genshin-optimizer/zzz/ui'
 import { Box } from '@mui/material'
 
-import { useCallback, useState } from 'react'
+import { Suspense, useCallback, useState } from 'react'
+import DupModal from './DupModal'
 
 export default function PageDiscs() {
   const [disc, setDisc] = useState<Partial<ICachedDisc>>({})
   const [show, onOpen, onClose] = useBoolState()
+  const [showDup, onShowDup, onHideDup] = useBoolState(false)
   const { database } = useDatabaseContext()
   const onAddNew = useCallback(() => {
     setDisc({})
@@ -27,16 +29,22 @@ export default function PageDiscs() {
 
   return (
     <Box display="flex" flexDirection="column" gap={1} my={1}>
-      <DiscEditor
-        disc={disc}
-        allowEmpty
-        allowUpload
-        show={show}
-        onClose={onClose}
-        onShow={onOpen}
-        cancelEdit={() => setDisc({})}
-      />
-      <DiscInventory onAdd={onAddNew} onEdit={onEdit} />
+      <Suspense fallback={false}>
+        <DiscEditor
+          disc={disc}
+          allowEmpty
+          allowUpload
+          show={show}
+          onClose={onClose}
+          onShow={onOpen}
+          cancelEdit={() => setDisc({})}
+        />
+      </Suspense>
+
+      <Suspense fallback={false}>
+        <DupModal show={showDup} onHide={onHideDup} setDiscToEdit={onEdit} />
+      </Suspense>
+      <DiscInventory onAdd={onAddNew} onEdit={onEdit} onShowDup={onShowDup} />
     </Box>
   )
 }

--- a/libs/zzz/ui/src/Disc/DiscInventory.tsx
+++ b/libs/zzz/ui/src/Disc/DiscInventory.tsx
@@ -10,6 +10,7 @@ import {
 } from '@genshin-optimizer/zzz/db-ui'
 import { discFilterConfigs } from '@genshin-optimizer/zzz/util'
 import AddIcon from '@mui/icons-material/Add'
+import DifferenceIcon from '@mui/icons-material/Difference'
 import {
   Box,
   Button,
@@ -29,9 +30,14 @@ const numToShowMap = { xs: 10, sm: 12, md: 24, lg: 24, xl: 24 }
 export type DiscInventoryProps = {
   onAdd?: () => void
   onEdit?: (id: string) => void
+  onShowDup?: () => void
 }
 
-export function DiscInventory({ onAdd, onEdit }: DiscInventoryProps) {
+export function DiscInventory({
+  onAdd,
+  onEdit,
+  onShowDup,
+}: DiscInventoryProps) {
   const { t } = useTranslation('disc')
   const { database } = useDatabaseContext()
   const [dirtyDatabase, setDirtyDatabase] = useForceUpdate()
@@ -114,6 +120,16 @@ export function DiscInventory({ onAdd, onEdit }: DiscInventoryProps) {
             startIcon={<AddIcon />}
           >
             {t('addNew')}
+          </Button>
+        </Grid>
+        <Grid item xs={1}>
+          <Button
+            fullWidth
+            onClick={onShowDup}
+            color="info"
+            startIcon={<DifferenceIcon />}
+          >
+            {t('showDupes')}
           </Button>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Describe your changes

- Add show dupes modal

## Issue or discord link

- Resolves: #2898 

## Testing/validation

![image](https://github.com/user-attachments/assets/70bbbd12-1528-4ffa-8384-75ad2c450b00)
![image](https://github.com/user-attachments/assets/1b0737a5-4038-4b52-9af3-ca37052600cf)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a modal dialog that lets users view and manage duplicate disc entries.
  - Added a new button in the disc inventory that triggers the display of duplicate disc information.
  - Enhanced the loading experience for disc management components to ensure a smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->