### PR TITLE
CI: Update release pipelines for simultaneous release/versions

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -36,20 +36,6 @@ jobs:
     name: 'build'
     steps:
       - uses: actions/checkout@v4
-      - name: Get Cache Key
-        id: get-cache-key
-        run: |
-          echo "key=$(git ls-tree -r HEAD | grep '^160000' | sha256sum | cut -d " " -f 1)" >> $GITHUB_OUTPUT
-      - uses: actions/cache/restore@v4
-        with:
-          path: .git/modules
-          key: submodule-${{ steps.get-cache-key.outputs.key }}
-          restore-keys: |
-            submodule-
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -65,10 +65,11 @@ jobs:
         run: |
           TEMP_FILE=$(mktemp)
           # List tags for GI and get the latest one
+          git fetch --tags --force
           oldTag=$(git tag --list '*[!zo]' --sort=creatordate | tail -n 1)
-          echo "**What's Changed**\n" >> $TEMP_FILE
+          echo -e "**What's Changed**\n" >> $TEMP_FILE
           git log --pretty='format:* %s' $oldTag..HEAD -- . ':!apps/somnia' ':!apps/somnia-e2e' ':!apps/sr-frontend' ':!apps/sr-frontend-e2e' ':!apps/zzz-frontend' ':!apps/zzz-frontend-e2e' ':!libs/gi/formula' ':!libs/gi/formula-ui' ':!libs/gi/i18n-node' ':!libs/game-opt' ':!libs/pando' ':!libs/sr' ':!libs/zzz' >> $TEMP_FILE
-          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
+          echo -e "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
           gh release create ${{ steps.get-version.outputs.version }} -F $TEMP_FILE -t ${{ steps.get-version.outputs.version }} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Make release
         if: steps.get-version.outputs.version != ''
         run: |
-          gh release create ${{ steps.get-version.outputs.version }} --generate-notes --target $(git rev-parse HEAD)
+          TEMP_FILE=$(mktemp)
+          # List tags for GI and get the latest one
+          oldTag=$(git tag --list '*[!zo]' --sort=creatordate | tail -n 1)
+          echo "**What's Changed**\n" >> $TEMP_FILE
+          git log --pretty='format:* %s' $oldTag..HEAD -- . ':!apps/somnia' ':!apps/somnia-e2e' ':!apps/sr-frontend' ':!apps/sr-frontend-e2e' ':!apps/zzz-frontend' ':!apps/zzz-frontend-e2e' ':!libs/gi/formula' ':!libs/gi/formula-ui' ':!libs/gi/i18n-node' ':!libs/game-opt' ':!libs/pando' ':!libs/sr' ':!libs/zzz' >> $TEMP_FILE
+          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}"
+          gh release create ${{ steps.get-version.outputs.version }} --F $TEMP_FILE -t ${{ steps.get-version.outputs.version }} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-new-release.yml
+++ b/.github/workflows/build-new-release.yml
@@ -66,7 +66,7 @@ jobs:
           oldTag=$(git tag --list '*[!zo]' --sort=creatordate | tail -n 1)
           echo "**What's Changed**\n" >> $TEMP_FILE
           git log --pretty='format:* %s' $oldTag..HEAD -- . ':!apps/somnia' ':!apps/somnia-e2e' ':!apps/sr-frontend' ':!apps/sr-frontend-e2e' ':!apps/zzz-frontend' ':!apps/zzz-frontend-e2e' ':!libs/gi/formula' ':!libs/gi/formula-ui' ':!libs/gi/i18n-node' ':!libs/game-opt' ':!libs/pando' ':!libs/sr' ':!libs/zzz' >> $TEMP_FILE
-          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}"
-          gh release create ${{ steps.get-version.outputs.version }} --F $TEMP_FILE -t ${{ steps.get-version.outputs.version }} --target $(git rev-parse HEAD)
+          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
+          gh release create ${{ steps.get-version.outputs.version }} -F $TEMP_FILE -t ${{ steps.get-version.outputs.version }} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -21,6 +21,8 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'zo-release') }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get version
         id: get-version
         run: |

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -1,0 +1,33 @@
+name: Build ZO Release
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  call-build-frontend:
+    uses: ./.github/workflows/build-frontend.yml
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'zo-release') }}
+    with:
+      frontend_name: 'zzz-frontend'
+      deployment_name: ''
+      repo_var_name: 'ZO_REPO'
+      repo_deploy_secret_name: 'ZO_REPO_SSH_KEY'
+      show_dev_components: false
+      nested_deployments: false
+  create-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version
+        id: get-version
+        run: |
+          echo "version=$(printf '%s' '${{ github.event.pull_request.title }}' | awk '{print $3}')" >> $GITHUB_OUTPUT
+      - name: Make release
+        if: steps.get-version.outputs.version != ''
+        run: |
+          gh release create ${{ steps.get-version.outputs.version }} --generate-notes --target $(git rev-parse HEAD)
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           TEMP_FILE=$(mktemp)
           # List tags for ZO and get the latest one
+          git tag --list
           oldTag=$(git tag --list '*+zo' --sort=creatordate | tail -n 1)
           echo "**What's Changed**\n" >> $TEMP_FILE
           git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' :!apps/frontend' :!apps/frontend-e2e' :!apps/gi-frontend' :!apps/gi-frontend-e2e' :!apps/sr-frontend' :!apps/sr-frontend-e2e' :!apps/somnia' :!apps/somnia-e2e' >> $TEMP_FILE

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -31,10 +31,9 @@ jobs:
           TEMP_FILE=$(mktemp)
           # List tags for ZO and get the latest one
           git fetch --tags --force
-          git tag --list
           oldTag=$(git tag --list '*+zo' --sort=creatordate | tail -n 1)
           echo -e "**What's Changed**\n" >> $TEMP_FILE
-          git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' :!apps/frontend' :!apps/frontend-e2e' :!apps/gi-frontend' :!apps/gi-frontend-e2e' :!apps/sr-frontend' :!apps/sr-frontend-e2e' :!apps/somnia' :!apps/somnia-e2e' >> $TEMP_FILE
+          git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' ':!apps/frontend' ':!apps/frontend-e2e' ':!apps/gi-frontend' ':!apps/gi-frontend-e2e' ':!apps/sr-frontend' ':!apps/sr-frontend-e2e' ':!apps/somnia' ':!apps/somnia-e2e' >> $TEMP_FILE
           echo -e "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
           gh release create ${{ steps.get-version.outputs.version }} -F $TEMP_FILE -t ${{steps.get-version.outputs.version}} --target $(git rev-parse HEAD)
         env:

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -21,6 +21,8 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'zo-release') }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Get version
         id: get-version
         run: |

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -18,7 +18,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'zo-release') }}
     steps:
       - uses: actions/checkout@v4
       - name: Get version

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -21,8 +21,6 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'zo-release') }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Get version
         id: get-version
         run: |
@@ -32,11 +30,12 @@ jobs:
         run: |
           TEMP_FILE=$(mktemp)
           # List tags for ZO and get the latest one
+          git fetch --tags --force
           git tag --list
           oldTag=$(git tag --list '*+zo' --sort=creatordate | tail -n 1)
-          echo "**What's Changed**\n" >> $TEMP_FILE
+          echo -e "**What's Changed**\n" >> $TEMP_FILE
           git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' :!apps/frontend' :!apps/frontend-e2e' :!apps/gi-frontend' :!apps/gi-frontend-e2e' :!apps/sr-frontend' :!apps/sr-frontend-e2e' :!apps/somnia' :!apps/somnia-e2e' >> $TEMP_FILE
-          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
+          echo -e "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
           gh release create ${{ steps.get-version.outputs.version }} -F $TEMP_FILE -t ${{steps.get-version.outputs.version}} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Make release
         if: steps.get-version.outputs.version != ''
         run: |
-          gh release create ${{ steps.get-version.outputs.version }} --generate-notes --target $(git rev-parse HEAD)
+          TEMP_FILE=$(mktemp)
+          # List tags for ZO and get the latest one
+          oldTag=$(git tag --list '*+zo' --sort=creatordate | tail -n 1)
+          echo "**What's Changed**\n" >> $TEMP_FILE
+          git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' :!apps/frontend' :!apps/frontend-e2e' :!apps/gi-frontend' :!apps/gi-frontend-e2e' :!apps/sr-frontend' :!apps/sr-frontend-e2e' :!apps/somnia' :!apps/somnia-e2e' >> $TEMP_FILE
+          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}"
+          gh release create ${{ steps.get-version.outputs.version }} --F $TEMP_FILE -t ${{steps.get-version.outputs.version}} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -33,7 +33,7 @@ jobs:
           oldTag=$(git tag --list '*+zo' --sort=creatordate | tail -n 1)
           echo "**What's Changed**\n" >> $TEMP_FILE
           git log --pretty='format:* %s' $oldTag..HEAD -- . ':!libs/gi' ':!libs/sr' :!apps/frontend' :!apps/frontend-e2e' :!apps/gi-frontend' :!apps/gi-frontend-e2e' :!apps/sr-frontend' :!apps/sr-frontend-e2e' :!apps/somnia' :!apps/somnia-e2e' >> $TEMP_FILE
-          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}"
-          gh release create ${{ steps.get-version.outputs.version }} --F $TEMP_FILE -t ${{steps.get-version.outputs.version}} --target $(git rev-parse HEAD)
+          echo "\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/$oldTag..${{ steps.get-version.outputs.version }}" >> $TEMP_FILE
+          gh release create ${{ steps.get-version.outputs.version }} -F $TEMP_FILE -t ${{steps.get-version.outputs.version}} --target $(git rev-parse HEAD)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-zo-release.yml
+++ b/.github/workflows/build-zo-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get version
         id: get-version
         run: |
-          echo "version=$(printf '%s' '${{ github.event.pull_request.title }}' | awk '{print $3}')" >> $GITHUB_OUTPUT
+          echo "version=$(printf '%s' '${{ github.event.pull_request.title }}' | awk '{print $4}')" >> $GITHUB_OUTPUT
       - name: Make release
         if: steps.get-version.outputs.version != ''
         run: |

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -7,6 +7,7 @@ on:
       - Build GO (WR) PR
       - Build SRO PR
       - Build ZO PR
+      - Build ZO Release
       - New Beta GO Release
       - New Beta SRO Release
       - New Beta ZO Release

--- a/.github/workflows/new-zo-release.yml
+++ b/.github/workflows/new-zo-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get version
         id: get-version
         run: |
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "version=${{ inputs.version }}+zo" >> $GITHUB_OUTPUT
       - name: Set git config
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/new-zo-release.yml
+++ b/.github/workflows/new-zo-release.yml
@@ -1,15 +1,47 @@
-name: New ZO Release
+name: New Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        type: string
 
 jobs:
-  call-build-frontend:
-    uses: ./.github/workflows/build-frontend.yml
-    with:
-      frontend_name: 'zzz-frontend'
-      deployment_name: ''
-      repo_var_name: 'ZO_REPO'
-      repo_deploy_secret_name: 'ZO_REPO_SSH_KEY'
-      show_dev_components: false
-      nested_deployments: false
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get version
+        id: get-version
+        run: |
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+      - name: Set git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Change version
+        if: steps.get-version.outputs.version != ''
+        run: |
+          TEMP_FILE=$(mktemp)
+          jq --arg v "${{ steps.get-version.outputs.version }}" '.version = $v' apps/zzz-frontend/package.json > $TEMP_FILE
+          cp $TEMP_FILE apps/zzz-frontend/package.json
+          git add .
+          git commit -m "${{ steps.get-version.outputs.version }}"
+      - name: Get commit msg
+        id: get-commit-msg
+        run: |
+          if [[ -z "${{ steps.get-version.outputs.version }}" ]]; then
+            echo "title-release=ZO: Release ref $(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          else
+            echo "title-release=ZO: Release version ${{ steps.get-version.outputs.version }} $(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          fi
+      - name: Create PR
+        run: |
+          git status
+          git push origin HEAD:actions/new-zo-release --force
+          gh pr create --base $(git rev-parse --abbrev-ref HEAD) --head actions/new-zo-release --title '${{ steps.get-commit-msg.outputs.title-release }}' --body '' --label zo-release
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/new-zo-release.yml
+++ b/.github/workflows/new-zo-release.yml
@@ -1,4 +1,4 @@
-name: New Release
+name: New ZO Release
 
 on:
   workflow_dispatch:

--- a/apps/zzz-frontend/package.json
+++ b/apps/zzz-frontend/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "zenless-optimizer",
+  "version": "1.0.0+zo"
+}


### PR DESCRIPTION
## Describe your changes

Update ZO and GI release workflows to support releasing and tagging independent versions for each, and maintaining an automatic changelog
ZO releases/tags will have `+zo` appended as build metadata, according to semver spec
ZO stores its version number in `apps/zzz-frontend/package.json`

New flow for ZZZ release is similar to GI release:
1. Start 'New ZO Release' action
2. Wait
3. Approve + merge PR for version bump
4. [Different from GI] Version will be automatically deployed (GI typically requires a 2nd PR here)
5. Release is automatically created with patch notes

Release notes for GI and ZZZ will do best effort to contain only changes relevant to those releases. Releasing them in an interleaving fashion will still produce proper diffs/release notes for each (See testing portion below for more detailed example)

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Process:
1. Create a GI release
1. Create a ZZZ release
1. Create a commit in GI library
1. Create a commit in ZZZ library
6. Create a commit in common library
7. Create a ZZZ release
  a. ZZZ release should contain notes for ZZZ and common change only
  b. ZZZ release should create a diff between past ZZZ release and current ZZZ release
  c. Example: https://github.com/nguyentvan7/genshin-optimizer/releases/tag/1.0.13%2Bzo
8. Create a GI release
  a. GI release should contain notes for GI and common change only
  b. GI release should create a diff between past GI release and current GI release
  c. Example: https://github.com/nguyentvan7/genshin-optimizer/releases/tag/10.22.8

Note that the common change appears in both release notes (since it impacts both apps)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Launched the Zenless Optimizer package at version 1.0.0+zo.
- **Chores**
	- Streamlined the front-end build and release workflows to improve efficiency.
	- Enhanced the automated release process to generate detailed release notes and support smoother, condition-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->