### PR TITLE
ZO: Bonus stat improvements

### DIFF
--- a/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
@@ -414,20 +414,17 @@ export class CharacterOptManager extends DataManager<
     charKey: CharacterKey,
     tag: BonusStatTag,
     value: number | null, // use null to remove the stat
-    index?: number // to edit an existing stat
+    index = -1 // to edit an existing stat
   ) {
     this.set(charKey, (charOpt) => {
-      const statIndex =
-        index ??
-        charOpt.bonusStats.findIndex((s) => shallowCompareObj(s.tag, tag))
       const bonusStats = [...charOpt.bonusStats]
-      if (statIndex === -1 && value !== null) {
+      if (index === -1 && value !== null) {
         bonusStats.push({ tag, value })
-      } else if (value === null && statIndex > -1) {
-        bonusStats.splice(statIndex, 1)
-      } else if (value !== null && statIndex > -1) {
-        bonusStats[statIndex].value = value
-        bonusStats[statIndex].tag = tag
+      } else if (value === null && index > -1) {
+        bonusStats.splice(index, 1)
+      } else if (value !== null && index > -1) {
+        bonusStats[index].value = value
+        bonusStats[index].tag = tag
       }
       return { bonusStats }
     })

--- a/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
@@ -91,6 +91,8 @@ export const bonusStatKeys: Array<keyof typeof own.final> = [
   'impact_',
   'anomMas_',
   'anomMas',
+  'pen_',
+  'pen',
 ] as const
 export type BonusStatKey = (typeof bonusStatKeys)[number]
 

--- a/libs/zzz/page-optimize/src/BonusStats.tsx
+++ b/libs/zzz/page-optimize/src/BonusStats.tsx
@@ -67,7 +67,7 @@ export function BonusStatsSection() {
     [database, characterKey]
   )
   const newTarget = (q: BonusStatKey) =>
-    database.charOpts.setBonusStat(characterKey, newBonusStatTag(q), 0, true)
+    database.charOpts.setBonusStat(characterKey, newBonusStatTag(q), 0, false)
   const setDescription = useCallback(
     (description: string | undefined) => {
       database.charMeta.set(characterKey, { description })

--- a/libs/zzz/page-optimize/src/BonusStats.tsx
+++ b/libs/zzz/page-optimize/src/BonusStats.tsx
@@ -23,7 +23,11 @@ import {
 import type { Attribute, Tag } from '@genshin-optimizer/zzz/formula'
 import { TagDisplay, qtMap } from '@genshin-optimizer/zzz/formula-ui'
 import { AttributeName, StatDisplay } from '@genshin-optimizer/zzz/ui'
-import { DeleteForever } from '@mui/icons-material'
+import {
+  CheckBox,
+  CheckBoxOutlineBlank,
+  DeleteForever,
+} from '@mui/icons-material'
 import {
   CardContent,
   IconButton,
@@ -47,12 +51,23 @@ export function BonusStatsSection() {
     characterKey
   )?.description
   const setStat = useCallback(
-    (tag: BonusStatTag, value: number | null, index?: number) =>
-      database.charOpts.setBonusStat(characterKey, tag, value, index),
+    (
+      tag: BonusStatTag,
+      value: number | null,
+      isEnabled: boolean,
+      index?: number
+    ) =>
+      database.charOpts.setBonusStat(
+        characterKey,
+        tag,
+        value,
+        isEnabled,
+        index
+      ),
     [database, characterKey]
   )
   const newTarget = (q: BonusStatKey) =>
-    database.charOpts.setBonusStat(characterKey, newBonusStatTag(q), 0)
+    database.charOpts.setBonusStat(characterKey, newBonusStatTag(q), 0, true)
   const setDescription = useCallback(
     (description: string | undefined) => {
       database.charMeta.set(characterKey, { description })
@@ -62,14 +77,16 @@ export function BonusStatsSection() {
 
   return (
     <Stack spacing={1}>
-      {bonusStats.map(({ tag, value }, i) => (
+      {bonusStats.map(({ tag, value, disabled }, i) => (
         <BonusStatDisplay
           key={JSON.stringify(tag) + i}
           tag={tag}
           value={value}
-          setValue={(value) => setStat(tag, value, i)}
-          onDelete={() => setStat(tag, null, i)}
-          setTag={(tag) => setStat(tag, value, i)}
+          disabled={disabled}
+          setValue={(value) => setStat(tag, value, disabled, i)}
+          onDelete={() => setStat(tag, null, disabled, i)}
+          setTag={(tag) => setStat(tag, value, disabled, i)}
+          toggleDisabled={() => setStat(tag, value, !disabled, i)}
         />
       ))}
       <InitialStatDropdown onSelect={newTarget} />
@@ -110,18 +127,22 @@ function BonusStatDisplay({
   tag,
   setTag,
   value,
+  disabled,
   setValue,
   onDelete,
+  toggleDisabled,
 }: {
   tag: BonusStatTag
   setTag: (tag: BonusStatTag) => void
   value: number
+  disabled: boolean
   setValue: (value: number) => void
   onDelete: () => void
+  toggleDisabled: () => void
 }) {
   const isPercent = tag.q?.endsWith('_')
   return (
-    <CardThemed bgt="light">
+    <CardThemed bgt="light" sx={{ opacity: disabled ? 0.4 : undefined }}>
       <CardContent
         sx={{
           display: 'flex',
@@ -131,6 +152,9 @@ function BonusStatDisplay({
           flexWrap: 'wrap',
         }}
       >
+        <IconButton onClick={toggleDisabled}>
+          {disabled ? <CheckBoxOutlineBlank /> : <CheckBox />}
+        </IconButton>
         <Typography>
           <TagDisplay tag={tag} />
         </Typography>

--- a/libs/zzz/page-optimize/src/CharCalcProvider.tsx
+++ b/libs/zzz/page-optimize/src/CharCalcProvider.tsx
@@ -64,13 +64,15 @@ export function CharCalcProvider({
               conditionalEntries(sheet, src, dst)(condKey, condValue)
             )
         ),
-        ...charOpt.bonusStats.flatMap(({ tag, value }) =>
-          withPreset(`preset0`, {
-            // since bonusStats are applied to own*, needs {src:key, dst:never}
-            tag: { ...tag, src: character.key, sheet: 'agg', et: 'own' },
-            value: constant(toDecimal(value, tag.q ?? '')),
-          })
-        ),
+        ...charOpt.bonusStats
+          .filter(({ disabled }) => !disabled)
+          .flatMap(({ tag, value }) =>
+            withPreset(`preset0`, {
+              // since bonusStats are applied to own*, needs {src:key, dst:never}
+              tag: { ...tag, src: character.key, sheet: 'agg', et: 'own' },
+              value: constant(toDecimal(value, tag.q ?? '')),
+            })
+          ),
         ...charOpt.enemyStats.flatMap(({ tag, value }) =>
           withPreset(`preset0`, {
             tag: { ...tag, qt: 'common', et: 'enemy', sheet: 'agg' },


### PR DESCRIPTION
## Describe your changes

* Add PEN and PEN Ratio to bonus stats
* Allow adding multiple versions of each bonus stat (e.g. one teambuff adds X amount and another teambuff adds Y amount)
* Add toggles to bonus stats

## Issue or discord link
- https://discord.com/channels/785153694478893126/1353253559495299134/1357922841399660585
- https://discord.com/channels/785153694478893126/1353253559495299134/1357922410904555570

## Testing/validation
![chrome_fVGkAcCLRG](https://github.com/user-attachments/assets/2b0716ef-0835-43a0-8e55-67fdc3fe9742)
Also verified that final stats were adjusted accordingly to the enabled/disabled state

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a toggle for bonus stats, allowing users to enable or disable individual stats directly from the UI.
  - Bonus stat cards now visually indicate their disabled state (e.g., adjusted opacity) for clearer differentiation.
  - Disabled bonus stats are automatically excluded from overall calculations, ensuring more focused and efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->