### PR TITLE
ZO: Add support for skillParams for agent skills

### DIFF
--- a/libs/sr/stats/src/generators/gen-map/genIndex.ts
+++ b/libs/sr/stats/src/generators/gen-map/genIndex.ts
@@ -24,7 +24,7 @@ export default async function genIndex(tree: Tree, map_type: string) {
 }
 
 async function writeIndex(path: string, keys: readonly string[]) {
-  const index = `
+  const index = `// WARNING: Generated file, do not modify
 ${keys.map((key) => `import ${key} from './maps/${key}'`).join('\n')}
 
 const maps = {

--- a/libs/zzz/dm/src/dm/character/character.ts
+++ b/libs/zzz/dm/src/dm/character/character.ts
@@ -8,6 +8,7 @@ import {
   allCharacterKeys,
 } from '@genshin-optimizer/zzz/consts'
 import { readHakushinJSON } from '../../util'
+import type { HakushinSkillKey } from './consts'
 import {
   attributeMap,
   characterIdMap,
@@ -85,7 +86,7 @@ type CharacterRawData = {
     }
   >
   Skill: Record<
-    'Basic' | 'Dodge' | 'Special' | 'Chain' | 'Assist',
+    HakushinSkillKey,
     {
       Description: Array<{
         Name: string
@@ -93,7 +94,7 @@ type CharacterRawData = {
         Param?: Array<{
           Name: string
           Desc: string
-          Param: Record<
+          Param?: Record<
             string,
             {
               Main: number

--- a/libs/zzz/dm/src/dm/character/character.ts
+++ b/libs/zzz/dm/src/dm/character/character.ts
@@ -248,7 +248,7 @@ export const charactersDetailedJSONData = Object.fromEntries(
                   if ('Param' in param) {
                     return {
                       ...param,
-                      Param: objMap(param.Param, (param2) => ({
+                      Param: objMap(param.Param ?? {}, (param2) => ({
                         ...param2,
                         Main: param2.Main / FLAT_SCALING,
                         Growth: param2.Growth / PERCENT_SCALING,

--- a/libs/zzz/dm/src/dm/character/consts.ts
+++ b/libs/zzz/dm/src/dm/character/consts.ts
@@ -2,6 +2,7 @@ import type {
   AttributeKey,
   CharacterRarityKey,
   FactionKey,
+  SkillKey,
   SpecialityKey,
   StatKey,
 } from '@genshin-optimizer/zzz/consts'
@@ -82,3 +83,17 @@ export const coreStatMap: Record<string, StatKey> = {
   'Anomaly Mastery': 'anomMas',
   'PEN Ratio': 'pen_',
 } as const
+
+export type HakushinSkillKey =
+  | 'Basic'
+  | 'Dodge'
+  | 'Special'
+  | 'Chain'
+  | 'Assist'
+export const hakushinSkillMap: Record<HakushinSkillKey, SkillKey> = {
+  Basic: 'basic',
+  Dodge: 'dodge',
+  Special: 'special',
+  Chain: 'chain',
+  Assist: 'assist',
+}

--- a/libs/zzz/dm/src/dm/character/index.ts
+++ b/libs/zzz/dm/src/dm/character/index.ts
@@ -1,2 +1,3 @@
 export * from './character'
 export * from './characters'
+export * from './consts'

--- a/libs/zzz/dm/tsconfig.json
+++ b/libs/zzz/dm/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false
+  },
   "files": [],
   "include": [],
   "references": [

--- a/libs/zzz/formula/src/data/char/util.ts
+++ b/libs/zzz/formula/src/data/char/util.ts
@@ -1,6 +1,6 @@
 import { constant, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import type { AttributeKey, SkillKey } from '@genshin-optimizer/zzz/consts'
-import type { CharacterDatum } from '@genshin-optimizer/zzz/stats'
+import type { CharacterDatum, SkillParam } from '@genshin-optimizer/zzz/stats'
 import type { DmgTag, FormulaArg, Stat } from '../util'
 import {
   type TagMapNodeEntries,
@@ -27,7 +27,7 @@ export function getBaseTag(data_gen: CharacterDatum): DmgTag {
  * @param name Base name to be used as the key
  * @param dmgTag Tag object containing damageType1, damageType2 and attribute
  * @param stat Stat that the damage scales on
- * @param levelScaling Array representing the scaling at different levels of the ability
+ * @param skillParam SkillParam object corresponding to the specific hit
  * @param abilityScalingType Ability level that the scaling depends on.
  * @param arg `{ team: true }` to use `teamBuff` instead of `ownBuff`. `{ cond: <node> }` to hide these instances behind a conditional check.
  * @param extra Buffs that should only apply to this damage instance
@@ -37,7 +37,7 @@ export function dmg(
   name: string,
   dmgTag: DmgTag,
   stat: Stat,
-  levelScaling: number[],
+  skillParam: SkillParam,
   abilityScalingType: AbilityScalingType,
   arg: FormulaArg = {},
   ...extra: TagMapNodeEntries
@@ -46,7 +46,10 @@ export function dmg(
     throw Error(
       `No damageType specified on ${name}. Please specify at least one.`
     )
-  const multi = percent(subscript(own.char[abilityScalingType], levelScaling))
+  const multi = sum(
+    skillParam.DamagePercentage,
+    prod(own.char[abilityScalingType], skillParam.DamagePercentageGrowth)
+  )
   const base = prod(own.final[stat], multi)
   return customDmg(name, dmgTag, base, arg, ...extra)
 }

--- a/libs/zzz/stats/Data/Characters/Anby.json
+++ b/libs/zzz/stats/Data/Characters/Anby.json
@@ -31,5 +31,216 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackTurboVolt": [
+        {
+          "DamagePercentage": 0.312,
+          "DamagePercentageGrowth": 0.029,
+          "StunRatio": 0.156,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 56.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 429,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.337,
+          "DamagePercentageGrowth": 0.031,
+          "StunRatio": 0.287,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 103.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 789.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.136,
+          "DamagePercentageGrowth": 0.104,
+          "StunRatio": 0.896,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 322.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2464,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.391,
+          "DamagePercentageGrowth": 0.218,
+          "StunRatio": 1.874,
+          "StunRatioGrowth": 0.086,
+          "SpRecovery": 674.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5153.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 172.47
+        }
+      ],
+      "BasicAttackThunderbolt": [
+        {
+          "DamagePercentage": 3.286,
+          "DamagePercentageGrowth": 0.299,
+          "StunRatio": 1.424,
+          "StunRatioGrowth": 0.065,
+          "SpRecovery": 512.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3916,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 127.5
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeSlide": [],
+      "DashAttackTaserBlast": [
+        {
+          "DamagePercentage": 0.567,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.284,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 102,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 781,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterThunderclap": [
+        {
+          "DamagePercentage": 1.802,
+          "DamagePercentageGrowth": 0.164,
+          "StunRatio": 1.617,
+          "StunRatioGrowth": 0.074,
+          "SpRecovery": 221.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1696.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 61.63
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackForkLightning": [
+        {
+          "DamagePercentage": 0.934,
+          "DamagePercentageGrowth": 0.085,
+          "StunRatio": 0.934,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2568.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 93.3
+        }
+      ],
+      "EXSpecialAttackLightningBolt": [
+        {
+          "DamagePercentage": 5.83,
+          "DamagePercentageGrowth": 0.53,
+          "StunRatio": 4.818,
+          "StunRatioGrowth": 0.219,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 18815.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 532.37
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackElectroEngine": [
+        {
+          "DamagePercentage": 5.424,
+          "DamagePercentageGrowth": 0.494,
+          "StunRatio": 1.434,
+          "StunRatioGrowth": 0.066,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22231,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 342.83
+        }
+      ],
+      "UltimateOverdriveEngine": [
+        {
+          "DamagePercentage": 15.126,
+          "DamagePercentageGrowth": 1.376,
+          "StunRatio": 9.916,
+          "StunRatioGrowth": 0.451,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 210.03
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistThunderfall": [
+        {
+          "DamagePercentage": 0.617,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.617,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 221.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1696.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 61.63
+        }
+      ],
+      "DefensiveAssistFlash": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpLightningWhirl": [
+        {
+          "DamagePercentage": 3.352,
+          "DamagePercentageGrowth": 0.305,
+          "StunRatio": 2.914,
+          "StunRatioGrowth": 0.133,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10419.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 313.22
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Anton.json
+++ b/libs/zzz/stats/Data/Characters/Anton.json
@@ -31,5 +31,277 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackEnthusiasticDrills": [
+        {
+          "DamagePercentage": 0.678,
+          "DamagePercentageGrowth": 0.062,
+          "StunRatio": 0.339,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 122,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 932.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.923,
+          "DamagePercentageGrowth": 0.084,
+          "StunRatio": 0.753,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 270.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2070.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.098,
+          "DamagePercentageGrowth": 0.1,
+          "StunRatio": 0.933,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 335.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2565.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.291,
+          "DamagePercentageGrowth": 0.209,
+          "StunRatio": 1.814,
+          "StunRatioGrowth": 0.083,
+          "SpRecovery": 653,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4988.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackEnthusiasticDrillsBurstMode": [
+        {
+          "DamagePercentage": 2.409,
+          "DamagePercentageGrowth": 0.219,
+          "StunRatio": 1.66,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5835.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 177.49
+        },
+        {
+          "DamagePercentage": 4.692,
+          "DamagePercentageGrowth": 0.427,
+          "StunRatio": 3.233,
+          "StunRatioGrowth": 0.147,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11365.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 345.73
+        },
+        {
+          "DamagePercentage": 4.569,
+          "DamagePercentageGrowth": 0.416,
+          "StunRatio": 3.148,
+          "StunRatioGrowth": 0.144,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11066,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 336.68
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeLetsMove": [],
+      "DashAttackFireWithFire": [
+        {
+          "DamagePercentage": 0.684,
+          "DamagePercentageGrowth": 0.063,
+          "StunRatio": 0.342,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 123,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 940.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterRetaliation": [
+        {
+          "DamagePercentage": 2.712,
+          "DamagePercentageGrowth": 0.247,
+          "StunRatio": 2.317,
+          "StunRatioGrowth": 0.106,
+          "SpRecovery": 474.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3621.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterOverloadDrillBurstMode": [
+        {
+          "DamagePercentage": 4.654,
+          "DamagePercentageGrowth": 0.424,
+          "StunRatio": 3.518,
+          "StunRatioGrowth": 0.16,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8849.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 269.23
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSpinBro": [
+        {
+          "DamagePercentage": 0.442,
+          "DamagePercentageGrowth": 0.041,
+          "StunRatio": 0.442,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1215.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 44.18
+        }
+      ],
+      "EXSpecialAttackSmashTheHorizonBro": [
+        {
+          "DamagePercentage": 1.951,
+          "DamagePercentageGrowth": 0.178,
+          "StunRatio": 1.951,
+          "StunRatioGrowth": 0.089,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5365.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 195.03
+        }
+      ],
+      "SpecialAttackExplosiveDrillBurstMode": [
+        {
+          "DamagePercentage": 2.314,
+          "DamagePercentageGrowth": 0.211,
+          "StunRatio": 1.184,
+          "StunRatioGrowth": 0.054,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7141.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 217.21
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackGoGoGo": [
+        {
+          "DamagePercentage": 6.407,
+          "DamagePercentageGrowth": 0.583,
+          "StunRatio": 2.417,
+          "StunRatioGrowth": 0.11,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24934.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 441.13
+        }
+      ],
+      "UltimateGoGoGoGoGo": [
+        {
+          "DamagePercentage": 18.164,
+          "DamagePercentageGrowth": 1.652,
+          "StunRatio": 2.434,
+          "StunRatioGrowth": 0.111,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 243.36
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistShoulderToShoulder": [
+        {
+          "DamagePercentage": 2.634,
+          "DamagePercentageGrowth": 0.24,
+          "StunRatio": 1.317,
+          "StunRatioGrowth": 0.06,
+          "SpRecovery": 474.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3621.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "QuickAssistProtectiveDrillBurstMode": [
+        {
+          "DamagePercentage": 3.654,
+          "DamagePercentageGrowth": 0.333,
+          "StunRatio": 2.518,
+          "StunRatioGrowth": 0.115,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8849.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 269.23
+        }
+      ],
+      "DefensiveAssistIronWrist": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpLimitBurst": [
+        {
+          "DamagePercentage": 3.258,
+          "DamagePercentageGrowth": 0.297,
+          "StunRatio": 2.827,
+          "StunRatioGrowth": 0.129,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10144.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 304.22
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Astra.json
+++ b/libs/zzz/stats/Data/Characters/Astra.json
@@ -31,5 +31,196 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackCapriccio": [
+        {
+          "DamagePercentage": 0.438,
+          "DamagePercentageGrowth": 0.04,
+          "StunRatio": 0.413,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 67.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1031.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 37.45
+        },
+        {
+          "DamagePercentage": 0.591,
+          "DamagePercentageGrowth": 0.054,
+          "StunRatio": 0.564,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 92.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1410.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 51.25
+        },
+        {
+          "DamagePercentage": 1.209,
+          "DamagePercentageGrowth": 0.11,
+          "StunRatio": 1.148,
+          "StunRatioGrowth": 0.053,
+          "SpRecovery": 187.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2871,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 104.31
+        },
+        {
+          "DamagePercentage": 2.707,
+          "DamagePercentageGrowth": 0.247,
+          "StunRatio": 2.194,
+          "StunRatioGrowth": 0.1,
+          "SpRecovery": 359,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5483.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 199.39
+        }
+      ],
+      "BasicAttackInterlude": [
+        {
+          "DamagePercentage": 0.55,
+          "DamagePercentageGrowth": 0.05,
+          "StunRatio": 0.484,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 63.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 484,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.59
+        }
+      ],
+      "BasicAttackChorus": [],
+      "BasicAttackFinale": []
+    },
+    "dodge": {
+      "DodgeMiniWaltz": [],
+      "DashAttackLunarEclipseMelody": [
+        {
+          "DamagePercentage": 0.807,
+          "DamagePercentageGrowth": 0.074,
+          "StunRatio": 0.404,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 132,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1009.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 36.64
+        }
+      ],
+      "DodgeCounterUmbrellaWaltz": [
+        {
+          "DamagePercentage": 1.1,
+          "DamagePercentageGrowth": 0.1,
+          "StunRatio": 0.968,
+          "StunRatioGrowth": 0.044,
+          "SpRecovery": 126.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 968,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 35.18
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackWindchimesOaths": [
+        {
+          "DamagePercentage": 0.55,
+          "DamagePercentageGrowth": 0.05,
+          "StunRatio": 0.484,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 484,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.59
+        }
+      ],
+      "IdyllicCadenza": [],
+      "Chord": [
+        {
+          "DamagePercentage": 0.46,
+          "DamagePercentageGrowth": 0.042,
+          "StunRatio": 0,
+          "StunRatioGrowth": 0,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 29.77
+        },
+        {
+          "DamagePercentage": 0.24,
+          "DamagePercentageGrowth": 0.022,
+          "StunRatio": 0,
+          "StunRatioGrowth": 0,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 10.32
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackTipsyConcerto": [
+        {
+          "DamagePercentage": 6.718,
+          "DamagePercentageGrowth": 0.611,
+          "StunRatio": 2.329,
+          "StunRatioGrowth": 0.106,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 411.16
+        }
+      ],
+      "UltimateFantasianSonata": [
+        {
+          "DamagePercentage": 19.598,
+          "DamagePercentageGrowth": 1.782,
+          "StunRatio": 2.383,
+          "StunRatioGrowth": 0.109,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 216.63
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistOneLuminousSky": [
+        {
+          "DamagePercentage": 0.55,
+          "DamagePercentageGrowth": 0.05,
+          "StunRatio": 0.484,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 63.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 484,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.59
+        }
+      ],
+      "EvasiveAssistTwoHearts": [],
+      "AssistFollowUpThreeLifetimesOfFate": [
+        {
+          "DamagePercentage": 3.046,
+          "DamagePercentageGrowth": 0.277,
+          "StunRatio": 2.61,
+          "StunRatioGrowth": 0.119,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8703.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 257.01
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Ben.json
+++ b/libs/zzz/stats/Data/Characters/Ben.json
@@ -31,5 +31,236 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackDebtReconciliation": [
+        {
+          "DamagePercentage": 0.659,
+          "DamagePercentageGrowth": 0.06,
+          "StunRatio": 0.471,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 169.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1295.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.89,
+          "DamagePercentageGrowth": 0.172,
+          "StunRatio": 1.569,
+          "StunRatioGrowth": 0.072,
+          "SpRecovery": 564.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4314.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 3.483,
+          "DamagePercentageGrowth": 0.317,
+          "StunRatio": 2.601,
+          "StunRatioGrowth": 0.119,
+          "SpRecovery": 936.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7152.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeMissingInvoice": [],
+      "DashAttackIncomingExpense": [
+        {
+          "DamagePercentage": 1.384,
+          "DamagePercentageGrowth": 0.126,
+          "StunRatio": 0.692,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 249.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1903,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterAccountsSettled": [
+        {
+          "DamagePercentage": 2.257,
+          "DamagePercentageGrowth": 0.206,
+          "StunRatio": 1.967,
+          "StunRatioGrowth": 0.09,
+          "SpRecovery": 348.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2659.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 96.66
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackFiscalFist": [
+        {
+          "DamagePercentage": 0.417,
+          "DamagePercentageGrowth": 0.038,
+          "StunRatio": 0.417,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1146.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.334,
+          "DamagePercentageGrowth": 0.213,
+          "StunRatio": 2.234,
+          "StunRatioGrowth": 0.102,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2293.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "EXSpecialAttackCashflowCounter": [
+        {
+          "DamagePercentage": 4.385,
+          "DamagePercentageGrowth": 0.399,
+          "StunRatio": 2.471,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9427,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 270.99
+        },
+        {
+          "DamagePercentage": 4.385,
+          "DamagePercentageGrowth": 0.399,
+          "StunRatio": 2.471,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9427,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 270.99
+        },
+        {
+          "DamagePercentage": 5.005,
+          "DamagePercentageGrowth": 0.455,
+          "StunRatio": 3.676,
+          "StunRatioGrowth": 0.168,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11253,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 330.71
+        },
+        {
+          "DamagePercentage": 5.512,
+          "DamagePercentageGrowth": 0.502,
+          "StunRatio": 3.676,
+          "StunRatioGrowth": 0.168,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11253,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 330.71
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackSignedAndSealed": [
+        {
+          "DamagePercentage": 6.273,
+          "DamagePercentageGrowth": 0.571,
+          "StunRatio": 3.283,
+          "StunRatioGrowth": 0.15,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24565.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 427.79
+        }
+      ],
+      "UltimateCompletePayback": [
+        {
+          "DamagePercentage": 16.43,
+          "DamagePercentageGrowth": 1.494,
+          "StunRatio": 1.1,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 110
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistJointAccount": [
+        {
+          "DamagePercentage": 0.967,
+          "DamagePercentageGrowth": 0.088,
+          "StunRatio": 0.967,
+          "StunRatioGrowth": 0.044,
+          "SpRecovery": 348.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2659.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 96.66
+        }
+      ],
+      "DefensiveAssistRiskAllocation": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.251,
+          "StunRatioGrowth": 0.103,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.684,
+          "StunRatioGrowth": 0.122,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.084,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpDontBreakContract": [
+        {
+          "DamagePercentage": 3.259,
+          "DamagePercentageGrowth": 0.297,
+          "StunRatio": 2.828,
+          "StunRatioGrowth": 0.129,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10147.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 304.26
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Billy.json
+++ b/libs/zzz/stats/Data/Characters/Billy.json
@@ -31,5 +31,213 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackFullFirepower": [
+        {
+          "DamagePercentage": 0.68,
+          "DamagePercentageGrowth": 0.062,
+          "StunRatio": 0.544,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 163.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 998.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 54.39
+        },
+        {
+          "DamagePercentage": 0.076,
+          "DamagePercentageGrowth": 0.007,
+          "StunRatio": 0.061,
+          "StunRatioGrowth": 0.003,
+          "SpRecovery": 54.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 332.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 6.04
+        },
+        {
+          "DamagePercentage": 0.618,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.547,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 196.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1504.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 29.03
+        },
+        {
+          "DamagePercentage": 0.127,
+          "DamagePercentageGrowth": 0.012,
+          "StunRatio": 0.089,
+          "StunRatioGrowth": 0.005,
+          "SpRecovery": 32.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 244.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 8.89
+        },
+        {
+          "DamagePercentage": 0.495,
+          "DamagePercentageGrowth": 0.045,
+          "StunRatio": 0.552,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 397.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1518,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 80.79
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeRiskyBusiness": [],
+      "DashAttackStarlightSanction": [
+        {
+          "DamagePercentage": 0.63,
+          "DamagePercentageGrowth": 0.058,
+          "StunRatio": 0.63,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 251.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1925,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 34.98
+        },
+        {
+          "DamagePercentage": 0.39,
+          "DamagePercentageGrowth": 0.036,
+          "StunRatio": 0.195,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 78,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 596.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 43.29
+        }
+      ],
+      "DodgeCounterFairFight": [
+        {
+          "DamagePercentage": 2.214,
+          "DamagePercentageGrowth": 0.202,
+          "StunRatio": 1.934,
+          "StunRatioGrowth": 0.088,
+          "SpRecovery": 336.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2568.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 93.36
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackStandStill": [
+        {
+          "DamagePercentage": 0.242,
+          "DamagePercentageGrowth": 0.022,
+          "StunRatio": 0.242,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 665.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 24.14
+        },
+        {
+          "DamagePercentage": 0.517,
+          "DamagePercentageGrowth": 0.047,
+          "StunRatio": 0.517,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1421.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 25.84
+        },
+        {
+          "DamagePercentage": 0.501,
+          "DamagePercentageGrowth": 0.046,
+          "StunRatio": 0.501,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1377.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 25
+        }
+      ],
+      "EXSpecialAttackClearanceTime": [
+        {
+          "DamagePercentage": 5.438,
+          "DamagePercentageGrowth": 0.495,
+          "StunRatio": 4.395,
+          "StunRatioGrowth": 0.2,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16203,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 446.87
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackStarlightMirage": [
+        {
+          "DamagePercentage": 7.352,
+          "DamagePercentageGrowth": 0.669,
+          "StunRatio": 1.966,
+          "StunRatioGrowth": 0.09,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24293.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 417.83
+        }
+      ],
+      "UltimateStarlightShineBright": [
+        {
+          "DamagePercentage": 15.977,
+          "DamagePercentageGrowth": 1.453,
+          "StunRatio": 1.906,
+          "StunRatioGrowth": 0.087,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 211.7
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistPowerOfTeamwork": [
+        {
+          "DamagePercentage": 0.934,
+          "DamagePercentageGrowth": 0.085,
+          "StunRatio": 0.934,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 336.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2568.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 93.36
+        }
+      ],
+      "EvasiveAssistFlashSpin": [],
+      "AssistFollowUpFatalShot": [
+        {
+          "DamagePercentage": 3.888,
+          "DamagePercentageGrowth": 0.354,
+          "StunRatio": 3.412,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 12001,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 364.97
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Burnice.json
+++ b/libs/zzz/stats/Data/Characters/Burnice.json
@@ -31,5 +31,284 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackDirectFlameBlend": [
+        {
+          "DamagePercentage": 0.448,
+          "DamagePercentageGrowth": 0.041,
+          "StunRatio": 0.187,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 61,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 467.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 16.94
+        },
+        {
+          "DamagePercentage": 0.435,
+          "DamagePercentageGrowth": 0.04,
+          "StunRatio": 0.308,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 100.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 770,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.717,
+          "DamagePercentageGrowth": 0.066,
+          "StunRatio": 0.478,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 156.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1193.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 43.37
+        },
+        {
+          "DamagePercentage": 0.666,
+          "DamagePercentageGrowth": 0.061,
+          "StunRatio": 0.304,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 99.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 759,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 27.54
+        },
+        {
+          "DamagePercentage": 0.963,
+          "DamagePercentageGrowth": 0.088,
+          "StunRatio": 0.52,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 169.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1298,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 47.19
+        }
+      ],
+      "BasicAttackMixedFlameBlend": [
+        {
+          "DamagePercentage": 1.254,
+          "DamagePercentageGrowth": 0.114,
+          "StunRatio": 0.965,
+          "StunRatioGrowth": 0.044,
+          "SpRecovery": 157.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2411.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 95.98
+        },
+        {
+          "DamagePercentage": 2.328,
+          "DamagePercentageGrowth": 0.212,
+          "StunRatio": 1.791,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 293.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4477,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 171.11
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeFieryPhantomDash": [],
+      "DashAttackDangerousFermentation": [
+        {
+          "DamagePercentage": 0.679,
+          "DamagePercentageGrowth": 0.062,
+          "StunRatio": 0.34,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 111,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 849.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 30.83
+        }
+      ],
+      "DodgeCounterFlutteringSteps": [
+        {
+          "DamagePercentage": 2.197,
+          "DamagePercentageGrowth": 0.2,
+          "StunRatio": 1.944,
+          "StunRatioGrowth": 0.089,
+          "SpRecovery": 138,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.66
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackIntenseHeatAgingMethod": [
+        {
+          "DamagePercentage": 0.578,
+          "DamagePercentageGrowth": 0.053,
+          "StunRatio": 0.578,
+          "StunRatioGrowth": 0.027,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1446.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 52.51
+        },
+        {
+          "DamagePercentage": 0.624,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.624,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1559.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.68
+        }
+      ],
+      "EXSpecialAttackIntenseHeatStirringMethod": [
+        {
+          "DamagePercentage": 5.438,
+          "DamagePercentageGrowth": 0.495,
+          "StunRatio": 3.786,
+          "StunRatioGrowth": 0.173,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 13675.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 411.1
+        },
+        {
+          "DamagePercentage": 0.967,
+          "DamagePercentageGrowth": 0.088,
+          "StunRatio": 0.657,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2400.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 71.55
+        }
+      ],
+      "EXSpecialAttackIntenseHeatStirringMethodDoubleShot": [
+        {
+          "DamagePercentage": 9.581,
+          "DamagePercentageGrowth": 0.871,
+          "StunRatio": 5.857,
+          "StunRatioGrowth": 0.267,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 18397.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 530.24
+        },
+        {
+          "DamagePercentage": 2.871,
+          "DamagePercentageGrowth": 0.261,
+          "StunRatio": 2.078,
+          "StunRatioGrowth": 0.095,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6036.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 183.65
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackFuelFedFlame": [
+        {
+          "DamagePercentage": 6.809,
+          "DamagePercentageGrowth": 0.619,
+          "StunRatio": 2.42,
+          "StunRatioGrowth": 0.11,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24337.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 1002.96
+        }
+      ],
+      "UltimateGloriousInferno": [
+        {
+          "DamagePercentage": 20.122,
+          "DamagePercentageGrowth": 1.83,
+          "StunRatio": 1.064,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 861.16
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistEnergizingSpecialtyDrink": [
+        {
+          "DamagePercentage": 0.844,
+          "DamagePercentageGrowth": 0.077,
+          "StunRatio": 0.844,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 138,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.66
+        }
+      ],
+      "DefensiveAssistSmokyCauldron": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpScorchingDew": [
+        {
+          "DamagePercentage": 3.276,
+          "DamagePercentageGrowth": 0.298,
+          "StunRatio": 2.824,
+          "StunRatioGrowth": 0.129,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9319.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 277.22
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Caesar.json
+++ b/libs/zzz/stats/Data/Characters/Caesar.json
@@ -31,5 +31,309 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackRampagingSlash": [
+        {
+          "DamagePercentage": 0.472,
+          "DamagePercentageGrowth": 0.043,
+          "StunRatio": 0.213,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 77.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 591.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 21.42
+        },
+        {
+          "DamagePercentage": 0.409,
+          "DamagePercentageGrowth": 0.038,
+          "StunRatio": 0.338,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 122.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 937.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 34.09
+        },
+        {
+          "DamagePercentage": 1.483,
+          "DamagePercentageGrowth": 0.135,
+          "StunRatio": 1.1,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 399.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3055.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 111.04
+        },
+        {
+          "DamagePercentage": 1.184,
+          "DamagePercentageGrowth": 0.108,
+          "StunRatio": 0.736,
+          "StunRatioGrowth": 0.034,
+          "SpRecovery": 267.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2046,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 74.32
+        },
+        {
+          "DamagePercentage": 0.788,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.675,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 245.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1875.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 68.12
+        },
+        {
+          "DamagePercentage": 1.986,
+          "DamagePercentageGrowth": 0.181,
+          "StunRatio": 1.375,
+          "StunRatioGrowth": 0.063,
+          "SpRecovery": 499.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3817,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 138.79
+        },
+        {
+          "DamagePercentage": 3.999,
+          "DamagePercentageGrowth": 0.364,
+          "StunRatio": 2.626,
+          "StunRatioGrowth": 0.12,
+          "SpRecovery": 954.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7295.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 265.24
+        }
+      ],
+      "BasicAttackDeadEnd": [
+        {
+          "DamagePercentage": 1.263,
+          "DamagePercentageGrowth": 0.115,
+          "StunRatio": 0.932,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 338.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2590.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 94.1
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeAdrift": [],
+      "DashAttackHogRush": [
+        {
+          "DamagePercentage": 0.623,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.312,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 102,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2728,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 28.31
+        }
+      ],
+      "DodgeCounterEyeForAnEye": [
+        {
+          "DamagePercentage": 1.935,
+          "DamagePercentageGrowth": 0.176,
+          "StunRatio": 1.742,
+          "StunRatioGrowth": 0.08,
+          "SpRecovery": 210.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1606,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 58.33
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackShockwaveShieldBash": [
+        {
+          "DamagePercentage": 0.533,
+          "DamagePercentageGrowth": 0.049,
+          "StunRatio": 0.24,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 665.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 24.18
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 0.77,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1102.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 40
+        }
+      ],
+      "SpecialAttackRoaringThrust": [
+        {
+          "DamagePercentage": 0.588,
+          "DamagePercentageGrowth": 0.054,
+          "StunRatio": 0.265,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 734.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 26.68
+        }
+      ],
+      "EXSpecialAttackParryCounter": [
+        {
+          "DamagePercentage": 3.872,
+          "DamagePercentageGrowth": 0.352,
+          "StunRatio": 2.526,
+          "StunRatioGrowth": 0.115,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8461.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 249.11
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.54,
+          "StunRatioGrowth": 0.07,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2750,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 100
+        },
+        {
+          "DamagePercentage": 3.872,
+          "DamagePercentageGrowth": 0.352,
+          "StunRatio": 2.526,
+          "StunRatioGrowth": 0.115,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8461.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 249.11
+        }
+      ],
+      "EXSpecialAttackOverpoweredShieldBash": [
+        {
+          "DamagePercentage": 4.257,
+          "DamagePercentageGrowth": 0.387,
+          "StunRatio": 2.884,
+          "StunRatioGrowth": 0.132,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9493,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 282.87
+        }
+      ],
+      "StanceSwitch": []
+    },
+    "chain": {
+      "ChainAttackRoadRageSlam": [
+        {
+          "DamagePercentage": 6.388,
+          "DamagePercentageGrowth": 0.581,
+          "StunRatio": 1.999,
+          "StunRatioGrowth": 0.091,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 23284.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 381.16
+        }
+      ],
+      "UltimateSavageSmash": [
+        {
+          "DamagePercentage": 20.123,
+          "DamagePercentageGrowth": 1.83,
+          "StunRatio": 2.787,
+          "StunRatioGrowth": 0.127,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 253.29
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistLaneChange": [
+        {
+          "DamagePercentage": 0.642,
+          "DamagePercentageGrowth": 0.059,
+          "StunRatio": 0.642,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 210.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1606,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 58.33
+        }
+      ],
+      "DefensiveAssistAegisShield": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.453,
+          "StunRatioGrowth": 0.157,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.693,
+          "StunRatioGrowth": 0.077,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpAidingBlade": [
+        {
+          "DamagePercentage": 4.072,
+          "DamagePercentageGrowth": 0.371,
+          "StunRatio": 3.563,
+          "StunRatioGrowth": 0.162,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11451,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 346.97
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Corin.json
+++ b/libs/zzz/stats/Data/Characters/Corin.json
@@ -31,5 +31,280 @@
     { "atk": 50, "crit_dmg_": 0.192 },
     { "atk": 50, "crit_dmg_": 0.288 },
     { "atk": 75, "crit_dmg_": 0.288 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackWipeout": [
+        {
+          "DamagePercentage": 0.82,
+          "DamagePercentageGrowth": 0.075,
+          "StunRatio": 0.41,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 147.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1127.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 40.99
+        },
+        {
+          "DamagePercentage": 0.766,
+          "DamagePercentageGrowth": 0.07,
+          "StunRatio": 0.702,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 252.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1930.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 70.16
+        },
+        {
+          "DamagePercentage": 1.792,
+          "DamagePercentageGrowth": 0.163,
+          "StunRatio": 1.238,
+          "StunRatioGrowth": 0.057,
+          "SpRecovery": 445.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3404.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 123.76
+        },
+        {
+          "DamagePercentage": 2.334,
+          "DamagePercentageGrowth": 0.213,
+          "StunRatio": 1.864,
+          "StunRatioGrowth": 0.085,
+          "SpRecovery": 670.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5126,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 186.33
+        },
+        {
+          "DamagePercentage": 4.212,
+          "DamagePercentageGrowth": 0.383,
+          "StunRatio": 3.42,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 1231,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9405,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 341.94
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeShoo": [],
+      "DashAttackOopsyDaisy": [
+        {
+          "DamagePercentage": 0.967,
+          "DamagePercentageGrowth": 0.088,
+          "StunRatio": 0.484,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 174.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1331,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 48.34
+        }
+      ],
+      "DodgeCounterNope": [
+        {
+          "DamagePercentage": 1.356,
+          "DamagePercentageGrowth": 0.124,
+          "StunRatio": 0.659,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 237,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1812.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 65.81
+        },
+        {
+          "DamagePercentage": 1.356,
+          "DamagePercentageGrowth": 0.124,
+          "StunRatio": 0.659,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 237,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1812.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 65.81
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackCleanSweep": [
+        {
+          "DamagePercentage": 0.667,
+          "DamagePercentageGrowth": 0.061,
+          "StunRatio": 0.667,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1834.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 66.68
+        },
+        {
+          "DamagePercentage": 0.375,
+          "DamagePercentageGrowth": 0.035,
+          "StunRatio": 0.375,
+          "StunRatioGrowth": 0.018,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1031.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 37.5
+        },
+        {
+          "DamagePercentage": 0.25,
+          "DamagePercentageGrowth": 0.023,
+          "StunRatio": 0.25,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 687.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 24.99
+        }
+      ],
+      "EXSpecialAttackSkirtAlert": [
+        {
+          "DamagePercentage": 3.451,
+          "DamagePercentageGrowth": 0.314,
+          "StunRatio": 2.064,
+          "StunRatioGrowth": 0.094,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6894.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 203.33
+        },
+        {
+          "DamagePercentage": 10.352,
+          "DamagePercentageGrowth": 0.942,
+          "StunRatio": 6.19,
+          "StunRatioGrowth": 0.282,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 20677.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 610.01
+        },
+        {
+          "DamagePercentage": 3.451,
+          "DamagePercentageGrowth": 0.314,
+          "StunRatio": 2.064,
+          "StunRatioGrowth": 0.094,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6894.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 203.33
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackSorry": [
+        {
+          "DamagePercentage": 6.873,
+          "DamagePercentageGrowth": 0.625,
+          "StunRatio": 2.883,
+          "StunRatioGrowth": 0.132,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 26215.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 487.79
+        }
+      ],
+      "UltimateVeryVerySorry": [
+        {
+          "DamagePercentage": 20.288,
+          "DamagePercentageGrowth": 1.845,
+          "StunRatio": 4.068,
+          "StunRatioGrowth": 0.185,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 406.7
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistEmergencyMeasures": [
+        {
+          "DamagePercentage": 1.317,
+          "DamagePercentageGrowth": 0.12,
+          "StunRatio": 1.317,
+          "StunRatioGrowth": 0.06,
+          "SpRecovery": 473.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3621.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 131.63
+        },
+        {
+          "DamagePercentage": 0.833,
+          "DamagePercentageGrowth": 0.076,
+          "StunRatio": 0.833,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 299.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2290.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 83.29
+        }
+      ],
+      "DefensiveAssistPPleaseAllowMe": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpQuickSweep": [
+        {
+          "DamagePercentage": 5.475,
+          "DamagePercentageGrowth": 0.498,
+          "StunRatio": 4.886,
+          "StunRatioGrowth": 0.223,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16678.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 518.01
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Ellen.json
+++ b/libs/zzz/stats/Data/Characters/Ellen.json
@@ -31,5 +31,290 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackSawTeethTrimming": [
+        {
+          "DamagePercentage": 0.488,
+          "DamagePercentageGrowth": 0.045,
+          "StunRatio": 0.244,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 67.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 610.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.111,
+          "DamagePercentageGrowth": 0.101,
+          "StunRatio": 0.868,
+          "StunRatioGrowth": 0.04,
+          "SpRecovery": 241.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2169.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.973,
+          "DamagePercentageGrowth": 0.271,
+          "StunRatio": 2.404,
+          "StunRatioGrowth": 0.11,
+          "SpRecovery": 668.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6011.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackFlashFreezeTrimming": [
+        {
+          "DamagePercentage": 0.996,
+          "DamagePercentageGrowth": 0.091,
+          "StunRatio": 0.488,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 135.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1221,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 44.35
+        },
+        {
+          "DamagePercentage": 1.84,
+          "DamagePercentageGrowth": 0.168,
+          "StunRatio": 0.902,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 250.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2255,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 81.99
+        },
+        {
+          "DamagePercentage": 4.962,
+          "DamagePercentageGrowth": 0.452,
+          "StunRatio": 2.455,
+          "StunRatioGrowth": 0.112,
+          "SpRecovery": 642.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6138,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 223.17
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeVortex": [],
+      "DashRoamingHunt": [],
+      "DashAttackArcticAmbush": [
+        {
+          "DamagePercentage": 0.623,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.623,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 203.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1556.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.59
+        },
+        {
+          "DamagePercentage": 1.276,
+          "DamagePercentageGrowth": 0.116,
+          "StunRatio": 0.982,
+          "StunRatioGrowth": 0.045,
+          "SpRecovery": 321.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2453,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 89.19
+        },
+        {
+          "DamagePercentage": 1.582,
+          "DamagePercentageGrowth": 0.144,
+          "StunRatio": 1.217,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 398.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3041.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 110.56
+        }
+      ],
+      "FlashFreeze": [],
+      "DashAttackMonstrousWave": [
+        {
+          "DamagePercentage": 0.77,
+          "DamagePercentageGrowth": 0.07,
+          "StunRatio": 0.385,
+          "StunRatioGrowth": 0.018,
+          "SpRecovery": 126,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 962.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DashAttackColdSnap": [
+        {
+          "DamagePercentage": 1.457,
+          "DamagePercentageGrowth": 0.133,
+          "StunRatio": 0.788,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 257.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1971.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 71.63
+        }
+      ],
+      "DodgeCounterReefRock": [
+        {
+          "DamagePercentage": 1.526,
+          "DamagePercentageGrowth": 0.139,
+          "StunRatio": 2.274,
+          "StunRatioGrowth": 0.104,
+          "SpRecovery": 384.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2937,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 106.7
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackDrift": [
+        {
+          "DamagePercentage": 0.505,
+          "DamagePercentageGrowth": 0.046,
+          "StunRatio": 0.505,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1262.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 45.84
+        }
+      ],
+      "EXSpecialAttackTailSwipe": [
+        {
+          "DamagePercentage": 3.772,
+          "DamagePercentageGrowth": 0.343,
+          "StunRatio": 4.051,
+          "StunRatioGrowth": 0.185,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 14036,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 403.73
+        }
+      ],
+      "EXSpecialAttackSharknami": [
+        {
+          "DamagePercentage": 5.533,
+          "DamagePercentageGrowth": 0.503,
+          "StunRatio": 3.717,
+          "StunRatioGrowth": 0.169,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 13070.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 372.19
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackAvalanche": [
+        {
+          "DamagePercentage": 7.946,
+          "DamagePercentageGrowth": 0.723,
+          "StunRatio": 3.557,
+          "StunRatioGrowth": 0.162,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 27181,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 522.83
+        }
+      ],
+      "UltimateEndlessWinter": [
+        {
+          "DamagePercentage": 18.908,
+          "DamagePercentageGrowth": 1.719,
+          "StunRatio": 1.852,
+          "StunRatioGrowth": 0.085,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 168.33
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistSharkSentinel": [
+        {
+          "DamagePercentage": 1.211,
+          "DamagePercentageGrowth": 0.111,
+          "StunRatio": 1.211,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 396.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3027.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 110.03
+        }
+      ],
+      "DefensiveAssistWavefrontImpact": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpSharkCruiser": [
+        {
+          "DamagePercentage": 4.379,
+          "DamagePercentageGrowth": 0.399,
+          "StunRatio": 3.848,
+          "StunRatioGrowth": 0.175,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 12276,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 373.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Evelyn.json
+++ b/libs/zzz/stats/Data/Characters/Evelyn.json
@@ -31,5 +31,277 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackRazorWire": [
+        {
+          "DamagePercentage": 0.512,
+          "DamagePercentageGrowth": 0.047,
+          "StunRatio": 0.256,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 83.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 640.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.621,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.538,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 176.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1344.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.782,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.621,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 203.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1553.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.867,
+          "DamagePercentageGrowth": 0.17,
+          "StunRatio": 1.53,
+          "StunRatioGrowth": 0.07,
+          "SpRecovery": 500.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3825.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 139.03
+        },
+        {
+          "DamagePercentage": 2.234,
+          "DamagePercentageGrowth": 0.204,
+          "StunRatio": 1.683,
+          "StunRatioGrowth": 0.077,
+          "SpRecovery": 550.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4207.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 152.91
+        }
+      ],
+      "PassiveBind": [],
+      "BasicAttackGarroteFirstForm": [
+        {
+          "DamagePercentage": 2.264,
+          "DamagePercentageGrowth": 0.206,
+          "StunRatio": 1.211,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 396.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3027.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 110.03
+        }
+      ],
+      "BasicAttackGarroteSecondForm": [
+        {
+          "DamagePercentage": 2.452,
+          "DamagePercentageGrowth": 0.223,
+          "StunRatio": 1.248,
+          "StunRatioGrowth": 0.057,
+          "SpRecovery": 408.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3118.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 113.36
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeArcStep": [],
+      "DashAttackPiercingAmbush": [
+        {
+          "DamagePercentage": 0.605,
+          "DamagePercentageGrowth": 0.055,
+          "StunRatio": 0.303,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 99,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 756.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterStranglingReversal": [
+        {
+          "DamagePercentage": 2.102,
+          "DamagePercentageGrowth": 0.192,
+          "StunRatio": 1.871,
+          "StunRatioGrowth": 0.086,
+          "SpRecovery": 252.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1927.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 70.03
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackLockedPosition": [
+        {
+          "DamagePercentage": 0.523,
+          "DamagePercentageGrowth": 0.048,
+          "StunRatio": 0.523,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2612.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 47.48
+        }
+      ],
+      "SpecialAttackBindingSunderFirstForm": [
+        {
+          "DamagePercentage": 0.404,
+          "DamagePercentageGrowth": 0.037,
+          "StunRatio": 0.404,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2015.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 36.64
+        },
+        {
+          "DamagePercentage": 0.34,
+          "DamagePercentageGrowth": 0.031,
+          "StunRatio": 0.34,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1696.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 30.84
+        }
+      ],
+      "EXSpecialAttackBindingSunderFinalForm": [
+        {
+          "DamagePercentage": 5.412,
+          "DamagePercentageGrowth": 0.492,
+          "StunRatio": 4.371,
+          "StunRatioGrowth": 0.199,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16134.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 444.62
+        },
+        {
+          "DamagePercentage": 0.596,
+          "DamagePercentageGrowth": 0.055,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1718.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.2
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackLunaluxSnare": [
+        {
+          "DamagePercentage": 8.293,
+          "DamagePercentageGrowth": 0.754,
+          "StunRatio": 2.366,
+          "StunRatioGrowth": 0.108,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16942.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 290.17
+        }
+      ],
+      "UltimateLunaluxGarroteTimbre": [
+        {
+          "DamagePercentage": 19.885,
+          "DamagePercentageGrowth": 1.808,
+          "StunRatio": 2.604,
+          "StunRatioGrowth": 0.119,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 236.7
+        }
+      ],
+      "UltimateLunaluxGarroteShadow": []
+    },
+    "assist": {
+      "QuickAssistFierceBlade": [
+        {
+          "DamagePercentage": 0.771,
+          "DamagePercentageGrowth": 0.071,
+          "StunRatio": 0.771,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 252.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1927.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 70.03
+        }
+      ],
+      "DefensiveAssistSilentProtection": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpCourseDisruption": [
+        {
+          "DamagePercentage": 2.916,
+          "DamagePercentageGrowth": 0.266,
+          "StunRatio": 2.49,
+          "StunRatioGrowth": 0.114,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8357.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 245.67
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Grace.json
+++ b/libs/zzz/stats/Data/Characters/Grace.json
@@ -31,5 +31,180 @@
     { "atk": 50, "anomMas": 24 },
     { "atk": 50, "anomMas": 36 },
     { "atk": 75, "anomMas": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackHighPressureSpike": [
+        {
+          "DamagePercentage": 0.551,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.18,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 61.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 470.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.597,
+          "DamagePercentageGrowth": 0.055,
+          "StunRatio": 0.347,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 118.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 910.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.248,
+          "DamagePercentageGrowth": 0.114,
+          "StunRatio": 0.716,
+          "StunRatioGrowth": 0.033,
+          "SpRecovery": 245.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1875.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.6
+        },
+        {
+          "DamagePercentage": 1.863,
+          "DamagePercentageGrowth": 0.17,
+          "StunRatio": 1.072,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 408.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3118.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.403,
+          "DamagePercentageGrowth": 0.037,
+          "StunRatio": 0.403,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 138,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1056,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeSafetyRegulation": [],
+      "DashAttackQuickInspection": [
+        {
+          "DamagePercentage": 0.333,
+          "DamagePercentageGrowth": 0.031,
+          "StunRatio": 0.167,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 57.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 437.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterViolationPenalty": [
+        {
+          "DamagePercentage": 1.642,
+          "DamagePercentageGrowth": 0.15,
+          "StunRatio": 1.505,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 156,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1193.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 43.33
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackObstructionRemoval": [
+        {
+          "DamagePercentage": 0.421,
+          "DamagePercentageGrowth": 0.039,
+          "StunRatio": 0.421,
+          "StunRatioGrowth": 0.02,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1102.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 70.03
+        }
+      ],
+      "EXSpecialAttackSuperchargedObstructionRemoval": [
+        {
+          "DamagePercentage": 1.669,
+          "DamagePercentageGrowth": 0.152,
+          "StunRatio": 1.342,
+          "StunRatioGrowth": 0.061,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5230.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 143.34
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackCollaborativeConstruction": [
+        {
+          "DamagePercentage": 5.713,
+          "DamagePercentageGrowth": 0.52,
+          "StunRatio": 1.523,
+          "StunRatioGrowth": 0.07,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22277.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 344.5
+        }
+      ],
+      "UltimateDemolitionBlastBeware": [
+        {
+          "DamagePercentage": 14.788,
+          "DamagePercentageGrowth": 1.345,
+          "StunRatio": 1.331,
+          "StunRatioGrowth": 0.061,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 895.7
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistIncidentManagement": [
+        {
+          "DamagePercentage": 0.455,
+          "DamagePercentageGrowth": 0.042,
+          "StunRatio": 0.455,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 156,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1193.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 43.33
+        }
+      ],
+      "EvasiveAssistRapidRiskResponse": [],
+      "AssistFollowUpCounterVoltNeedle": [
+        {
+          "DamagePercentage": 3.593,
+          "DamagePercentageGrowth": 0.327,
+          "StunRatio": 3.128,
+          "StunRatioGrowth": 0.143,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10628.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 320.01
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Harumasa.json
+++ b/libs/zzz/stats/Data/Characters/Harumasa.json
@@ -31,5 +31,288 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackCloudPiercer": [
+        {
+          "DamagePercentage": 0.424,
+          "DamagePercentageGrowth": 0.039,
+          "StunRatio": 0.265,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 86.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 662.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.398,
+          "DamagePercentageGrowth": 0.037,
+          "StunRatio": 0.443,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 145,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1108.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.709,
+          "DamagePercentageGrowth": 0.065,
+          "StunRatio": 0.661,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 216.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1652.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.901,
+          "DamagePercentageGrowth": 0.082,
+          "StunRatio": 0.896,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 293,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2238.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 49.17
+        },
+        {
+          "DamagePercentage": 1.329,
+          "DamagePercentageGrowth": 0.121,
+          "StunRatio": 1.154,
+          "StunRatioGrowth": 0.053,
+          "SpRecovery": 377.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2887.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 65.84
+        }
+      ],
+      "BasicAttackCloudPiercerDrift": [
+        {
+          "DamagePercentage": 0.695,
+          "DamagePercentageGrowth": 0.064,
+          "StunRatio": 0.487,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 159.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1218.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackFallingFeather": [
+        {
+          "DamagePercentage": 1.054,
+          "DamagePercentageGrowth": 0.096,
+          "StunRatio": 0.527,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 172.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1317.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 33.51
+        }
+      ],
+      "BasicAttackHaOtoNoYa": [
+        {
+          "DamagePercentage": 0.159,
+          "DamagePercentageGrowth": 0.015,
+          "StunRatio": 0,
+          "StunRatioGrowth": 0,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeQuickFlash": [],
+      "DashAttackHitenNoTsuru": [
+        {
+          "DamagePercentage": 0.807,
+          "DamagePercentageGrowth": 0.074,
+          "StunRatio": 0.404,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 132.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1009.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterHiddenEdge": [
+        {
+          "DamagePercentage": 2.196,
+          "DamagePercentageGrowth": 0.2,
+          "StunRatio": 1.943,
+          "StunRatioGrowth": 0.089,
+          "SpRecovery": 275.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 53.64
+        }
+      ],
+      "DashAttackHitenNoTsuruSlash": [
+        {
+          "DamagePercentage": 1.623,
+          "DamagePercentageGrowth": 0.148,
+          "StunRatio": 0.66,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 108,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1650,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 41.97
+        },
+        {
+          "DamagePercentage": 1.666,
+          "DamagePercentageGrowth": 0.152,
+          "StunRatio": 0.459,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 75.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1146.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 29.16
+        },
+        {
+          "DamagePercentage": 1.896,
+          "DamagePercentageGrowth": 0.173,
+          "StunRatio": 0.495,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 81,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1237.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.47
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackNowhereToHide": [
+        {
+          "DamagePercentage": 0.523,
+          "DamagePercentageGrowth": 0.048,
+          "StunRatio": 0.523,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1309,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 33.26
+        }
+      ],
+      "EXSpecialAttackNowhereToRun": [
+        {
+          "DamagePercentage": 4.493,
+          "DamagePercentageGrowth": 0.409,
+          "StunRatio": 4.49,
+          "StunRatioGrowth": 0.205,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16478,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 319.11
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackKaiHanare": [
+        {
+          "DamagePercentage": 5.176,
+          "DamagePercentageGrowth": 0.471,
+          "StunRatio": 1.834,
+          "StunRatioGrowth": 0.084,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22871.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 256.33
+        }
+      ],
+      "UltimateZanshin": [
+        {
+          "DamagePercentage": 19.539,
+          "DamagePercentageGrowth": 1.777,
+          "StunRatio": 1.069,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 61.81
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistBracedBow": [
+        {
+          "DamagePercentage": 0.843,
+          "DamagePercentageGrowth": 0.077,
+          "StunRatio": 0.843,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 275.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 53.64
+        }
+      ],
+      "DefensiveAssistYugamae": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.476,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.952,
+          "StunRatioGrowth": 0.135,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.192,
+          "StunRatioGrowth": 0.055,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpYugamaeSlash": [
+        {
+          "DamagePercentage": 3.071,
+          "DamagePercentageGrowth": 0.28,
+          "StunRatio": 2.633,
+          "StunRatioGrowth": 0.12,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8769.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 181.45
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Jane.json
+++ b/libs/zzz/stats/Data/Characters/Jane.json
@@ -31,5 +31,311 @@
     { "atk": 50, "anomMas": 24 },
     { "atk": 50, "anomMas": 36 },
     { "atk": 75, "anomMas": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackDancingBlades": [
+        {
+          "DamagePercentage": 0.361,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.153,
+          "StunRatioGrowth": 0.007,
+          "SpRecovery": 50.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 382.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 21.34
+        },
+        {
+          "DamagePercentage": 0.623,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.443,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 144.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1105.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 52.06
+        },
+        {
+          "DamagePercentage": 0.835,
+          "DamagePercentageGrowth": 0.076,
+          "StunRatio": 0.595,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 194.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1487.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 68.78
+        },
+        {
+          "DamagePercentage": 1.634,
+          "DamagePercentageGrowth": 0.149,
+          "StunRatio": 1.097,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 358.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2741.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 127.45
+        },
+        {
+          "DamagePercentage": 0.988,
+          "DamagePercentageGrowth": 0.09,
+          "StunRatio": 0.687,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 224.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1716,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.71
+        },
+        {
+          "DamagePercentage": 2.913,
+          "DamagePercentageGrowth": 0.265,
+          "StunRatio": 2,
+          "StunRatioGrowth": 0.091,
+          "SpRecovery": 654.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4999.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 226.62
+        }
+      ],
+      "Passion": [],
+      "BasicAttackSalchowJump": [
+        {
+          "DamagePercentage": 3.008,
+          "DamagePercentageGrowth": 0.274,
+          "StunRatio": 2.292,
+          "StunRatioGrowth": 0.105,
+          "SpRecovery": 749.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5728.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 273.4
+        },
+        {
+          "DamagePercentage": 1.613,
+          "DamagePercentageGrowth": 0.147,
+          "StunRatio": 1.229,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 402,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3071.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 146.56
+        }
+      ]
+    },
+    "dodge": {
+      "DodgePhantom": [],
+      "DashAttackEdgeJump": [
+        {
+          "DamagePercentage": 0.715,
+          "DamagePercentageGrowth": 0.065,
+          "StunRatio": 0.358,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 117,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 893.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 32.5
+        },
+        {
+          "DamagePercentage": 0.715,
+          "DamagePercentageGrowth": 0.065,
+          "StunRatio": 0.358,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 117,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 893.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 32.5
+        }
+      ],
+      "DashAttackPhantomThrust": [
+        {
+          "DamagePercentage": 1.045,
+          "DamagePercentageGrowth": 0.095,
+          "StunRatio": 0.523,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 171,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1306.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 47.48
+        }
+      ],
+      "DodgeCounterSwiftShadow": [
+        {
+          "DamagePercentage": 3.412,
+          "DamagePercentageGrowth": 0.311,
+          "StunRatio": 2.292,
+          "StunRatioGrowth": 0.105,
+          "SpRecovery": 390,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2981,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 177.67
+        },
+        {
+          "DamagePercentage": 3.412,
+          "DamagePercentageGrowth": 0.311,
+          "StunRatio": 2.292,
+          "StunRatioGrowth": 0.105,
+          "SpRecovery": 390,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2981,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 177.67
+        }
+      ],
+      "DodgeCounterSwiftShadowDance": [
+        {
+          "DamagePercentage": 3.87,
+          "DamagePercentageGrowth": 0.352,
+          "StunRatio": 2.475,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 449.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3437.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 194.31
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackAerialSweep": [
+        {
+          "DamagePercentage": 0.578,
+          "DamagePercentageGrowth": 0.053,
+          "StunRatio": 0.578,
+          "StunRatioGrowth": 0.027,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1443.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 52.5
+        }
+      ],
+      "EXSpecialAttackAerialSweepClearout": [
+        {
+          "DamagePercentage": 5.747,
+          "DamagePercentageGrowth": 0.523,
+          "StunRatio": 4.681,
+          "StunRatioGrowth": 0.213,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 17030.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 473.96
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackFlowersOfSin": [
+        {
+          "DamagePercentage": 6.326,
+          "DamagePercentageGrowth": 0.576,
+          "StunRatio": 2.376,
+          "StunRatioGrowth": 0.108,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24887.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 439.46
+        }
+      ],
+      "UltimateFinalCurtain": [
+        {
+          "DamagePercentage": 14.706,
+          "DamagePercentageGrowth": 1.337,
+          "StunRatio": 1.865,
+          "StunRatioGrowth": 0.085,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 966.58
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistDarkThorn": [
+        {
+          "DamagePercentage": 1.192,
+          "DamagePercentageGrowth": 0.109,
+          "StunRatio": 1.192,
+          "StunRatioGrowth": 0.055,
+          "SpRecovery": 390,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2981,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 108.33
+        }
+      ],
+      "QuickAssistLutzJump": [
+        {
+          "DamagePercentage": 1.375,
+          "DamagePercentageGrowth": 0.125,
+          "StunRatio": 1.375,
+          "StunRatioGrowth": 0.063,
+          "SpRecovery": 449.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3437.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 124.96
+        }
+      ],
+      "DefensiveAssistLastDefense": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpGaleSweep": [
+        {
+          "DamagePercentage": 3.455,
+          "DamagePercentageGrowth": 0.315,
+          "StunRatio": 2.99,
+          "StunRatioGrowth": 0.136,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9801,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 292.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Koleda.json
+++ b/libs/zzz/stats/Data/Characters/Koleda.json
@@ -31,5 +31,291 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackSmashNBash": [
+        {
+          "DamagePercentage": 0.636,
+          "DamagePercentageGrowth": 0.058,
+          "StunRatio": 0.318,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 109,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 833.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.792,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.655,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 224.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1716,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.261,
+          "DamagePercentageGrowth": 0.115,
+          "StunRatio": 1.043,
+          "StunRatioGrowth": 0.048,
+          "SpRecovery": 357.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2730.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 3.174,
+          "DamagePercentageGrowth": 0.289,
+          "StunRatio": 2.493,
+          "StunRatioGrowth": 0.114,
+          "SpRecovery": 854.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6531.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.608,
+          "DamagePercentageGrowth": 0.147,
+          "StunRatio": 0.614,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 210.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1608.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 44.35
+        },
+        {
+          "DamagePercentage": 4.049,
+          "DamagePercentageGrowth": 0.369,
+          "StunRatio": 1.566,
+          "StunRatioGrowth": 0.072,
+          "SpRecovery": 597.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4562.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 149.08
+        },
+        {
+          "DamagePercentage": 5.013,
+          "DamagePercentageGrowth": 0.456,
+          "StunRatio": 2.346,
+          "StunRatioGrowth": 0.107,
+          "SpRecovery": 731.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5585.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 186.29
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeWaitNSee": [],
+      "DashAttackTremble": [
+        {
+          "DamagePercentage": 0.561,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.281,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 96.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 734.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterDontLookDownOnMe": [
+        {
+          "DamagePercentage": 3.439,
+          "DamagePercentageGrowth": 0.313,
+          "StunRatio": 2.888,
+          "StunRatioGrowth": 0.132,
+          "SpRecovery": 629.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4812.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 174.96
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackHammerTime": [
+        {
+          "DamagePercentage": 0.519,
+          "DamagePercentageGrowth": 0.048,
+          "StunRatio": 0.519,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1358.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.18
+        },
+        {
+          "DamagePercentage": 0.778,
+          "DamagePercentageGrowth": 0.071,
+          "StunRatio": 0.778,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2037.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 59.18
+        },
+        {
+          "DamagePercentage": 0.855,
+          "DamagePercentageGrowth": 0.078,
+          "StunRatio": 0.778,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2037.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 59.18
+        }
+      ],
+      "EXSpecialAttackBoilingFurnace": [
+        {
+          "DamagePercentage": 1.523,
+          "DamagePercentageGrowth": 0.139,
+          "StunRatio": 1.523,
+          "StunRatioGrowth": 0.07,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3987.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 72.48
+        },
+        {
+          "DamagePercentage": 6.06,
+          "DamagePercentageGrowth": 0.551,
+          "StunRatio": 4.94,
+          "StunRatioGrowth": 0.225,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 17096.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 476.12
+        },
+        {
+          "DamagePercentage": 6.666,
+          "DamagePercentageGrowth": 0.606,
+          "StunRatio": 4.94,
+          "StunRatioGrowth": 0.225,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 17096.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 476.12
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackNaturalDisaster": [
+        {
+          "DamagePercentage": 6.36,
+          "DamagePercentageGrowth": 0.579,
+          "StunRatio": 2.17,
+          "StunRatioGrowth": 0.099,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 23971.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 406.13
+        }
+      ],
+      "UltimateHammerquake": [
+        {
+          "DamagePercentage": 15.488,
+          "DamagePercentageGrowth": 1.408,
+          "StunRatio": 10.049,
+          "StunRatioGrowth": 0.457,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 180.03
+        },
+        {
+          "DamagePercentage": 16.94,
+          "DamagePercentageGrowth": 1.54,
+          "StunRatio": 10.965,
+          "StunRatioGrowth": 0.499,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 190.66
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistComingThru": [
+        {
+          "DamagePercentage": 1.838,
+          "DamagePercentageGrowth": 0.168,
+          "StunRatio": 1.838,
+          "StunRatioGrowth": 0.084,
+          "SpRecovery": 629.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4812.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 174.96
+        }
+      ],
+      "DefensiveAssistProtectiveHammer": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.59,
+          "StunRatioGrowth": 0.118,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.273,
+          "StunRatioGrowth": 0.149,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.593,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpHammerBell": [
+        {
+          "DamagePercentage": 3.592,
+          "DamagePercentageGrowth": 0.327,
+          "StunRatio": 3.127,
+          "StunRatioGrowth": 0.143,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10626,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 319.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Lighter.json
+++ b/libs/zzz/stats/Data/Characters/Lighter.json
@@ -31,5 +31,346 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackLFormThunderingFist": [
+        {
+          "DamagePercentage": 0.392,
+          "DamagePercentageGrowth": 0.036,
+          "StunRatio": 0.196,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 64.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 492.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.48,
+          "DamagePercentageGrowth": 0.044,
+          "StunRatio": 0.329,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 107.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 822.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.553,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.467,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 152.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1166,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.869,
+          "DamagePercentageGrowth": 0.079,
+          "StunRatio": 0.605,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 197.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1512.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.477,
+          "DamagePercentageGrowth": 0.044,
+          "StunRatio": 0.332,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 108.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 830.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.581,
+          "DamagePercentageGrowth": 0.053,
+          "StunRatio": 0.404,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 132.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1009.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.328,
+          "DamagePercentageGrowth": 0.03,
+          "StunRatio": 0.228,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 74.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 569.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.89,
+          "DamagePercentageGrowth": 0.081,
+          "StunRatio": 0.619,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 202.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1548.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.789,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.761,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 249.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1903,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 55.05
+        },
+        {
+          "DamagePercentage": 1.636,
+          "DamagePercentageGrowth": 0.149,
+          "StunRatio": 1.295,
+          "StunRatioGrowth": 0.059,
+          "SpRecovery": 476.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3638.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 123.87
+        },
+        {
+          "DamagePercentage": 1.229,
+          "DamagePercentageGrowth": 0.112,
+          "StunRatio": 0.813,
+          "StunRatioGrowth": 0.037,
+          "SpRecovery": 279.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2139.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 77.7
+        },
+        {
+          "DamagePercentage": 1.046,
+          "DamagePercentageGrowth": 0.096,
+          "StunRatio": 0.795,
+          "StunRatioGrowth": 0.037,
+          "SpRecovery": 273.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2092.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.05
+        },
+        {
+          "DamagePercentage": 1.772,
+          "DamagePercentageGrowth": 0.162,
+          "StunRatio": 1.363,
+          "StunRatioGrowth": 0.062,
+          "SpRecovery": 446,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3407.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 123.87
+        },
+        {
+          "DamagePercentage": 3.643,
+          "DamagePercentageGrowth": 0.332,
+          "StunRatio": 0.855,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 279.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2139.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 77.7
+        },
+        {
+          "DamagePercentage": 1.197,
+          "DamagePercentageGrowth": 0.109,
+          "StunRatio": 0.921,
+          "StunRatioGrowth": 0.042,
+          "SpRecovery": 301.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2301.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 83.66
+        },
+        {
+          "DamagePercentage": 4.354,
+          "DamagePercentageGrowth": 0.396,
+          "StunRatio": 1.324,
+          "StunRatioGrowth": 0.061,
+          "SpRecovery": 360.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2758.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 100.23
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeShadowedSlide": [],
+      "DashAttackChargingSlam": [
+        {
+          "DamagePercentage": 0.899,
+          "DamagePercentageGrowth": 0.082,
+          "StunRatio": 0.45,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 147.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1124.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterBlazingFlash": [
+        {
+          "DamagePercentage": 1.863,
+          "DamagePercentageGrowth": 0.17,
+          "StunRatio": 1.687,
+          "StunRatioGrowth": 0.077,
+          "SpRecovery": 192.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1468.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 53.33
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackVFormSunriseUppercut": [
+        {
+          "DamagePercentage": 0.363,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.363,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 825,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 30
+        }
+      ],
+      "EXSpecialAttackVFormSunriseUppercutFullDistance": [
+        {
+          "DamagePercentage": 4.863,
+          "DamagePercentageGrowth": 0.443,
+          "StunRatio": 4.035,
+          "StunRatioGrowth": 0.184,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 12933.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 367.64
+        },
+        {
+          "DamagePercentage": 2.927,
+          "DamagePercentageGrowth": 0.267,
+          "StunRatio": 2.477,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7672.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 223.26
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackVFormScorchingSun": [
+        {
+          "DamagePercentage": 7.121,
+          "DamagePercentageGrowth": 0.648,
+          "StunRatio": 2.732,
+          "StunRatioGrowth": 0.125,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 25118.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 447.83
+        }
+      ],
+      "UltimateWFormCrownedInferno": [
+        {
+          "DamagePercentage": 15.08,
+          "DamagePercentageGrowth": 1.371,
+          "StunRatio": 9.474,
+          "StunRatioGrowth": 0.431,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 96.69
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistBlazingFlashGuard": [
+        {
+          "DamagePercentage": 0.697,
+          "DamagePercentageGrowth": 0.064,
+          "StunRatio": 0.697,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 228,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1743.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 63.33
+        }
+      ],
+      "DefensiveAssistSwiftBreak": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpChargingSlamStab": [
+        {
+          "DamagePercentage": 2.198,
+          "DamagePercentageGrowth": 0.2,
+          "StunRatio": 1.823,
+          "StunRatioGrowth": 0.083,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6432.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 182.72
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Lucy.json
+++ b/libs/zzz/stats/Data/Characters/Lucy.json
@@ -31,5 +31,285 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackLadysBat": [
+        {
+          "DamagePercentage": 0.566,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.283,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 101.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 778.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.778,
+          "DamagePercentageGrowth": 0.071,
+          "StunRatio": 0.65,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 234,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1787.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.889,
+          "DamagePercentageGrowth": 0.172,
+          "StunRatio": 1.574,
+          "StunRatioGrowth": 0.072,
+          "SpRecovery": 566.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4328.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 134.01
+        },
+        {
+          "DamagePercentage": 2.115,
+          "DamagePercentageGrowth": 0.193,
+          "StunRatio": 1.623,
+          "StunRatioGrowth": 0.074,
+          "SpRecovery": 584.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4463.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.726,
+          "DamagePercentageGrowth": 0.248,
+          "StunRatio": 2.08,
+          "StunRatioGrowth": 0.095,
+          "SpRecovery": 748.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5720,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 186.25
+        }
+      ],
+      "GuardBoarsToArms": [
+        {
+          "DamagePercentage": 0.925,
+          "DamagePercentageGrowth": 0.085,
+          "StunRatio": 0.155,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.275,
+          "DamagePercentageGrowth": 0.116,
+          "StunRatio": 0.213,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.75,
+          "DamagePercentageGrowth": 0.16,
+          "StunRatio": 0.292,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "GuardBoarsSpinningSwing": [
+        {
+          "DamagePercentage": 2.5,
+          "DamagePercentageGrowth": 0.228,
+          "StunRatio": 0.2,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeFoulBall": [],
+      "DashAttackFearlessBoar": [
+        {
+          "DamagePercentage": 0.784,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.392,
+          "StunRatioGrowth": 0.018,
+          "SpRecovery": 141.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1078,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterReturningTusk": [
+        {
+          "DamagePercentage": 3.08,
+          "DamagePercentageGrowth": 0.28,
+          "StunRatio": 2.6,
+          "StunRatioGrowth": 0.119,
+          "SpRecovery": 575.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4400,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 159.96
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSolidHit": [
+        {
+          "DamagePercentage": 0.617,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.617,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1696.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 61.65
+        },
+        {
+          "DamagePercentage": 0.692,
+          "DamagePercentageGrowth": 0.063,
+          "StunRatio": 0.692,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1903,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 69.15
+        }
+      ],
+      "EXSpecialAttackHomeRun": [
+        {
+          "DamagePercentage": 5.084,
+          "DamagePercentageGrowth": 0.463,
+          "StunRatio": 3.646,
+          "StunRatioGrowth": 0.166,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16615.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 335.41
+        },
+        {
+          "DamagePercentage": 5.364,
+          "DamagePercentageGrowth": 0.488,
+          "StunRatio": 3.896,
+          "StunRatioGrowth": 0.178,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 17440.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 342.41
+        }
+      ],
+      "CheerOn": []
+    },
+    "chain": {
+      "ChainAttackGrandSlam": [
+        {
+          "DamagePercentage": 4.924,
+          "DamagePercentageGrowth": 0.448,
+          "StunRatio": 0.934,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 20856,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 292.8
+        }
+      ],
+      "UltimateWalkOffHomeRun": [
+        {
+          "DamagePercentage": 17.186,
+          "DamagePercentageGrowth": 1.563,
+          "StunRatio": 2.835,
+          "StunRatioGrowth": 0.129,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 315
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistHitByPitch": [
+        {
+          "DamagePercentage": 1.6,
+          "DamagePercentageGrowth": 0.146,
+          "StunRatio": 1.6,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 575.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4400,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 159.96
+        }
+      ],
+      "DefensiveAssistSafeOnBase": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.077,
+          "StunRatioGrowth": 0.095,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.294,
+          "StunRatioGrowth": 0.105,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 0.694,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpScoredARun": [
+        {
+          "DamagePercentage": 3.491,
+          "DamagePercentageGrowth": 0.318,
+          "StunRatio": 3.043,
+          "StunRatioGrowth": 0.139,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10832.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 326.67
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Lycaon.json
+++ b/libs/zzz/stats/Data/Characters/Lycaon.json
@@ -31,5 +31,324 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackMoonHunter": [
+        {
+          "DamagePercentage": 0.292,
+          "DamagePercentageGrowth": 0.027,
+          "StunRatio": 0.146,
+          "StunRatioGrowth": 0.007,
+          "SpRecovery": 50.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 382.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.371,
+          "DamagePercentageGrowth": 0.034,
+          "StunRatio": 0.121,
+          "StunRatioGrowth": 0.006,
+          "SpRecovery": 41.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 316.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 11.48
+        },
+        {
+          "DamagePercentage": 0.349,
+          "DamagePercentageGrowth": 0.032,
+          "StunRatio": 0.303,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 103.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 794.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.564,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.329,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 112.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 860.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.28
+        },
+        {
+          "DamagePercentage": 0.584,
+          "DamagePercentageGrowth": 0.054,
+          "StunRatio": 0.456,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 156.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1196.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.995,
+          "DamagePercentageGrowth": 0.091,
+          "StunRatio": 0.537,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 184.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1408,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 51.13
+        },
+        {
+          "DamagePercentage": 1.52,
+          "DamagePercentageGrowth": 0.139,
+          "StunRatio": 1.12,
+          "StunRatioGrowth": 0.051,
+          "SpRecovery": 383.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2931.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.109,
+          "DamagePercentageGrowth": 0.192,
+          "StunRatio": 1.071,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 367.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2805,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 101.98
+        },
+        {
+          "DamagePercentage": 1.807,
+          "DamagePercentageGrowth": 0.165,
+          "StunRatio": 1.477,
+          "StunRatioGrowth": 0.068,
+          "SpRecovery": 506.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3866.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.776,
+          "DamagePercentageGrowth": 0.253,
+          "StunRatio": 1.631,
+          "StunRatioGrowth": 0.075,
+          "SpRecovery": 558.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4270.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 155.24
+        },
+        {
+          "DamagePercentage": 3.557,
+          "DamagePercentageGrowth": 0.324,
+          "StunRatio": 2.056,
+          "StunRatioGrowth": 0.094,
+          "SpRecovery": 704.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5384.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 195.75
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeSuitablePositioning": [],
+      "DashAttackKeepItClean": [
+        {
+          "DamagePercentage": 0.473,
+          "DamagePercentageGrowth": 0.043,
+          "StunRatio": 0.237,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 81.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 621.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterEtiquetteManual": [
+        {
+          "DamagePercentage": 1.87,
+          "DamagePercentageGrowth": 0.17,
+          "StunRatio": 1.681,
+          "StunRatioGrowth": 0.077,
+          "SpRecovery": 216.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1652.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 60.03
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackTimeToHunt": [
+        {
+          "DamagePercentage": 0.228,
+          "DamagePercentageGrowth": 0.021,
+          "StunRatio": 0.228,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 596.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 21.66
+        },
+        {
+          "DamagePercentage": 0.543,
+          "DamagePercentageGrowth": 0.05,
+          "StunRatio": 0.543,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1421.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 25.83
+        },
+        {
+          "DamagePercentage": 1.103,
+          "DamagePercentageGrowth": 0.101,
+          "StunRatio": 1.103,
+          "StunRatioGrowth": 0.051,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2890.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 52.5
+        }
+      ],
+      "EXSpecialAttackThrillOfTheHunt": [
+        {
+          "DamagePercentage": 2.524,
+          "DamagePercentageGrowth": 0.23,
+          "StunRatio": 2.115,
+          "StunRatioGrowth": 0.097,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6985,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 200.76
+        },
+        {
+          "DamagePercentage": 2.819,
+          "DamagePercentageGrowth": 0.257,
+          "StunRatio": 2.389,
+          "StunRatioGrowth": 0.109,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7738.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 225.42
+        },
+        {
+          "DamagePercentage": 5.371,
+          "DamagePercentageGrowth": 0.489,
+          "StunRatio": 4.529,
+          "StunRatioGrowth": 0.206,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 14792.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 428.48
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackAsYouWish": [
+        {
+          "DamagePercentage": 6.378,
+          "DamagePercentageGrowth": 0.58,
+          "StunRatio": 2.188,
+          "StunRatioGrowth": 0.1,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 24018.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 407.86
+        }
+      ],
+      "UltimateMissionComplete": [
+        {
+          "DamagePercentage": 16.941,
+          "DamagePercentageGrowth": 1.541,
+          "StunRatio": 10.966,
+          "StunRatioGrowth": 0.499,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 173.36
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistWolfPack": [
+        {
+          "DamagePercentage": 0.631,
+          "DamagePercentageGrowth": 0.058,
+          "StunRatio": 0.631,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 216.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1652.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 60.03
+        }
+      ],
+      "DefensiveAssistDisruptedHunt": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.59,
+          "StunRatioGrowth": 0.118,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.273,
+          "StunRatioGrowth": 0.149,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.593,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpVengefulCounterattack": [
+        {
+          "DamagePercentage": 2.883,
+          "DamagePercentageGrowth": 0.263,
+          "StunRatio": 2.468,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8635,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 254.76
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Miyabi.json
+++ b/libs/zzz/stats/Data/Characters/Miyabi.json
@@ -31,5 +31,304 @@
     { "atk": 50, "anomProf": 60 },
     { "atk": 50, "anomProf": 90 },
     { "atk": 75, "anomProf": 90 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackKazahana": [
+        {
+          "DamagePercentage": 0.269,
+          "DamagePercentageGrowth": 0.025,
+          "StunRatio": 0.135,
+          "StunRatioGrowth": 0.007,
+          "SpRecovery": 44,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 338.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.296,
+          "DamagePercentageGrowth": 0.027,
+          "StunRatio": 0.269,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 87.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 673.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.628,
+          "DamagePercentageGrowth": 0.058,
+          "StunRatio": 0.464,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 151.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1160.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 62.9
+        },
+        {
+          "DamagePercentage": 0.965,
+          "DamagePercentageGrowth": 0.088,
+          "StunRatio": 0.821,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 268.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2051.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 91.21
+        },
+        {
+          "DamagePercentage": 1.29,
+          "DamagePercentageGrowth": 0.118,
+          "StunRatio": 1.31,
+          "StunRatioGrowth": 0.06,
+          "SpRecovery": 428.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3275.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 129.27
+        }
+      ],
+      "BasicAttackShimotsuki": [
+        {
+          "DamagePercentage": 4.547,
+          "DamagePercentageGrowth": 0.414,
+          "StunRatio": 0.44,
+          "StunRatioGrowth": 0.02,
+          "SpRecovery": 144,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1100,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 39.98
+        },
+        {
+          "DamagePercentage": 8.581,
+          "DamagePercentageGrowth": 0.781,
+          "StunRatio": 0.624,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 204.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1559.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.68
+        },
+        {
+          "DamagePercentage": 21.411,
+          "DamagePercentageGrowth": 1.947,
+          "StunRatio": 3.778,
+          "StunRatioGrowth": 0.172,
+          "SpRecovery": 618.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9443.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 343.36
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeMizutori": [],
+      "DashAttackFuyubachi": [
+        {
+          "DamagePercentage": 0.258,
+          "DamagePercentageGrowth": 0.024,
+          "StunRatio": 0.129,
+          "StunRatioGrowth": 0.006,
+          "SpRecovery": 42.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 321.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterKanSuzume": [
+        {
+          "DamagePercentage": 2.459,
+          "DamagePercentageGrowth": 0.224,
+          "StunRatio": 2.145,
+          "StunRatioGrowth": 0.098,
+          "SpRecovery": 342,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2612.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 94.99
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackMiyuki": [
+        {
+          "DamagePercentage": 0.358,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.358,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 896.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 32.51
+        }
+      ],
+      "EXSpecialAttackHisetsu": [
+        {
+          "DamagePercentage": 1.574,
+          "DamagePercentageGrowth": 0.144,
+          "StunRatio": 1.287,
+          "StunRatioGrowth": 0.059,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4653,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 157.75
+        },
+        {
+          "DamagePercentage": 2.36,
+          "DamagePercentageGrowth": 0.215,
+          "StunRatio": 1.93,
+          "StunRatioGrowth": 0.088,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6976.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 250.52
+        },
+        {
+          "DamagePercentage": 1.933,
+          "DamagePercentageGrowth": 0.176,
+          "StunRatio": 1.62,
+          "StunRatioGrowth": 0.074,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5615.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 189.25
+        },
+        {
+          "DamagePercentage": 2.899,
+          "DamagePercentageGrowth": 0.264,
+          "StunRatio": 2.43,
+          "StunRatioGrowth": 0.111,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8420.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 297.77
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackSpringsCall": [
+        {
+          "DamagePercentage": 1.884,
+          "DamagePercentageGrowth": 0.172,
+          "StunRatio": 0.567,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6905.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 111.36
+        },
+        {
+          "DamagePercentage": 1.884,
+          "DamagePercentageGrowth": 0.172,
+          "StunRatio": 0.567,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6905.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 111.36
+        },
+        {
+          "DamagePercentage": 2.512,
+          "DamagePercentageGrowth": 0.229,
+          "StunRatio": 0.756,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9204.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 148.48
+        }
+      ],
+      "UltimateLingeringSnow": [
+        {
+          "DamagePercentage": 23.88,
+          "DamagePercentageGrowth": 2.171,
+          "StunRatio": 3.704,
+          "StunRatioGrowth": 0.169,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 1137.16
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistDancingPetals": [
+        {
+          "DamagePercentage": 1.045,
+          "DamagePercentageGrowth": 0.095,
+          "StunRatio": 1.045,
+          "StunRatioGrowth": 0.048,
+          "SpRecovery": 342,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2612.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 94.99
+        }
+      ],
+      "DefensiveAssistDriftingPetals": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.283,
+          "StunRatioGrowth": 0.059,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpFallingPetals": [
+        {
+          "DamagePercentage": 3.378,
+          "DamagePercentageGrowth": 0.308,
+          "StunRatio": 2.919,
+          "StunRatioGrowth": 0.133,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9594.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 286.17
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Nekomata.json
+++ b/libs/zzz/stats/Data/Characters/Nekomata.json
@@ -31,5 +31,227 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackKittySlash": [
+        {
+          "DamagePercentage": 0.552,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.18,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 61.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 470.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.08
+        },
+        {
+          "DamagePercentage": 0.626,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.371,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 126.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 970.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 35.24
+        },
+        {
+          "DamagePercentage": 0.727,
+          "DamagePercentageGrowth": 0.067,
+          "StunRatio": 0.467,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 159.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1223.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 44.4
+        },
+        {
+          "DamagePercentage": 1.702,
+          "DamagePercentageGrowth": 0.155,
+          "StunRatio": 1.037,
+          "StunRatioGrowth": 0.048,
+          "SpRecovery": 355.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2717,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 98.73
+        },
+        {
+          "DamagePercentage": 1.236,
+          "DamagePercentageGrowth": 0.113,
+          "StunRatio": 0.589,
+          "StunRatioGrowth": 0.027,
+          "SpRecovery": 201.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1542.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.02
+        }
+      ],
+      "BasicAttackCrimsonBlade": [
+        {
+          "DamagePercentage": 0.718,
+          "DamagePercentageGrowth": 0.066,
+          "StunRatio": 0.589,
+          "StunRatioGrowth": 0.027,
+          "SpRecovery": 201.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1542.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.02
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeCantTouchMeow": [],
+      "DashAttackOverHere": [
+        {
+          "DamagePercentage": 0.351,
+          "DamagePercentageGrowth": 0.032,
+          "StunRatio": 0.176,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 60.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1606,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 16.68
+        }
+      ],
+      "DodgeCounterPhantomClaws": [
+        {
+          "DamagePercentage": 2.279,
+          "DamagePercentageGrowth": 0.208,
+          "StunRatio": 1.995,
+          "StunRatioGrowth": 0.091,
+          "SpRecovery": 323.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2475,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 89.96
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSurpriseAttack": [
+        {
+          "DamagePercentage": 0.473,
+          "DamagePercentageGrowth": 0.043,
+          "StunRatio": 0.473,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1240.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 45.01
+        }
+      ],
+      "EXSpecialAttackSuperSurpriseAttack": [
+        {
+          "DamagePercentage": 5.397,
+          "DamagePercentageGrowth": 0.491,
+          "StunRatio": 4.554,
+          "StunRatioGrowth": 0.207,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 14861,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 430.73
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackClawSwipe": [
+        {
+          "DamagePercentage": 5.362,
+          "DamagePercentageGrowth": 0.488,
+          "StunRatio": 1.592,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22918.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 367.86
+        }
+      ],
+      "UltimateClawSmash": [
+        {
+          "DamagePercentage": 15.711,
+          "DamagePercentageGrowth": 1.429,
+          "StunRatio": 1.181,
+          "StunRatioGrowth": 0.054,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 124.96
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistCatsPaw": [
+        {
+          "DamagePercentage": 0.945,
+          "DamagePercentageGrowth": 0.086,
+          "StunRatio": 0.945,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 323.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2475,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 89.96
+        }
+      ],
+      "DefensiveAssistDesperateDefense": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.59,
+          "StunRatioGrowth": 0.118,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.273,
+          "StunRatioGrowth": 0.149,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.593,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpShadowStrike": [
+        {
+          "DamagePercentage": 3.004,
+          "DamagePercentageGrowth": 0.274,
+          "StunRatio": 2.581,
+          "StunRatioGrowth": 0.118,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8976,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 265.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Nicole.json
+++ b/libs/zzz/stats/Data/Characters/Nicole.json
@@ -31,5 +31,394 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackCunningCombo": [
+        {
+          "DamagePercentage": 0.389,
+          "DamagePercentageGrowth": 0.036,
+          "StunRatio": 0.195,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 70,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 536.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.271,
+          "DamagePercentageGrowth": 0.025,
+          "StunRatio": 0.209,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 70,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 536.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.353,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.29,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 104.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 797.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.361,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.278,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 104.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 797.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.243,
+          "DamagePercentageGrowth": 0.113,
+          "StunRatio": 1.043,
+          "StunRatioGrowth": 0.048,
+          "SpRecovery": 375.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2868.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.804,
+          "DamagePercentageGrowth": 0.164,
+          "StunRatio": 1.388,
+          "StunRatioGrowth": 0.064,
+          "SpRecovery": 375.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2868.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackDoAsIPlease": [
+        {
+          "DamagePercentage": 0.494,
+          "DamagePercentageGrowth": 0.045,
+          "StunRatio": 0.209,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 70,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 536.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.658,
+          "DamagePercentageGrowth": 0.06,
+          "StunRatio": 0.278,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 104.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 797.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 3.29,
+          "DamagePercentageGrowth": 0.3,
+          "StunRatio": 1.388,
+          "StunRatioGrowth": 0.064,
+          "SpRecovery": 375.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2868.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeSpeedDemon": [],
+      "DashAttackJackInTheBox": [
+        {
+          "DamagePercentage": 0.412,
+          "DamagePercentageGrowth": 0.038,
+          "StunRatio": 0.29,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 102,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 781,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.173,
+          "DamagePercentageGrowth": 0.107,
+          "StunRatio": 0.451,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 102,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 781,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.6,
+          "DamagePercentageGrowth": 0.055,
+          "StunRatio": 0.6,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 215.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 825,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterDivertedBombard": [
+        {
+          "DamagePercentage": 0.912,
+          "DamagePercentageGrowth": 0.083,
+          "StunRatio": 0.817,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 227.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 871.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.64
+        },
+        {
+          "DamagePercentage": 0.912,
+          "DamagePercentageGrowth": 0.083,
+          "StunRatio": 0.817,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 191.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 871.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.64
+        }
+      ],
+      "DashAttackDoAsIPlease": [
+        {
+          "DamagePercentage": 1.173,
+          "DamagePercentageGrowth": 0.107,
+          "StunRatio": 0.451,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 102,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 781,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 121.29
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSugarcoatedBullet": [
+        {
+          "DamagePercentage": 0.263,
+          "DamagePercentageGrowth": 0.024,
+          "StunRatio": 0.25,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 723.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 26.24
+        },
+        {
+          "DamagePercentage": 0.263,
+          "DamagePercentageGrowth": 0.024,
+          "StunRatio": 0.25,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 723.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 26.24
+        }
+      ],
+      "EXSpecialAttackStuffedSugarcoatedBullet": [
+        {
+          "DamagePercentage": 2.15,
+          "DamagePercentageGrowth": 0.196,
+          "StunRatio": 1.798,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6880.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 197.35
+        },
+        {
+          "DamagePercentage": 1.075,
+          "DamagePercentageGrowth": 0.098,
+          "StunRatio": 0.899,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3440.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 98.67
+        },
+        {
+          "DamagePercentage": 1.075,
+          "DamagePercentageGrowth": 0.098,
+          "StunRatio": 0.899,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3440.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 98.67
+        },
+        {
+          "DamagePercentage": 3.87,
+          "DamagePercentageGrowth": 0.352,
+          "StunRatio": 3.236,
+          "StunRatioGrowth": 0.148,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 13761,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 394.71
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackEtherShellacking": [
+        {
+          "DamagePercentage": 1.048,
+          "DamagePercentageGrowth": 0.096,
+          "StunRatio": 0.25,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4345,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.89
+        },
+        {
+          "DamagePercentage": 1.048,
+          "DamagePercentageGrowth": 0.096,
+          "StunRatio": 0.25,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4345,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.89
+        },
+        {
+          "DamagePercentage": 2.83,
+          "DamagePercentageGrowth": 0.258,
+          "StunRatio": 0.675,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 13035,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 194.69
+        }
+      ],
+      "UltimateEtherGrenade": [
+        {
+          "DamagePercentage": 6.468,
+          "DamagePercentageGrowth": 0.588,
+          "StunRatio": 0.36,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 35.99
+        },
+        {
+          "DamagePercentage": 8.732,
+          "DamagePercentageGrowth": 0.794,
+          "StunRatio": 0.486,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 53.99
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistEmergencyBombard": [
+        {
+          "DamagePercentage": 0.317,
+          "DamagePercentageGrowth": 0.029,
+          "StunRatio": 0.317,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 114,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 871.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.64
+        },
+        {
+          "DamagePercentage": 0.317,
+          "DamagePercentageGrowth": 0.029,
+          "StunRatio": 0.317,
+          "StunRatioGrowth": 0.015,
+          "SpRecovery": 114,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 871.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.64
+        }
+      ],
+      "DefensiveAssistTheHareStrikesBack": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpWindowOfOpportunity": [
+        {
+          "DamagePercentage": 3.771,
+          "DamagePercentageGrowth": 0.343,
+          "StunRatio": 3.303,
+          "StunRatioGrowth": 0.151,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11657.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 353.67
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Piper.json
+++ b/libs/zzz/stats/Data/Characters/Piper.json
@@ -31,5 +31,251 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackLoadUpAndRollOut": [
+        {
+          "DamagePercentage": 0.59,
+          "DamagePercentageGrowth": 0.054,
+          "StunRatio": 0.295,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 106.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 811.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 29.48
+        },
+        {
+          "DamagePercentage": 0.788,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.645,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 231.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1773.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.4
+        },
+        {
+          "DamagePercentage": 1.501,
+          "DamagePercentageGrowth": 0.137,
+          "StunRatio": 1.219,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 438.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3352.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 121.89
+        },
+        {
+          "DamagePercentage": 3.206,
+          "DamagePercentageGrowth": 0.292,
+          "StunRatio": 2.522,
+          "StunRatioGrowth": 0.115,
+          "SpRecovery": 907.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6935.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 252.11
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeHandbrakeDrift": [],
+      "DashAttackPedalToTheMetal": [
+        {
+          "DamagePercentage": 0.901,
+          "DamagePercentageGrowth": 0.082,
+          "StunRatio": 0.451,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 162.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1240.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 45.01
+        }
+      ],
+      "DodgeCounterPowerDrift": [
+        {
+          "DamagePercentage": 2.69,
+          "DamagePercentageGrowth": 0.245,
+          "StunRatio": 2.3,
+          "StunRatioGrowth": 0.105,
+          "SpRecovery": 467.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3575,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 129.96
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackTireSpin": [
+        {
+          "DamagePercentage": 2.717,
+          "DamagePercentageGrowth": 0.247,
+          "StunRatio": 2.717,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3737.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 271.66
+        }
+      ],
+      "SpecialAttackOneTrillionTons": [
+        {
+          "DamagePercentage": 0.934,
+          "DamagePercentageGrowth": 0.085,
+          "StunRatio": 0.934,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2568.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 93.33
+        },
+        {
+          "DamagePercentage": 1.034,
+          "DamagePercentageGrowth": 0.094,
+          "StunRatio": 1.034,
+          "StunRatioGrowth": 0.047,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2843.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 103.36
+        },
+        {
+          "DamagePercentage": 2.35,
+          "DamagePercentageGrowth": 0.214,
+          "StunRatio": 2.35,
+          "StunRatioGrowth": 0.107,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6462.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 235
+        }
+      ],
+      "EXSpecialAttackEngineSpin": [
+        {
+          "DamagePercentage": 1.871,
+          "DamagePercentageGrowth": 0.171,
+          "StunRatio": 1.096,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3709.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 161.25
+        }
+      ],
+      "EXSpecialAttackReallyHeavy": [
+        {
+          "DamagePercentage": 6.129,
+          "DamagePercentageGrowth": 0.558,
+          "StunRatio": 3.968,
+          "StunRatioGrowth": 0.181,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 12619.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 532.55
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackBuckleUp": [
+        {
+          "DamagePercentage": 6.523,
+          "DamagePercentageGrowth": 0.593,
+          "StunRatio": 2.533,
+          "StunRatioGrowth": 0.116,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 25253.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 452.79
+        }
+      ],
+      "UltimateHoldOnTight": [
+        {
+          "DamagePercentage": 16.604,
+          "DamagePercentageGrowth": 1.51,
+          "StunRatio": 3.283,
+          "StunRatioGrowth": 0.15,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 1127.54
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistBrakeTap": [
+        {
+          "DamagePercentage": 1.3,
+          "DamagePercentageGrowth": 0.119,
+          "StunRatio": 1.3,
+          "StunRatioGrowth": 0.06,
+          "SpRecovery": 467.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3575,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 129.96
+        }
+      ],
+      "DefensiveAssistEmergencyBrake": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpOvertakingManeuver": [
+        {
+          "DamagePercentage": 4.005,
+          "DamagePercentageGrowth": 0.365,
+          "StunRatio": 3.52,
+          "StunRatioGrowth": 0.16,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 12344.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 376.22
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Pulchra.json
+++ b/libs/zzz/stats/Data/Characters/Pulchra.json
@@ -31,5 +31,195 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackSwiftStrike": [
+        {
+          "DamagePercentage": 0.357,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.285,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 102.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 783.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 28.48
+        },
+        {
+          "DamagePercentage": 0.941,
+          "DamagePercentageGrowth": 0.086,
+          "StunRatio": 0.753,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 270.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2070.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 75.22
+        },
+        {
+          "DamagePercentage": 1.676,
+          "DamagePercentageGrowth": 0.153,
+          "StunRatio": 1.341,
+          "StunRatioGrowth": 0.061,
+          "SpRecovery": 482.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3687.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 134.05
+        }
+      ],
+      "BasicAttackLeapingStrike": [
+        {
+          "DamagePercentage": 1.35,
+          "DamagePercentageGrowth": 0.123,
+          "StunRatio": 1.08,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 388.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2970,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 107.97
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeReversalShot": [],
+      "DashAttackFirstStrikeAdvantage": [
+        {
+          "DamagePercentage": 0.483,
+          "DamagePercentageGrowth": 0.044,
+          "StunRatio": 0.242,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 87,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 665.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 24.14
+        }
+      ],
+      "DodgeCounterRelentlessRetribution": [
+        {
+          "DamagePercentage": 2.018,
+          "DamagePercentageGrowth": 0.184,
+          "StunRatio": 1.783,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 281.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2153.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 78.29
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackRendingClaw": [
+        {
+          "DamagePercentage": 0.251,
+          "DamagePercentageGrowth": 0.023,
+          "StunRatio": 0.501,
+          "StunRatioGrowth": 0.023,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1377.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 25
+        }
+      ],
+      "SpecialAttackRendingClawNightmareShadow": [
+        {
+          "DamagePercentage": 0.463,
+          "DamagePercentageGrowth": 0.043,
+          "StunRatio": 0.29,
+          "StunRatioGrowth": 0.014,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.36
+        },
+        {
+          "DamagePercentage": 0.535,
+          "DamagePercentageGrowth": 0.049,
+          "StunRatio": 0.348,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.36
+        }
+      ],
+      "EXSpecialAttackRendingClawFlashstep": [
+        {
+          "DamagePercentage": 3.477,
+          "DamagePercentageGrowth": 0.317,
+          "StunRatio": 2.117,
+          "StunRatioGrowth": 0.097,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 14264.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 255.48
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackHeyDidntExpectThatRight": [
+        {
+          "DamagePercentage": 5.341,
+          "DamagePercentageGrowth": 0.486,
+          "StunRatio": 1.351,
+          "StunRatioGrowth": 0.062,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22002.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 334.53
+        }
+      ],
+      "UltimateOhTimeToPlay": [
+        {
+          "DamagePercentage": 13.938,
+          "DamagePercentageGrowth": 1.268,
+          "StunRatio": 8.823,
+          "StunRatioGrowth": 0.402,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 114.96
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistContractBodyguard": [
+        {
+          "DamagePercentage": 0.783,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.783,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 281.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2153.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 78.29
+        }
+      ],
+      "EvasiveAssistContractOutsourcedCombat": [],
+      "AssistFollowUpIndependentPricing": [
+        {
+          "DamagePercentage": 3.071,
+          "DamagePercentageGrowth": 0.28,
+          "StunRatio": 2.653,
+          "StunRatioGrowth": 0.121,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 9594.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 286.17
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/QingYi.json
+++ b/libs/zzz/stats/Data/Characters/QingYi.json
@@ -31,5 +31,285 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackPenultimate": [
+        {
+          "DamagePercentage": 0.472,
+          "DamagePercentageGrowth": 0.043,
+          "StunRatio": 0.236,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 77.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 591.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.103,
+          "DamagePercentageGrowth": 0.101,
+          "StunRatio": 0.552,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 180.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1380.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.221,
+          "DamagePercentageGrowth": 0.111,
+          "StunRatio": 0.822,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 268.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2392.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.176,
+          "DamagePercentageGrowth": 0.016,
+          "StunRatio": 0.191,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 48,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 368.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 13.33
+        },
+        {
+          "DamagePercentage": 1.064,
+          "DamagePercentageGrowth": 0.097,
+          "StunRatio": 1.063,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 347.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2656.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 64.54
+        },
+        {
+          "DamagePercentage": 2.344,
+          "DamagePercentageGrowth": 0.214,
+          "StunRatio": 2.047,
+          "StunRatioGrowth": 0.094,
+          "SpRecovery": 669.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5117.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 153.99
+        }
+      ],
+      "BasicAttackEnchantedBlossoms": [
+        {
+          "DamagePercentage": 0.856,
+          "DamagePercentageGrowth": 0.078,
+          "StunRatio": 0.856,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 279.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2139.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 77.74
+        }
+      ],
+      "FlashConnect": [],
+      "BasicAttackEnchantedMoonlitBlossoms": [
+        {
+          "DamagePercentage": 4.487,
+          "DamagePercentageGrowth": 0.408,
+          "StunRatio": 2.719,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 684.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5230.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 190.13
+        },
+        {
+          "DamagePercentage": 3.944,
+          "DamagePercentageGrowth": 0.359,
+          "StunRatio": 2.176,
+          "StunRatioGrowth": 0.099,
+          "SpRecovery": 547.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4185.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 152.14
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeSwanSong": [],
+      "DashAttackBreach": [
+        {
+          "DamagePercentage": 0.495,
+          "DamagePercentageGrowth": 0.045,
+          "StunRatio": 0.248,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 81,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 618.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterLingeringSentiments": [
+        {
+          "DamagePercentage": 2.84,
+          "DamagePercentageGrowth": 0.259,
+          "StunRatio": 1.904,
+          "StunRatioGrowth": 0.087,
+          "SpRecovery": 438.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3346.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 121.66
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSunlitGlory": [
+        {
+          "DamagePercentage": 0.624,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.624,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1559.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.68
+        }
+      ],
+      "EXSpecialAttackMoonlitBegonia": [
+        {
+          "DamagePercentage": 1.507,
+          "DamagePercentageGrowth": 0.137,
+          "StunRatio": 1.111,
+          "StunRatioGrowth": 0.051,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4086.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 124.65
+        },
+        {
+          "DamagePercentage": 2.11,
+          "DamagePercentageGrowth": 0.192,
+          "StunRatio": 1.555,
+          "StunRatioGrowth": 0.071,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5720,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 174.51
+        },
+        {
+          "DamagePercentage": 2.411,
+          "DamagePercentageGrowth": 0.22,
+          "StunRatio": 1.777,
+          "StunRatioGrowth": 0.081,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6536.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 199.44
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackTranquilSerenade": [
+        {
+          "DamagePercentage": 6.479,
+          "DamagePercentageGrowth": 0.589,
+          "StunRatio": 2.09,
+          "StunRatioGrowth": 0.095,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 23512.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 389.46
+        }
+      ],
+      "UltimateEightSoundsOfGanzhou": [
+        {
+          "DamagePercentage": 16.707,
+          "DamagePercentageGrowth": 1.519,
+          "StunRatio": 10.971,
+          "StunRatioGrowth": 0.499,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 215.03
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistWindThroughThePines": [
+        {
+          "DamagePercentage": 1.339,
+          "DamagePercentageGrowth": 0.122,
+          "StunRatio": 1.339,
+          "StunRatioGrowth": 0.061,
+          "SpRecovery": 438.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3346.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 121.66
+        }
+      ],
+      "DefensiveAssistGracefulEmbellishment": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.493,
+          "StunRatioGrowth": 0.114,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.043,
+          "StunRatioGrowth": 0.139,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.283,
+          "StunRatioGrowth": 0.059,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpSongOfTheClearRiver": [
+        {
+          "DamagePercentage": 3.764,
+          "DamagePercentageGrowth": 0.343,
+          "StunRatio": 2.79,
+          "StunRatioGrowth": 0.127,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4540.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 320.01
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Rina.json
+++ b/libs/zzz/stats/Data/Characters/Rina.json
@@ -31,5 +31,182 @@
     { "atk": 50, "pen_": 0.096 },
     { "atk": 50, "pen_": 0.144 },
     { "atk": 75, "pen_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackWhackTheDimwit": [
+        {
+          "DamagePercentage": 0.44,
+          "DamagePercentageGrowth": 0.04,
+          "StunRatio": 0.245,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 83.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 640.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.114,
+          "DamagePercentageGrowth": 0.102,
+          "StunRatio": 0.884,
+          "StunRatioGrowth": 0.041,
+          "SpRecovery": 302.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1652.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.171,
+          "DamagePercentageGrowth": 0.107,
+          "StunRatio": 0.966,
+          "StunRatioGrowth": 0.044,
+          "SpRecovery": 331,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3861,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 83.63
+        },
+        {
+          "DamagePercentage": 1.839,
+          "DamagePercentageGrowth": 0.168,
+          "StunRatio": 1.468,
+          "StunRatioGrowth": 0.067,
+          "SpRecovery": 559,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3418.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 104.74
+        }
+      ],
+      "BasicAttackShooTheFool": [
+        {
+          "DamagePercentage": 3.151,
+          "DamagePercentageGrowth": 0.287,
+          "StunRatio": 3.151,
+          "StunRatioGrowth": 0.144,
+          "SpRecovery": 1080.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8252.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 300.03
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeDressAdjustment": [],
+      "DashAttackSuddenSurprise": [
+        {
+          "DamagePercentage": 1.05,
+          "DamagePercentageGrowth": 0.096,
+          "StunRatio": 0.525,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 180,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1375,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterBangbooCallback": [
+        {
+          "DamagePercentage": 2.276,
+          "DamagePercentageGrowth": 0.207,
+          "StunRatio": 2.276,
+          "StunRatioGrowth": 0.104,
+          "SpRecovery": 420.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3212,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 116.7
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackBeatTheBlockhead": [
+        {
+          "DamagePercentage": 0.613,
+          "DamagePercentageGrowth": 0.056,
+          "StunRatio": 0.613,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1606,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 58.35
+        }
+      ],
+      "EXSpecialAttackDimwitDisappearingTrick": [
+        {
+          "DamagePercentage": 5.46,
+          "DamagePercentageGrowth": 0.497,
+          "StunRatio": 4.445,
+          "StunRatioGrowth": 0.203,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11459.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 471.62
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackCodeOfConduct": [
+        {
+          "DamagePercentage": 10.13,
+          "DamagePercentageGrowth": 0.921,
+          "StunRatio": 1.751,
+          "StunRatioGrowth": 0.08,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22874.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 366.2
+        }
+      ],
+      "UltimateTheQueensAttendants": [
+        {
+          "DamagePercentage": 21.167,
+          "DamagePercentageGrowth": 1.925,
+          "StunRatio": 1.138,
+          "StunRatioGrowth": 0.052,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 108.37
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistDupleMeterAllemande": [
+        {
+          "DamagePercentage": 1.226,
+          "DamagePercentageGrowth": 0.112,
+          "StunRatio": 1.226,
+          "StunRatioGrowth": 0.056,
+          "SpRecovery": 420.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3212,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 116.7
+        }
+      ],
+      "EvasiveAssistTripleMeterCourante": [],
+      "AssistFollowUpQuadrupleMeterGavotte": [
+        {
+          "DamagePercentage": 3.494,
+          "DamagePercentageGrowth": 0.318,
+          "StunRatio": 3.036,
+          "StunRatioGrowth": 0.138,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10351,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 310.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Seth.json
+++ b/libs/zzz/stats/Data/Characters/Seth.json
@@ -31,5 +31,238 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackLightningStrike": [
+        {
+          "DamagePercentage": 0.362,
+          "DamagePercentageGrowth": 0.033,
+          "StunRatio": 0.181,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 65.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 497.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.565,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.451,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 162.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1240.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.933,
+          "DamagePercentageGrowth": 0.176,
+          "StunRatio": 1.513,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 544.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4160.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.974,
+          "DamagePercentageGrowth": 0.089,
+          "StunRatio": 0.805,
+          "StunRatioGrowth": 0.037,
+          "SpRecovery": 289.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2213.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 80.41
+        }
+      ],
+      "BasicAttackLightningStrikeElectrified": [
+        {
+          "DamagePercentage": 3.828,
+          "DamagePercentageGrowth": 0.348,
+          "StunRatio": 1.617,
+          "StunRatioGrowth": 0.074,
+          "SpRecovery": 582.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4446.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 161.68
+        },
+        {
+          "DamagePercentage": 4.242,
+          "DamagePercentageGrowth": 0.386,
+          "StunRatio": 1.455,
+          "StunRatioGrowth": 0.067,
+          "SpRecovery": 476,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3638.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 132.2
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeEvasionManeuver": [],
+      "DashAttackThunderAssault": [
+        {
+          "DamagePercentage": 1.1,
+          "DamagePercentageGrowth": 0.1,
+          "StunRatio": 0.55,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 198,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1512.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterRetreatToAdvance": [
+        {
+          "DamagePercentage": 2.3,
+          "DamagePercentageGrowth": 0.21,
+          "StunRatio": 2,
+          "StunRatioGrowth": 0.091,
+          "SpRecovery": 360,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2750,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 100
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackThunderShieldRush": [
+        {
+          "DamagePercentage": 0.692,
+          "DamagePercentageGrowth": 0.063,
+          "StunRatio": 0.692,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1903,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 69.18
+        }
+      ],
+      "EXSpecialAttackThunderShieldRushHighVoltage": [
+        {
+          "DamagePercentage": 6.46,
+          "DamagePercentageGrowth": 0.588,
+          "StunRatio": 5.404,
+          "StunRatioGrowth": 0.246,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 20671.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 593.16
+        },
+        {
+          "DamagePercentage": 9.998,
+          "DamagePercentageGrowth": 0.909,
+          "StunRatio": 8.49,
+          "StunRatioGrowth": 0.386,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 31641.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 924.38
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackFinalJudgement": [
+        {
+          "DamagePercentage": 7.041,
+          "DamagePercentageGrowth": 0.641,
+          "StunRatio": 3.051,
+          "StunRatioGrowth": 0.139,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 26677.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 504.53
+        }
+      ],
+      "UltimateJusticePrevails": [
+        {
+          "DamagePercentage": 20.243,
+          "DamagePercentageGrowth": 1.841,
+          "StunRatio": 4.033,
+          "StunRatioGrowth": 0.184,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 403.29
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistArmedSupport": [
+        {
+          "DamagePercentage": 1,
+          "DamagePercentageGrowth": 0.091,
+          "StunRatio": 1,
+          "StunRatioGrowth": 0.046,
+          "SpRecovery": 360,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2750,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 100
+        }
+      ],
+      "DefensiveAssistThundershield": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpPublicSecurityRuling": [
+        {
+          "DamagePercentage": 4.285,
+          "DamagePercentageGrowth": 0.39,
+          "StunRatio": 3.78,
+          "StunRatioGrowth": 0.172,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 13169.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 403.22
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Soldier0Anby.json
+++ b/libs/zzz/stats/Data/Characters/Soldier0Anby.json
@@ -31,5 +31,262 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackPenetratingShock": [
+        {
+          "DamagePercentage": 0.327,
+          "DamagePercentageGrowth": 0.03,
+          "StunRatio": 0.279,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 91.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 698.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 25.32
+        },
+        {
+          "DamagePercentage": 0.622,
+          "DamagePercentageGrowth": 0.057,
+          "StunRatio": 0.545,
+          "StunRatioGrowth": 0.025,
+          "SpRecovery": 178.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1364,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 49.54
+        },
+        {
+          "DamagePercentage": 0.801,
+          "DamagePercentageGrowth": 0.073,
+          "StunRatio": 0.719,
+          "StunRatioGrowth": 0.033,
+          "SpRecovery": 235,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1795.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 65.27
+        },
+        {
+          "DamagePercentage": 0.399,
+          "DamagePercentageGrowth": 0.037,
+          "StunRatio": 0.621,
+          "StunRatioGrowth": 0.029,
+          "SpRecovery": 203.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1553.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 56.4
+        },
+        {
+          "DamagePercentage": 1.545,
+          "DamagePercentageGrowth": 0.141,
+          "StunRatio": 1.377,
+          "StunRatioGrowth": 0.063,
+          "SpRecovery": 450.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3443,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 125.16
+        },
+        {
+          "DamagePercentage": 1.485,
+          "DamagePercentageGrowth": 0.135,
+          "StunRatio": 1.309,
+          "StunRatioGrowth": 0.06,
+          "SpRecovery": 428.3,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3272.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 118.95
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeStrobe": [],
+      "DashAttackTorrent": [
+        {
+          "DamagePercentage": 0.825,
+          "DamagePercentageGrowth": 0.075,
+          "StunRatio": 0.413,
+          "StunRatioGrowth": 0.019,
+          "SpRecovery": 135,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1031.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 37.48
+        }
+      ],
+      "DodgeCounterGroundFlashCounter": [
+        {
+          "DamagePercentage": 2.506,
+          "DamagePercentageGrowth": 0.228,
+          "StunRatio": 2.182,
+          "StunRatioGrowth": 0.1,
+          "SpRecovery": 353.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2706,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 98.3
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackCelestialThunder": [
+        {
+          "DamagePercentage": 0.596,
+          "DamagePercentageGrowth": 0.055,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1490.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 54.16
+        }
+      ],
+      "SpecialAttackAzureFlash": [
+        {
+          "DamagePercentage": 1.672,
+          "DamagePercentageGrowth": 0.152,
+          "StunRatio": 0,
+          "StunRatioGrowth": 0,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.43,
+          "DamagePercentageGrowth": 0.04,
+          "StunRatio": 0.331,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 827.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 30.03
+        }
+      ],
+      "SpecialAttackThunderSmite": [
+        {
+          "DamagePercentage": 1.881,
+          "DamagePercentageGrowth": 0.171,
+          "StunRatio": 0,
+          "StunRatioGrowth": 0,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "EXSpecialAttackSunderingBolt": [
+        {
+          "DamagePercentage": 3.796,
+          "DamagePercentageGrowth": 0.346,
+          "StunRatio": 4.586,
+          "StunRatioGrowth": 0.209,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 16755.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 464.96
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackLeapingThunderstrike": [
+        {
+          "DamagePercentage": 5.638,
+          "DamagePercentageGrowth": 0.513,
+          "StunRatio": 1.981,
+          "StunRatioGrowth": 0.091,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 23240.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 379.5
+        }
+      ],
+      "UltimateVoidstrike": [
+        {
+          "DamagePercentage": 17.349,
+          "DamagePercentageGrowth": 1.578,
+          "StunRatio": 2.769,
+          "StunRatioGrowth": 0.126,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 251.66
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistCloudFlash": [
+        {
+          "DamagePercentage": 1.082,
+          "DamagePercentageGrowth": 0.099,
+          "StunRatio": 1.082,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 177,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2706,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 98.3
+        }
+      ],
+      "DefensiveAssistCounterSurge": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpConductingBlow": [
+        {
+          "DamagePercentage": 4.071,
+          "DamagePercentageGrowth": 0.371,
+          "StunRatio": 3.562,
+          "StunRatioGrowth": 0.162,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11451,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 346.92
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Soldier11.json
+++ b/libs/zzz/stats/Data/Characters/Soldier11.json
@@ -31,5 +31,262 @@
     { "atk": 50, "crit_": 0.096 },
     { "atk": 50, "crit_": 0.144 },
     { "atk": 75, "crit_": 0.144 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackWarmupSparks": [
+        {
+          "DamagePercentage": 0.344,
+          "DamagePercentageGrowth": 0.032,
+          "StunRatio": 0.172,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 58.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 451,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.412,
+          "DamagePercentageGrowth": 0.038,
+          "StunRatio": 0.344,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 117.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 899.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.028,
+          "DamagePercentageGrowth": 0.094,
+          "StunRatio": 0.823,
+          "StunRatioGrowth": 0.038,
+          "SpRecovery": 282,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2156,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.134,
+          "DamagePercentageGrowth": 0.194,
+          "StunRatio": 1.676,
+          "StunRatioGrowth": 0.077,
+          "SpRecovery": 574.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4389,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackFireSuppression": [
+        {
+          "DamagePercentage": 0.551,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.18,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 61.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 470.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 17.05
+        },
+        {
+          "DamagePercentage": 0.572,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.336,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 114.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 880,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 31.91
+        },
+        {
+          "DamagePercentage": 1.32,
+          "DamagePercentageGrowth": 0.12,
+          "StunRatio": 0.752,
+          "StunRatioGrowth": 0.035,
+          "SpRecovery": 257.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1969,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 71.57
+        },
+        {
+          "DamagePercentage": 3.407,
+          "DamagePercentageGrowth": 0.31,
+          "StunRatio": 1.92,
+          "StunRatioGrowth": 0.088,
+          "SpRecovery": 658.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5029.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 182.8
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeTemperedFire": [],
+      "DashAttackBlazingFire": [
+        {
+          "DamagePercentage": 0.683,
+          "DamagePercentageGrowth": 0.063,
+          "StunRatio": 0.342,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 117.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 896.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DashAttackFireSuppression": [
+        {
+          "DamagePercentage": 0.788,
+          "DamagePercentageGrowth": 0.072,
+          "StunRatio": 0.788,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 270.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2065.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 75
+        }
+      ],
+      "DodgeCounterBackdraft": [
+        {
+          "DamagePercentage": 2.62,
+          "DamagePercentageGrowth": 0.239,
+          "StunRatio": 2.258,
+          "StunRatioGrowth": 0.103,
+          "SpRecovery": 414,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3162.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 114.99
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackRagingFire": [
+        {
+          "DamagePercentage": 0.526,
+          "DamagePercentageGrowth": 0.048,
+          "StunRatio": 0.526,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1377.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 50.01
+        }
+      ],
+      "EXSpecialAttackFerventFire": [
+        {
+          "DamagePercentage": 6.75,
+          "DamagePercentageGrowth": 0.614,
+          "StunRatio": 5.435,
+          "StunRatioGrowth": 0.248,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 21125.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 580.18
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackUpliftingFlame": [
+        {
+          "DamagePercentage": 6.325,
+          "DamagePercentageGrowth": 0.575,
+          "StunRatio": 2.136,
+          "StunRatioGrowth": 0.098,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 23881,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 402.86
+        }
+      ],
+      "UltimateBellowingFlame": [
+        {
+          "DamagePercentage": 21.03,
+          "DamagePercentageGrowth": 1.912,
+          "StunRatio": 2.85,
+          "StunRatioGrowth": 0.13,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 246.7
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistCoveringFire": [
+        {
+          "DamagePercentage": 1.208,
+          "DamagePercentageGrowth": 0.11,
+          "StunRatio": 1.208,
+          "StunRatioGrowth": 0.055,
+          "SpRecovery": 414,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3162.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 114.99
+        }
+      ],
+      "DefensiveAssistHoldTheLine": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.59,
+          "StunRatioGrowth": 0.118,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.273,
+          "StunRatioGrowth": 0.149,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.593,
+          "StunRatioGrowth": 0.073,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpReignition": [
+        {
+          "DamagePercentage": 3.837,
+          "DamagePercentageGrowth": 0.349,
+          "StunRatio": 3.355,
+          "StunRatioGrowth": 0.153,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 11313.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 342.42
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Soukaku.json
+++ b/libs/zzz/stats/Data/Characters/Soukaku.json
@@ -31,5 +31,308 @@
     { "atk": 50, "enerRegen": 24 },
     { "atk": 50, "enerRegen": 36 },
     { "atk": 75, "enerRegen": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackMakingRiceCakes": [
+        {
+          "DamagePercentage": 0.662,
+          "DamagePercentageGrowth": 0.061,
+          "StunRatio": 0.331,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 119.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 910.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.163,
+          "DamagePercentageGrowth": 0.197,
+          "StunRatio": 1.88,
+          "StunRatioGrowth": 0.086,
+          "SpRecovery": 676.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4441.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.931,
+          "DamagePercentageGrowth": 0.267,
+          "StunRatio": 2.217,
+          "StunRatioGrowth": 0.101,
+          "SpRecovery": 798,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5420.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "BasicAttackMakingRiceCakesFrostedBanner": [
+        {
+          "DamagePercentage": 0.766,
+          "DamagePercentageGrowth": 0.07,
+          "StunRatio": 0.466,
+          "StunRatioGrowth": 0.022,
+          "SpRecovery": 167.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1281.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 46.57
+        },
+        {
+          "DamagePercentage": 2.285,
+          "DamagePercentageGrowth": 0.208,
+          "StunRatio": 1.275,
+          "StunRatioGrowth": 0.058,
+          "SpRecovery": 458.8,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3506.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 127.43
+        },
+        {
+          "DamagePercentage": 5.114,
+          "DamagePercentageGrowth": 0.465,
+          "StunRatio": 2.633,
+          "StunRatioGrowth": 0.12,
+          "SpRecovery": 947.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7240.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 263.21
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeGrabABite": [],
+      "DashAttack5050": [
+        {
+          "DamagePercentage": 0.767,
+          "DamagePercentageGrowth": 0.07,
+          "StunRatio": 0.384,
+          "StunRatioGrowth": 0.018,
+          "SpRecovery": 138,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1056,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DashAttack5050FrostedBanner": [
+        {
+          "DamagePercentage": 1.315,
+          "DamagePercentageGrowth": 0.12,
+          "StunRatio": 0.801,
+          "StunRatioGrowth": 0.037,
+          "SpRecovery": 288.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2202.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 80.03
+        }
+      ],
+      "DodgeCounterAwayFromMySnacks": [
+        {
+          "DamagePercentage": 2.473,
+          "DamagePercentageGrowth": 0.225,
+          "StunRatio": 2.134,
+          "StunRatioGrowth": 0.097,
+          "SpRecovery": 407.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3118.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 113.3
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackCoolingBento": [
+        {
+          "DamagePercentage": 0.284,
+          "DamagePercentageGrowth": 0.026,
+          "StunRatio": 0.284,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 781,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 28.34
+        },
+        {
+          "DamagePercentage": 1.001,
+          "DamagePercentageGrowth": 0.091,
+          "StunRatio": 1.001,
+          "StunRatioGrowth": 0.046,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2752.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 50.01
+        }
+      ],
+      "EXSpecialAttackFanningMosquitoes": [
+        {
+          "DamagePercentage": 2.624,
+          "DamagePercentageGrowth": 0.239,
+          "StunRatio": 2.258,
+          "StunRatioGrowth": 0.103,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8222.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 244.07
+        },
+        {
+          "DamagePercentage": 1.021,
+          "DamagePercentageGrowth": 0.093,
+          "StunRatio": 0.879,
+          "StunRatioGrowth": 0.04,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3198.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 94.91
+        }
+      ],
+      "SpecialAttackRally": [
+        {
+          "DamagePercentage": 2.501,
+          "DamagePercentageGrowth": 0.228,
+          "StunRatio": 2.751,
+          "StunRatioGrowth": 0.126,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6877.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 125
+        },
+        {
+          "DamagePercentage": 1.401,
+          "DamagePercentageGrowth": 0.128,
+          "StunRatio": 1.401,
+          "StunRatioGrowth": 0.064,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3852.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 70.01
+        },
+        {
+          "DamagePercentage": 2.45,
+          "DamagePercentageGrowth": 0.223,
+          "StunRatio": 2.45,
+          "StunRatioGrowth": 0.112,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 6737.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 122.5
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackPuddingSlash": [
+        {
+          "DamagePercentage": 7.458,
+          "DamagePercentageGrowth": 0.678,
+          "StunRatio": 3.468,
+          "StunRatioGrowth": 0.158,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 27824.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 546.2
+        }
+      ],
+      "UltimateJumboPuddingSlash": [
+        {
+          "DamagePercentage": 19.898,
+          "DamagePercentageGrowth": 1.809,
+          "StunRatio": 3.768,
+          "StunRatioGrowth": 0.172,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 376.7
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistASetForTwo": [
+        {
+          "DamagePercentage": 1.134,
+          "DamagePercentageGrowth": 0.104,
+          "StunRatio": 1.134,
+          "StunRatioGrowth": 0.052,
+          "SpRecovery": 407.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3118.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 113.3
+        }
+      ],
+      "DefensiveAssistGuardingTactics": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.467,
+          "StunRatioGrowth": 0.113,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.117,
+          "StunRatioGrowth": 0.142,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.517,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpSweepingStrike": [
+        {
+          "DamagePercentage": 2.64,
+          "DamagePercentageGrowth": 0.24,
+          "StunRatio": 2.313,
+          "StunRatioGrowth": 0.106,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 8159.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 247.57
+        },
+        {
+          "DamagePercentage": 1.132,
+          "DamagePercentageGrowth": 0.103,
+          "StunRatio": 0.991,
+          "StunRatioGrowth": 0.046,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3498,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 106.1
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Trigger.json
+++ b/libs/zzz/stats/Data/Characters/Trigger.json
@@ -31,5 +31,275 @@
     { "atk": 50, "impact": 12 },
     { "atk": 50, "impact": 18 },
     { "atk": 75, "impact": 18 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackColdBoreShot": [
+        {
+          "DamagePercentage": 0.345,
+          "DamagePercentageGrowth": 0.032,
+          "StunRatio": 0.173,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 98.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 756.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.569,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.285,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 200.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1531.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.109,
+          "DamagePercentageGrowth": 0.101,
+          "StunRatio": 0.608,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 328.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2508,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 2.43,
+          "DamagePercentageGrowth": 0.221,
+          "StunRatio": 1.769,
+          "StunRatioGrowth": 0.081,
+          "SpRecovery": 697.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5329.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 174.41
+        }
+      ],
+      "BasicAttackSilencedShot": [
+        {
+          "DamagePercentage": 0.476,
+          "DamagePercentageGrowth": 0.044,
+          "StunRatio": 0.238,
+          "StunRatioGrowth": 0.011,
+          "SpRecovery": 136.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4160.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 108.03
+        },
+        {
+          "DamagePercentage": 2.339,
+          "DamagePercentageGrowth": 0.213,
+          "StunRatio": 1.488,
+          "StunRatioGrowth": 0.068,
+          "SpRecovery": 695.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 5315.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 193.22
+        },
+        {
+          "DamagePercentage": 1.312,
+          "DamagePercentageGrowth": 0.12,
+          "StunRatio": 0.656,
+          "StunRatioGrowth": 0.03,
+          "SpRecovery": 448.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3429.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 119.26
+        }
+      ],
+      "BasicAttackHarmonizingShot": [
+        {
+          "DamagePercentage": 0.479,
+          "DamagePercentageGrowth": 0.044,
+          "StunRatio": 0.359,
+          "StunRatioGrowth": 0.017,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 10.86
+        }
+      ],
+      "BasicAttackHarmonizingShotTartarus": [
+        {
+          "DamagePercentage": 0.226,
+          "DamagePercentageGrowth": 0.021,
+          "StunRatio": 0.17,
+          "StunRatioGrowth": 0.008,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 20.49
+        },
+        {
+          "DamagePercentage": 0.452,
+          "DamagePercentageGrowth": 0.042,
+          "StunRatio": 0.34,
+          "StunRatioGrowth": 0.016,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 40.98
+        }
+      ]
+    },
+    "dodge": {
+      "DodgePhantomConcealment": [],
+      "DashAttackVengefulSpecter": [
+        {
+          "DamagePercentage": 0.514,
+          "DamagePercentageGrowth": 0.047,
+          "StunRatio": 0.257,
+          "StunRatioGrowth": 0.012,
+          "SpRecovery": 84.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 643.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterCondemnedSoul": [
+        {
+          "DamagePercentage": 2.197,
+          "DamagePercentageGrowth": 0.2,
+          "StunRatio": 1.944,
+          "StunRatioGrowth": 0.089,
+          "SpRecovery": 276,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.66
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackSpectralFlash": [
+        {
+          "DamagePercentage": 0.715,
+          "DamagePercentageGrowth": 0.065,
+          "StunRatio": 0.715,
+          "StunRatioGrowth": 0.033,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1787.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 65
+        }
+      ],
+      "EXSpecialAttackFlashBurial": [
+        {
+          "DamagePercentage": 6.344,
+          "DamagePercentageGrowth": 0.577,
+          "StunRatio": 4.327,
+          "StunRatioGrowth": 0.197,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 21084.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 356.66
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackStygianGuide": [
+        {
+          "DamagePercentage": 5.747,
+          "DamagePercentageGrowth": 0.523,
+          "StunRatio": 1.358,
+          "StunRatioGrowth": 0.062,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 21681,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 322.86
+        }
+      ],
+      "UltimateUnderworldRequiem": [
+        {
+          "DamagePercentage": 14.805,
+          "DamagePercentageGrowth": 1.346,
+          "StunRatio": 9.22,
+          "StunRatioGrowth": 0.42,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.66
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistColdBoreCoverFire": [
+        {
+          "DamagePercentage": 0.844,
+          "DamagePercentageGrowth": 0.077,
+          "StunRatio": 0.844,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 276,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2109.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.66
+        }
+      ],
+      "DefensiveAssistDelayingDemise": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.713,
+          "StunRatioGrowth": 0.124,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.428,
+          "StunRatioGrowth": 0.156,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.668,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpPiercingThunder": [
+        {
+          "DamagePercentage": 4.329,
+          "DamagePercentageGrowth": 0.394,
+          "StunRatio": 3.274,
+          "StunRatioGrowth": 0.149,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2774.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 369.51
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/Yanagi.json
+++ b/libs/zzz/stats/Data/Characters/Yanagi.json
@@ -31,5 +31,283 @@
     { "atk": 50, "anomMas": 24 },
     { "atk": 50, "anomMas": 36 },
     { "atk": 75, "anomMas": 36 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackTsukuyomiKagura": [],
+      "StanceJougen": [
+        {
+          "DamagePercentage": 0.566,
+          "DamagePercentageGrowth": 0.052,
+          "StunRatio": 0.278,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 100.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 695.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.997,
+          "DamagePercentageGrowth": 0.091,
+          "StunRatio": 0.681,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 247.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1702.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.131,
+          "DamagePercentageGrowth": 0.103,
+          "StunRatio": 0.694,
+          "StunRatioGrowth": 0.032,
+          "SpRecovery": 252.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1735.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 79.91
+        },
+        {
+          "DamagePercentage": 1.266,
+          "DamagePercentageGrowth": 0.116,
+          "StunRatio": 0.776,
+          "StunRatioGrowth": 0.036,
+          "SpRecovery": 282.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1941.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 89.42
+        },
+        {
+          "DamagePercentage": 2.369,
+          "DamagePercentageGrowth": 0.216,
+          "StunRatio": 1.452,
+          "StunRatioGrowth": 0.066,
+          "SpRecovery": 528,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3630,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 167.35
+        }
+      ],
+      "StanceKagen": [
+        {
+          "DamagePercentage": 1.131,
+          "DamagePercentageGrowth": 0.103,
+          "StunRatio": 0.555,
+          "StunRatioGrowth": 0.026,
+          "SpRecovery": 201.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1388.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.292,
+          "DamagePercentageGrowth": 0.118,
+          "StunRatio": 0.931,
+          "StunRatioGrowth": 0.043,
+          "SpRecovery": 338.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2329.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.728,
+          "DamagePercentageGrowth": 0.067,
+          "StunRatio": 0.446,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 162.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1116.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 51.38
+        },
+        {
+          "DamagePercentage": 1.077,
+          "DamagePercentageGrowth": 0.098,
+          "StunRatio": 0.661,
+          "StunRatioGrowth": 0.031,
+          "SpRecovery": 240.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1652.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.07
+        },
+        {
+          "DamagePercentage": 2.718,
+          "DamagePercentageGrowth": 0.248,
+          "StunRatio": 1.667,
+          "StunRatioGrowth": 0.076,
+          "SpRecovery": 605.9,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4166.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 192.04
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeWanderingBreeze": [],
+      "DashAttackFleetingFlight": [
+        {
+          "DamagePercentage": 0.504,
+          "DamagePercentageGrowth": 0.046,
+          "StunRatio": 0.454,
+          "StunRatioGrowth": 0.021,
+          "SpRecovery": 165,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1135.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "DodgeCounterRapidRetaliation": [
+        {
+          "DamagePercentage": 2.316,
+          "DamagePercentageGrowth": 0.211,
+          "StunRatio": 1.832,
+          "StunRatioGrowth": 0.084,
+          "SpRecovery": 306.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2106.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.52
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackRuten": [
+        {
+          "DamagePercentage": 1.174,
+          "DamagePercentageGrowth": 0.107,
+          "StunRatio": 1.057,
+          "StunRatioGrowth": 0.049,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2642.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 96
+        }
+      ],
+      "EXSpecialAttackGekkaRuten": [
+        {
+          "DamagePercentage": 1.638,
+          "DamagePercentageGrowth": 0.149,
+          "StunRatio": 1.271,
+          "StunRatioGrowth": 0.058,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 4193.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 143.5
+        },
+        {
+          "DamagePercentage": 3.778,
+          "DamagePercentageGrowth": 0.344,
+          "StunRatio": 1.096,
+          "StunRatioGrowth": 0.05,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 7634,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 268.54
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackCelestialHarmony": [
+        {
+          "DamagePercentage": 5.931,
+          "DamagePercentageGrowth": 0.54,
+          "StunRatio": 1.783,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 21411.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 359.58
+        }
+      ],
+      "UltimateRaieiTenge": [
+        {
+          "DamagePercentage": 15.118,
+          "DamagePercentageGrowth": 1.375,
+          "StunRatio": 0.975,
+          "StunRatioGrowth": 0.045,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 904.39
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistBladeOfElegance": [
+        {
+          "DamagePercentage": 0.936,
+          "DamagePercentageGrowth": 0.086,
+          "StunRatio": 0.842,
+          "StunRatioGrowth": 0.039,
+          "SpRecovery": 306.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2106.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 76.52
+        }
+      ],
+      "DefensiveAssistRadiantReversal": [
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 2.442,
+          "StunRatioGrowth": 0.111,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 3.086,
+          "StunRatioGrowth": 0.141,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0,
+          "DamagePercentageGrowth": 0,
+          "StunRatio": 1.502,
+          "StunRatioGrowth": 0.069,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        }
+      ],
+      "AssistFollowUpWeepingWillowStab": [
+        {
+          "DamagePercentage": 4.071,
+          "DamagePercentageGrowth": 0.371,
+          "StunRatio": 3.206,
+          "StunRatioGrowth": 0.146,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10307,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 312.23
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/Data/Characters/ZhuYuan.json
+++ b/libs/zzz/stats/Data/Characters/ZhuYuan.json
@@ -31,5 +31,272 @@
     { "atk": 50, "crit_dmg_": 0.192 },
     { "atk": 50, "crit_dmg_": 0.288 },
     { "atk": 75, "crit_dmg_": 0.288 }
-  ]
+  ],
+  "skillParams": {
+    "basic": {
+      "BasicAttackDontMove": [
+        {
+          "DamagePercentage": 0.431,
+          "DamagePercentageGrowth": 0.04,
+          "StunRatio": 0.216,
+          "StunRatioGrowth": 0.01,
+          "SpRecovery": 70.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 539,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.264,
+          "DamagePercentageGrowth": 0.115,
+          "StunRatio": 0.973,
+          "StunRatioGrowth": 0.045,
+          "SpRecovery": 318.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2431,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 104.77
+        },
+        {
+          "DamagePercentage": 1.373,
+          "DamagePercentageGrowth": 0.125,
+          "StunRatio": 0.947,
+          "StunRatioGrowth": 0.044,
+          "SpRecovery": 309.7,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 2367.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.51,
+          "DamagePercentageGrowth": 0.138,
+          "StunRatio": 1.243,
+          "StunRatioGrowth": 0.057,
+          "SpRecovery": 406.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3107.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 59.12
+        },
+        {
+          "DamagePercentage": 1.622,
+          "DamagePercentageGrowth": 0.148,
+          "StunRatio": 1.392,
+          "StunRatioGrowth": 0.064,
+          "SpRecovery": 455.4,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3478.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 60.05
+        }
+      ],
+      "BasicAttackPleaseDoNotResist": [
+        {
+          "DamagePercentage": 0.537,
+          "DamagePercentageGrowth": 0.049,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 99.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 759,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 0.537,
+          "DamagePercentageGrowth": 0.049,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 183.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1402.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.609,
+          "DamagePercentageGrowth": 0.147,
+          "StunRatio": 1.787,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 490.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3748.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.359,
+          "DamagePercentageGrowth": 0.124,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 99.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 759,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 54.15
+        },
+        {
+          "DamagePercentage": 1.359,
+          "DamagePercentageGrowth": 0.124,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 183.5,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1402.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 54.15
+        },
+        {
+          "DamagePercentage": 4.077,
+          "DamagePercentageGrowth": 0.371,
+          "StunRatio": 1.787,
+          "StunRatioGrowth": 0.082,
+          "SpRecovery": 490.6,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 3748.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 162.45
+        }
+      ]
+    },
+    "dodge": {
+      "DodgeTacticalDetour": [],
+      "DashAttackFirepowerOffensive": [
+        {
+          "DamagePercentage": 0.551,
+          "DamagePercentageGrowth": 0.051,
+          "StunRatio": 0.276,
+          "StunRatioGrowth": 0.013,
+          "SpRecovery": 90.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 690.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 50
+        }
+      ],
+      "DashAttackOverwhelmingFirepower": [
+        {
+          "DamagePercentage": 0.537,
+          "DamagePercentageGrowth": 0.049,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 117.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 896.5,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 0
+        },
+        {
+          "DamagePercentage": 1.359,
+          "DamagePercentageGrowth": 0.124,
+          "StunRatio": 0.596,
+          "StunRatioGrowth": 0.028,
+          "SpRecovery": 234.1,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1790.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 54.15
+        }
+      ],
+      "DodgeCounterFireBlast": [
+        {
+          "DamagePercentage": 1.768,
+          "DamagePercentageGrowth": 0.161,
+          "StunRatio": 1.614,
+          "StunRatioGrowth": 0.074,
+          "SpRecovery": 168.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1287,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 46.7
+        }
+      ]
+    },
+    "special": {
+      "SpecialAttackBuckshotBlast": [
+        {
+          "DamagePercentage": 0.184,
+          "DamagePercentageGrowth": 0.017,
+          "StunRatio": 0.184,
+          "StunRatioGrowth": 0.009,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 459.25,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 16.65
+        }
+      ],
+      "EXSpecialAttackFullBarrage": [
+        {
+          "DamagePercentage": 5.874,
+          "DamagePercentageGrowth": 0.534,
+          "StunRatio": 4.8,
+          "StunRatioGrowth": 0.219,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 17371.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 485.12
+        }
+      ]
+    },
+    "chain": {
+      "ChainAttackEradicationMode": [
+        {
+          "DamagePercentage": 5.875,
+          "DamagePercentageGrowth": 0.535,
+          "StunRatio": 1.486,
+          "StunRatioGrowth": 0.068,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 22002.75,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 334.5
+        }
+      ],
+      "UltimateMaxEradicationMode": [
+        {
+          "DamagePercentage": 19.776,
+          "DamagePercentageGrowth": 1.798,
+          "StunRatio": 1.251,
+          "StunRatioGrowth": 0.0627,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 0,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 103.33
+        }
+      ]
+    },
+    "assist": {
+      "QuickAssistCoveringShot": [
+        {
+          "DamagePercentage": 0.514,
+          "DamagePercentageGrowth": 0.047,
+          "StunRatio": 0.514,
+          "StunRatioGrowth": 0.024,
+          "SpRecovery": 168.2,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 1287,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 46.7
+        }
+      ],
+      "EvasiveAssistGuardedBackup": [],
+      "AssistFollowUpDefensiveCounter": [
+        {
+          "DamagePercentage": 3.558,
+          "DamagePercentageGrowth": 0.324,
+          "StunRatio": 3.086,
+          "StunRatioGrowth": 0.141,
+          "SpRecovery": 0,
+          "SpRecoveryGrowth": 0,
+          "FeverRecovery": 10076,
+          "FeverRecoveryGrowth": 0,
+          "AttributeInfliction": 301.97
+        }
+      ]
+    }
+  }
 }

--- a/libs/zzz/stats/src/allStat_gen.json
+++ b/libs/zzz/stats/src/allStat_gen.json
@@ -95,7 +95,218 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackTurboVolt": [
+            {
+              "DamagePercentage": 0.312,
+              "DamagePercentageGrowth": 0.029,
+              "StunRatio": 0.156,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 56.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 429,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.337,
+              "DamagePercentageGrowth": 0.031,
+              "StunRatio": 0.287,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 103.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 789.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.136,
+              "DamagePercentageGrowth": 0.104,
+              "StunRatio": 0.896,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 322.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2464,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.391,
+              "DamagePercentageGrowth": 0.218,
+              "StunRatio": 1.874,
+              "StunRatioGrowth": 0.086,
+              "SpRecovery": 674.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5153.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 172.47
+            }
+          ],
+          "BasicAttackThunderbolt": [
+            {
+              "DamagePercentage": 3.286,
+              "DamagePercentageGrowth": 0.299,
+              "StunRatio": 1.424,
+              "StunRatioGrowth": 0.065,
+              "SpRecovery": 512.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3916,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 127.5
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeSlide": [],
+          "DashAttackTaserBlast": [
+            {
+              "DamagePercentage": 0.567,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.284,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 102,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 781,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterThunderclap": [
+            {
+              "DamagePercentage": 1.802,
+              "DamagePercentageGrowth": 0.164,
+              "StunRatio": 1.617,
+              "StunRatioGrowth": 0.074,
+              "SpRecovery": 221.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1696.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 61.63
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackForkLightning": [
+            {
+              "DamagePercentage": 0.934,
+              "DamagePercentageGrowth": 0.085,
+              "StunRatio": 0.934,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2568.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 93.3
+            }
+          ],
+          "EXSpecialAttackLightningBolt": [
+            {
+              "DamagePercentage": 5.83,
+              "DamagePercentageGrowth": 0.53,
+              "StunRatio": 4.818,
+              "StunRatioGrowth": 0.219,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 18815.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 532.37
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackElectroEngine": [
+            {
+              "DamagePercentage": 5.424,
+              "DamagePercentageGrowth": 0.494,
+              "StunRatio": 1.434,
+              "StunRatioGrowth": 0.066,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22231,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 342.83
+            }
+          ],
+          "UltimateOverdriveEngine": [
+            {
+              "DamagePercentage": 15.126,
+              "DamagePercentageGrowth": 1.376,
+              "StunRatio": 9.916,
+              "StunRatioGrowth": 0.451,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 210.03
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistThunderfall": [
+            {
+              "DamagePercentage": 0.617,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.617,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 221.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1696.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 61.63
+            }
+          ],
+          "DefensiveAssistFlash": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpLightningWhirl": [
+            {
+              "DamagePercentage": 3.352,
+              "DamagePercentageGrowth": 0.305,
+              "StunRatio": 2.914,
+              "StunRatioGrowth": 0.133,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10419.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 313.22
+            }
+          ]
+        }
+      }
     },
     "Nekomata": {
       "id": "1021",
@@ -172,7 +383,229 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackKittySlash": [
+            {
+              "DamagePercentage": 0.552,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.18,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 61.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 470.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.08
+            },
+            {
+              "DamagePercentage": 0.626,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.371,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 126.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 970.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 35.24
+            },
+            {
+              "DamagePercentage": 0.727,
+              "DamagePercentageGrowth": 0.067,
+              "StunRatio": 0.467,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 159.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1223.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 44.4
+            },
+            {
+              "DamagePercentage": 1.702,
+              "DamagePercentageGrowth": 0.155,
+              "StunRatio": 1.037,
+              "StunRatioGrowth": 0.048,
+              "SpRecovery": 355.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2717,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 98.73
+            },
+            {
+              "DamagePercentage": 1.236,
+              "DamagePercentageGrowth": 0.113,
+              "StunRatio": 0.589,
+              "StunRatioGrowth": 0.027,
+              "SpRecovery": 201.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1542.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.02
+            }
+          ],
+          "BasicAttackCrimsonBlade": [
+            {
+              "DamagePercentage": 0.718,
+              "DamagePercentageGrowth": 0.066,
+              "StunRatio": 0.589,
+              "StunRatioGrowth": 0.027,
+              "SpRecovery": 201.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1542.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.02
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeCantTouchMeow": [],
+          "DashAttackOverHere": [
+            {
+              "DamagePercentage": 0.351,
+              "DamagePercentageGrowth": 0.032,
+              "StunRatio": 0.176,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 60.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1606,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 16.68
+            }
+          ],
+          "DodgeCounterPhantomClaws": [
+            {
+              "DamagePercentage": 2.279,
+              "DamagePercentageGrowth": 0.208,
+              "StunRatio": 1.995,
+              "StunRatioGrowth": 0.091,
+              "SpRecovery": 323.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2475,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 89.96
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSurpriseAttack": [
+            {
+              "DamagePercentage": 0.473,
+              "DamagePercentageGrowth": 0.043,
+              "StunRatio": 0.473,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1240.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 45.01
+            }
+          ],
+          "EXSpecialAttackSuperSurpriseAttack": [
+            {
+              "DamagePercentage": 5.397,
+              "DamagePercentageGrowth": 0.491,
+              "StunRatio": 4.554,
+              "StunRatioGrowth": 0.207,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 14861,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 430.73
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackClawSwipe": [
+            {
+              "DamagePercentage": 5.362,
+              "DamagePercentageGrowth": 0.488,
+              "StunRatio": 1.592,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22918.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 367.86
+            }
+          ],
+          "UltimateClawSmash": [
+            {
+              "DamagePercentage": 15.711,
+              "DamagePercentageGrowth": 1.429,
+              "StunRatio": 1.181,
+              "StunRatioGrowth": 0.054,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 124.96
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistCatsPaw": [
+            {
+              "DamagePercentage": 0.945,
+              "DamagePercentageGrowth": 0.086,
+              "StunRatio": 0.945,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 323.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2475,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 89.96
+            }
+          ],
+          "DefensiveAssistDesperateDefense": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.59,
+              "StunRatioGrowth": 0.118,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.273,
+              "StunRatioGrowth": 0.149,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.593,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpShadowStrike": [
+            {
+              "DamagePercentage": 3.004,
+              "DamagePercentageGrowth": 0.274,
+              "StunRatio": 2.581,
+              "StunRatioGrowth": 0.118,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8976,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 265.92
+            }
+          ]
+        }
+      }
     },
     "Nicole": {
       "id": "1031",
@@ -249,7 +682,396 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackCunningCombo": [
+            {
+              "DamagePercentage": 0.389,
+              "DamagePercentageGrowth": 0.036,
+              "StunRatio": 0.195,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 70,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 536.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.271,
+              "DamagePercentageGrowth": 0.025,
+              "StunRatio": 0.209,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 70,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 536.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.353,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.29,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 104.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 797.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.361,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.278,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 104.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 797.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.243,
+              "DamagePercentageGrowth": 0.113,
+              "StunRatio": 1.043,
+              "StunRatioGrowth": 0.048,
+              "SpRecovery": 375.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2868.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.804,
+              "DamagePercentageGrowth": 0.164,
+              "StunRatio": 1.388,
+              "StunRatioGrowth": 0.064,
+              "SpRecovery": 375.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2868.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackDoAsIPlease": [
+            {
+              "DamagePercentage": 0.494,
+              "DamagePercentageGrowth": 0.045,
+              "StunRatio": 0.209,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 70,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 536.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.658,
+              "DamagePercentageGrowth": 0.06,
+              "StunRatio": 0.278,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 104.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 797.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 3.29,
+              "DamagePercentageGrowth": 0.3,
+              "StunRatio": 1.388,
+              "StunRatioGrowth": 0.064,
+              "SpRecovery": 375.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2868.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeSpeedDemon": [],
+          "DashAttackJackInTheBox": [
+            {
+              "DamagePercentage": 0.412,
+              "DamagePercentageGrowth": 0.038,
+              "StunRatio": 0.29,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 102,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 781,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.173,
+              "DamagePercentageGrowth": 0.107,
+              "StunRatio": 0.451,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 102,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 781,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.6,
+              "DamagePercentageGrowth": 0.055,
+              "StunRatio": 0.6,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 215.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 825,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterDivertedBombard": [
+            {
+              "DamagePercentage": 0.912,
+              "DamagePercentageGrowth": 0.083,
+              "StunRatio": 0.817,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 227.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 871.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.64
+            },
+            {
+              "DamagePercentage": 0.912,
+              "DamagePercentageGrowth": 0.083,
+              "StunRatio": 0.817,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 191.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 871.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.64
+            }
+          ],
+          "DashAttackDoAsIPlease": [
+            {
+              "DamagePercentage": 1.173,
+              "DamagePercentageGrowth": 0.107,
+              "StunRatio": 0.451,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 102,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 781,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 121.29
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSugarcoatedBullet": [
+            {
+              "DamagePercentage": 0.263,
+              "DamagePercentageGrowth": 0.024,
+              "StunRatio": 0.25,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 723.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 26.24
+            },
+            {
+              "DamagePercentage": 0.263,
+              "DamagePercentageGrowth": 0.024,
+              "StunRatio": 0.25,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 723.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 26.24
+            }
+          ],
+          "EXSpecialAttackStuffedSugarcoatedBullet": [
+            {
+              "DamagePercentage": 2.15,
+              "DamagePercentageGrowth": 0.196,
+              "StunRatio": 1.798,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6880.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 197.35
+            },
+            {
+              "DamagePercentage": 1.075,
+              "DamagePercentageGrowth": 0.098,
+              "StunRatio": 0.899,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3440.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 98.67
+            },
+            {
+              "DamagePercentage": 1.075,
+              "DamagePercentageGrowth": 0.098,
+              "StunRatio": 0.899,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3440.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 98.67
+            },
+            {
+              "DamagePercentage": 3.87,
+              "DamagePercentageGrowth": 0.352,
+              "StunRatio": 3.236,
+              "StunRatioGrowth": 0.148,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 13761,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 394.71
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackEtherShellacking": [
+            {
+              "DamagePercentage": 1.048,
+              "DamagePercentageGrowth": 0.096,
+              "StunRatio": 0.25,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4345,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.89
+            },
+            {
+              "DamagePercentage": 1.048,
+              "DamagePercentageGrowth": 0.096,
+              "StunRatio": 0.25,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4345,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.89
+            },
+            {
+              "DamagePercentage": 2.83,
+              "DamagePercentageGrowth": 0.258,
+              "StunRatio": 0.675,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 13035,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 194.69
+            }
+          ],
+          "UltimateEtherGrenade": [
+            {
+              "DamagePercentage": 6.468,
+              "DamagePercentageGrowth": 0.588,
+              "StunRatio": 0.36,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 35.99
+            },
+            {
+              "DamagePercentage": 8.732,
+              "DamagePercentageGrowth": 0.794,
+              "StunRatio": 0.486,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 53.99
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistEmergencyBombard": [
+            {
+              "DamagePercentage": 0.317,
+              "DamagePercentageGrowth": 0.029,
+              "StunRatio": 0.317,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 114,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 871.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.64
+            },
+            {
+              "DamagePercentage": 0.317,
+              "DamagePercentageGrowth": 0.029,
+              "StunRatio": 0.317,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 114,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 871.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.64
+            }
+          ],
+          "DefensiveAssistTheHareStrikesBack": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpWindowOfOpportunity": [
+            {
+              "DamagePercentage": 3.771,
+              "DamagePercentageGrowth": 0.343,
+              "StunRatio": 3.303,
+              "StunRatioGrowth": 0.151,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11657.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 353.67
+            }
+          ]
+        }
+      }
     },
     "Soldier11": {
       "id": "1041",
@@ -326,7 +1148,264 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackWarmupSparks": [
+            {
+              "DamagePercentage": 0.344,
+              "DamagePercentageGrowth": 0.032,
+              "StunRatio": 0.172,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 58.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 451,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.412,
+              "DamagePercentageGrowth": 0.038,
+              "StunRatio": 0.344,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 117.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 899.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.028,
+              "DamagePercentageGrowth": 0.094,
+              "StunRatio": 0.823,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 282,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2156,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.134,
+              "DamagePercentageGrowth": 0.194,
+              "StunRatio": 1.676,
+              "StunRatioGrowth": 0.077,
+              "SpRecovery": 574.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4389,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackFireSuppression": [
+            {
+              "DamagePercentage": 0.551,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.18,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 61.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 470.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.05
+            },
+            {
+              "DamagePercentage": 0.572,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.336,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 114.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 880,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.91
+            },
+            {
+              "DamagePercentage": 1.32,
+              "DamagePercentageGrowth": 0.12,
+              "StunRatio": 0.752,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 257.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1969,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 71.57
+            },
+            {
+              "DamagePercentage": 3.407,
+              "DamagePercentageGrowth": 0.31,
+              "StunRatio": 1.92,
+              "StunRatioGrowth": 0.088,
+              "SpRecovery": 658.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5029.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 182.8
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeTemperedFire": [],
+          "DashAttackBlazingFire": [
+            {
+              "DamagePercentage": 0.683,
+              "DamagePercentageGrowth": 0.063,
+              "StunRatio": 0.342,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 117.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 896.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DashAttackFireSuppression": [
+            {
+              "DamagePercentage": 0.788,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.788,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 270.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2065.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 75
+            }
+          ],
+          "DodgeCounterBackdraft": [
+            {
+              "DamagePercentage": 2.62,
+              "DamagePercentageGrowth": 0.239,
+              "StunRatio": 2.258,
+              "StunRatioGrowth": 0.103,
+              "SpRecovery": 414,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3162.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 114.99
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackRagingFire": [
+            {
+              "DamagePercentage": 0.526,
+              "DamagePercentageGrowth": 0.048,
+              "StunRatio": 0.526,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1377.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 50.01
+            }
+          ],
+          "EXSpecialAttackFerventFire": [
+            {
+              "DamagePercentage": 6.75,
+              "DamagePercentageGrowth": 0.614,
+              "StunRatio": 5.435,
+              "StunRatioGrowth": 0.248,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 21125.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 580.18
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackUpliftingFlame": [
+            {
+              "DamagePercentage": 6.325,
+              "DamagePercentageGrowth": 0.575,
+              "StunRatio": 2.136,
+              "StunRatioGrowth": 0.098,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 23881,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 402.86
+            }
+          ],
+          "UltimateBellowingFlame": [
+            {
+              "DamagePercentage": 21.03,
+              "DamagePercentageGrowth": 1.912,
+              "StunRatio": 2.85,
+              "StunRatioGrowth": 0.13,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 246.7
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistCoveringFire": [
+            {
+              "DamagePercentage": 1.208,
+              "DamagePercentageGrowth": 0.11,
+              "StunRatio": 1.208,
+              "StunRatioGrowth": 0.055,
+              "SpRecovery": 414,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3162.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 114.99
+            }
+          ],
+          "DefensiveAssistHoldTheLine": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.59,
+              "StunRatioGrowth": 0.118,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.273,
+              "StunRatioGrowth": 0.149,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.593,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpReignition": [
+            {
+              "DamagePercentage": 3.837,
+              "DamagePercentageGrowth": 0.349,
+              "StunRatio": 3.355,
+              "StunRatioGrowth": 0.153,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11313.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 342.42
+            }
+          ]
+        }
+      }
     },
     "Corin": {
       "id": "1061",
@@ -403,7 +1482,282 @@
           "atk": 75,
           "crit_dmg_": 0.288
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackWipeout": [
+            {
+              "DamagePercentage": 0.82,
+              "DamagePercentageGrowth": 0.075,
+              "StunRatio": 0.41,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 147.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1127.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 40.99
+            },
+            {
+              "DamagePercentage": 0.766,
+              "DamagePercentageGrowth": 0.07,
+              "StunRatio": 0.702,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 252.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1930.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 70.16
+            },
+            {
+              "DamagePercentage": 1.792,
+              "DamagePercentageGrowth": 0.163,
+              "StunRatio": 1.238,
+              "StunRatioGrowth": 0.057,
+              "SpRecovery": 445.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3404.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 123.76
+            },
+            {
+              "DamagePercentage": 2.334,
+              "DamagePercentageGrowth": 0.213,
+              "StunRatio": 1.864,
+              "StunRatioGrowth": 0.085,
+              "SpRecovery": 670.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5126,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 186.33
+            },
+            {
+              "DamagePercentage": 4.212,
+              "DamagePercentageGrowth": 0.383,
+              "StunRatio": 3.42,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 1231,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9405,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 341.94
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeShoo": [],
+          "DashAttackOopsyDaisy": [
+            {
+              "DamagePercentage": 0.967,
+              "DamagePercentageGrowth": 0.088,
+              "StunRatio": 0.484,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 174.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1331,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 48.34
+            }
+          ],
+          "DodgeCounterNope": [
+            {
+              "DamagePercentage": 1.356,
+              "DamagePercentageGrowth": 0.124,
+              "StunRatio": 0.659,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 237,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1812.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 65.81
+            },
+            {
+              "DamagePercentage": 1.356,
+              "DamagePercentageGrowth": 0.124,
+              "StunRatio": 0.659,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 237,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1812.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 65.81
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackCleanSweep": [
+            {
+              "DamagePercentage": 0.667,
+              "DamagePercentageGrowth": 0.061,
+              "StunRatio": 0.667,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1834.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 66.68
+            },
+            {
+              "DamagePercentage": 0.375,
+              "DamagePercentageGrowth": 0.035,
+              "StunRatio": 0.375,
+              "StunRatioGrowth": 0.018,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1031.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 37.5
+            },
+            {
+              "DamagePercentage": 0.25,
+              "DamagePercentageGrowth": 0.023,
+              "StunRatio": 0.25,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 687.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 24.99
+            }
+          ],
+          "EXSpecialAttackSkirtAlert": [
+            {
+              "DamagePercentage": 3.451,
+              "DamagePercentageGrowth": 0.314,
+              "StunRatio": 2.064,
+              "StunRatioGrowth": 0.094,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6894.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 203.33
+            },
+            {
+              "DamagePercentage": 10.352,
+              "DamagePercentageGrowth": 0.942,
+              "StunRatio": 6.19,
+              "StunRatioGrowth": 0.282,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 20677.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 610.01
+            },
+            {
+              "DamagePercentage": 3.451,
+              "DamagePercentageGrowth": 0.314,
+              "StunRatio": 2.064,
+              "StunRatioGrowth": 0.094,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6894.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 203.33
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackSorry": [
+            {
+              "DamagePercentage": 6.873,
+              "DamagePercentageGrowth": 0.625,
+              "StunRatio": 2.883,
+              "StunRatioGrowth": 0.132,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 26215.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 487.79
+            }
+          ],
+          "UltimateVeryVerySorry": [
+            {
+              "DamagePercentage": 20.288,
+              "DamagePercentageGrowth": 1.845,
+              "StunRatio": 4.068,
+              "StunRatioGrowth": 0.185,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 406.7
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistEmergencyMeasures": [
+            {
+              "DamagePercentage": 1.317,
+              "DamagePercentageGrowth": 0.12,
+              "StunRatio": 1.317,
+              "StunRatioGrowth": 0.06,
+              "SpRecovery": 473.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3621.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 131.63
+            },
+            {
+              "DamagePercentage": 0.833,
+              "DamagePercentageGrowth": 0.076,
+              "StunRatio": 0.833,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 299.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2290.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 83.29
+            }
+          ],
+          "DefensiveAssistPPleaseAllowMe": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpQuickSweep": [
+            {
+              "DamagePercentage": 5.475,
+              "DamagePercentageGrowth": 0.498,
+              "StunRatio": 4.886,
+              "StunRatioGrowth": 0.223,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16678.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 518.01
+            }
+          ]
+        }
+      }
     },
     "Caesar": {
       "id": "1071",
@@ -480,7 +1834,311 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackRampagingSlash": [
+            {
+              "DamagePercentage": 0.472,
+              "DamagePercentageGrowth": 0.043,
+              "StunRatio": 0.213,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 77.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 591.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 21.42
+            },
+            {
+              "DamagePercentage": 0.409,
+              "DamagePercentageGrowth": 0.038,
+              "StunRatio": 0.338,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 122.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 937.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 34.09
+            },
+            {
+              "DamagePercentage": 1.483,
+              "DamagePercentageGrowth": 0.135,
+              "StunRatio": 1.1,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 399.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3055.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 111.04
+            },
+            {
+              "DamagePercentage": 1.184,
+              "DamagePercentageGrowth": 0.108,
+              "StunRatio": 0.736,
+              "StunRatioGrowth": 0.034,
+              "SpRecovery": 267.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2046,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 74.32
+            },
+            {
+              "DamagePercentage": 0.788,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.675,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 245.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1875.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 68.12
+            },
+            {
+              "DamagePercentage": 1.986,
+              "DamagePercentageGrowth": 0.181,
+              "StunRatio": 1.375,
+              "StunRatioGrowth": 0.063,
+              "SpRecovery": 499.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3817,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 138.79
+            },
+            {
+              "DamagePercentage": 3.999,
+              "DamagePercentageGrowth": 0.364,
+              "StunRatio": 2.626,
+              "StunRatioGrowth": 0.12,
+              "SpRecovery": 954.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7295.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 265.24
+            }
+          ],
+          "BasicAttackDeadEnd": [
+            {
+              "DamagePercentage": 1.263,
+              "DamagePercentageGrowth": 0.115,
+              "StunRatio": 0.932,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 338.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2590.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 94.1
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeAdrift": [],
+          "DashAttackHogRush": [
+            {
+              "DamagePercentage": 0.623,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.312,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 102,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2728,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 28.31
+            }
+          ],
+          "DodgeCounterEyeForAnEye": [
+            {
+              "DamagePercentage": 1.935,
+              "DamagePercentageGrowth": 0.176,
+              "StunRatio": 1.742,
+              "StunRatioGrowth": 0.08,
+              "SpRecovery": 210.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1606,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 58.33
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackShockwaveShieldBash": [
+            {
+              "DamagePercentage": 0.533,
+              "DamagePercentageGrowth": 0.049,
+              "StunRatio": 0.24,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 665.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 24.18
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 0.77,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1102.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 40
+            }
+          ],
+          "SpecialAttackRoaringThrust": [
+            {
+              "DamagePercentage": 0.588,
+              "DamagePercentageGrowth": 0.054,
+              "StunRatio": 0.265,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 734.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 26.68
+            }
+          ],
+          "EXSpecialAttackParryCounter": [
+            {
+              "DamagePercentage": 3.872,
+              "DamagePercentageGrowth": 0.352,
+              "StunRatio": 2.526,
+              "StunRatioGrowth": 0.115,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8461.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 249.11
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.54,
+              "StunRatioGrowth": 0.07,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2750,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 100
+            },
+            {
+              "DamagePercentage": 3.872,
+              "DamagePercentageGrowth": 0.352,
+              "StunRatio": 2.526,
+              "StunRatioGrowth": 0.115,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8461.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 249.11
+            }
+          ],
+          "EXSpecialAttackOverpoweredShieldBash": [
+            {
+              "DamagePercentage": 4.257,
+              "DamagePercentageGrowth": 0.387,
+              "StunRatio": 2.884,
+              "StunRatioGrowth": 0.132,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9493,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 282.87
+            }
+          ],
+          "StanceSwitch": []
+        },
+        "chain": {
+          "ChainAttackRoadRageSlam": [
+            {
+              "DamagePercentage": 6.388,
+              "DamagePercentageGrowth": 0.581,
+              "StunRatio": 1.999,
+              "StunRatioGrowth": 0.091,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 23284.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 381.16
+            }
+          ],
+          "UltimateSavageSmash": [
+            {
+              "DamagePercentage": 20.123,
+              "DamagePercentageGrowth": 1.83,
+              "StunRatio": 2.787,
+              "StunRatioGrowth": 0.127,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 253.29
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistLaneChange": [
+            {
+              "DamagePercentage": 0.642,
+              "DamagePercentageGrowth": 0.059,
+              "StunRatio": 0.642,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 210.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1606,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 58.33
+            }
+          ],
+          "DefensiveAssistAegisShield": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.453,
+              "StunRatioGrowth": 0.157,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.693,
+              "StunRatioGrowth": 0.077,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpAidingBlade": [
+            {
+              "DamagePercentage": 4.072,
+              "DamagePercentageGrowth": 0.371,
+              "StunRatio": 3.563,
+              "StunRatioGrowth": 0.162,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11451,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 346.97
+            }
+          ]
+        }
+      }
     },
     "Billy": {
       "id": "1081",
@@ -557,7 +2215,215 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackFullFirepower": [
+            {
+              "DamagePercentage": 0.68,
+              "DamagePercentageGrowth": 0.062,
+              "StunRatio": 0.544,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 163.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 998.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 54.39
+            },
+            {
+              "DamagePercentage": 0.076,
+              "DamagePercentageGrowth": 0.007,
+              "StunRatio": 0.061,
+              "StunRatioGrowth": 0.003,
+              "SpRecovery": 54.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 332.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 6.04
+            },
+            {
+              "DamagePercentage": 0.618,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.547,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 196.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1504.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 29.03
+            },
+            {
+              "DamagePercentage": 0.127,
+              "DamagePercentageGrowth": 0.012,
+              "StunRatio": 0.089,
+              "StunRatioGrowth": 0.005,
+              "SpRecovery": 32.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 244.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 8.89
+            },
+            {
+              "DamagePercentage": 0.495,
+              "DamagePercentageGrowth": 0.045,
+              "StunRatio": 0.552,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 397.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1518,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 80.79
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeRiskyBusiness": [],
+          "DashAttackStarlightSanction": [
+            {
+              "DamagePercentage": 0.63,
+              "DamagePercentageGrowth": 0.058,
+              "StunRatio": 0.63,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 251.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1925,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 34.98
+            },
+            {
+              "DamagePercentage": 0.39,
+              "DamagePercentageGrowth": 0.036,
+              "StunRatio": 0.195,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 78,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 596.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 43.29
+            }
+          ],
+          "DodgeCounterFairFight": [
+            {
+              "DamagePercentage": 2.214,
+              "DamagePercentageGrowth": 0.202,
+              "StunRatio": 1.934,
+              "StunRatioGrowth": 0.088,
+              "SpRecovery": 336.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2568.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 93.36
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackStandStill": [
+            {
+              "DamagePercentage": 0.242,
+              "DamagePercentageGrowth": 0.022,
+              "StunRatio": 0.242,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 665.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 24.14
+            },
+            {
+              "DamagePercentage": 0.517,
+              "DamagePercentageGrowth": 0.047,
+              "StunRatio": 0.517,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1421.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 25.84
+            },
+            {
+              "DamagePercentage": 0.501,
+              "DamagePercentageGrowth": 0.046,
+              "StunRatio": 0.501,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1377.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 25
+            }
+          ],
+          "EXSpecialAttackClearanceTime": [
+            {
+              "DamagePercentage": 5.438,
+              "DamagePercentageGrowth": 0.495,
+              "StunRatio": 4.395,
+              "StunRatioGrowth": 0.2,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16203,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 446.87
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackStarlightMirage": [
+            {
+              "DamagePercentage": 7.352,
+              "DamagePercentageGrowth": 0.669,
+              "StunRatio": 1.966,
+              "StunRatioGrowth": 0.09,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24293.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 417.83
+            }
+          ],
+          "UltimateStarlightShineBright": [
+            {
+              "DamagePercentage": 15.977,
+              "DamagePercentageGrowth": 1.453,
+              "StunRatio": 1.906,
+              "StunRatioGrowth": 0.087,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 211.7
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistPowerOfTeamwork": [
+            {
+              "DamagePercentage": 0.934,
+              "DamagePercentageGrowth": 0.085,
+              "StunRatio": 0.934,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 336.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2568.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 93.36
+            }
+          ],
+          "EvasiveAssistFlashSpin": [],
+          "AssistFollowUpFatalShot": [
+            {
+              "DamagePercentage": 3.888,
+              "DamagePercentageGrowth": 0.354,
+              "StunRatio": 3.412,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 12001,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 364.97
+            }
+          ]
+        }
+      }
     },
     "Miyabi": {
       "id": "1091",
@@ -634,7 +2500,306 @@
           "atk": 75,
           "anomProf": 90
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackKazahana": [
+            {
+              "DamagePercentage": 0.269,
+              "DamagePercentageGrowth": 0.025,
+              "StunRatio": 0.135,
+              "StunRatioGrowth": 0.007,
+              "SpRecovery": 44,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 338.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.296,
+              "DamagePercentageGrowth": 0.027,
+              "StunRatio": 0.269,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 87.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 673.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.628,
+              "DamagePercentageGrowth": 0.058,
+              "StunRatio": 0.464,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 151.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1160.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 62.9
+            },
+            {
+              "DamagePercentage": 0.965,
+              "DamagePercentageGrowth": 0.088,
+              "StunRatio": 0.821,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 268.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2051.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 91.21
+            },
+            {
+              "DamagePercentage": 1.29,
+              "DamagePercentageGrowth": 0.118,
+              "StunRatio": 1.31,
+              "StunRatioGrowth": 0.06,
+              "SpRecovery": 428.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3275.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 129.27
+            }
+          ],
+          "BasicAttackShimotsuki": [
+            {
+              "DamagePercentage": 4.547,
+              "DamagePercentageGrowth": 0.414,
+              "StunRatio": 0.44,
+              "StunRatioGrowth": 0.02,
+              "SpRecovery": 144,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1100,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 39.98
+            },
+            {
+              "DamagePercentage": 8.581,
+              "DamagePercentageGrowth": 0.781,
+              "StunRatio": 0.624,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 204.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1559.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.68
+            },
+            {
+              "DamagePercentage": 21.411,
+              "DamagePercentageGrowth": 1.947,
+              "StunRatio": 3.778,
+              "StunRatioGrowth": 0.172,
+              "SpRecovery": 618.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9443.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 343.36
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeMizutori": [],
+          "DashAttackFuyubachi": [
+            {
+              "DamagePercentage": 0.258,
+              "DamagePercentageGrowth": 0.024,
+              "StunRatio": 0.129,
+              "StunRatioGrowth": 0.006,
+              "SpRecovery": 42.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 321.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterKanSuzume": [
+            {
+              "DamagePercentage": 2.459,
+              "DamagePercentageGrowth": 0.224,
+              "StunRatio": 2.145,
+              "StunRatioGrowth": 0.098,
+              "SpRecovery": 342,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2612.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 94.99
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackMiyuki": [
+            {
+              "DamagePercentage": 0.358,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.358,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 896.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 32.51
+            }
+          ],
+          "EXSpecialAttackHisetsu": [
+            {
+              "DamagePercentage": 1.574,
+              "DamagePercentageGrowth": 0.144,
+              "StunRatio": 1.287,
+              "StunRatioGrowth": 0.059,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4653,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 157.75
+            },
+            {
+              "DamagePercentage": 2.36,
+              "DamagePercentageGrowth": 0.215,
+              "StunRatio": 1.93,
+              "StunRatioGrowth": 0.088,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6976.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 250.52
+            },
+            {
+              "DamagePercentage": 1.933,
+              "DamagePercentageGrowth": 0.176,
+              "StunRatio": 1.62,
+              "StunRatioGrowth": 0.074,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5615.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 189.25
+            },
+            {
+              "DamagePercentage": 2.899,
+              "DamagePercentageGrowth": 0.264,
+              "StunRatio": 2.43,
+              "StunRatioGrowth": 0.111,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8420.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 297.77
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackSpringsCall": [
+            {
+              "DamagePercentage": 1.884,
+              "DamagePercentageGrowth": 0.172,
+              "StunRatio": 0.567,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6905.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 111.36
+            },
+            {
+              "DamagePercentage": 1.884,
+              "DamagePercentageGrowth": 0.172,
+              "StunRatio": 0.567,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6905.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 111.36
+            },
+            {
+              "DamagePercentage": 2.512,
+              "DamagePercentageGrowth": 0.229,
+              "StunRatio": 0.756,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9204.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 148.48
+            }
+          ],
+          "UltimateLingeringSnow": [
+            {
+              "DamagePercentage": 23.88,
+              "DamagePercentageGrowth": 2.171,
+              "StunRatio": 3.704,
+              "StunRatioGrowth": 0.169,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 1137.16
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistDancingPetals": [
+            {
+              "DamagePercentage": 1.045,
+              "DamagePercentageGrowth": 0.095,
+              "StunRatio": 1.045,
+              "StunRatioGrowth": 0.048,
+              "SpRecovery": 342,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2612.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 94.99
+            }
+          ],
+          "DefensiveAssistDriftingPetals": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.283,
+              "StunRatioGrowth": 0.059,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpFallingPetals": [
+            {
+              "DamagePercentage": 3.378,
+              "DamagePercentageGrowth": 0.308,
+              "StunRatio": 2.919,
+              "StunRatioGrowth": 0.133,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9594.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 286.17
+            }
+          ]
+        }
+      }
     },
     "Koleda": {
       "id": "1101",
@@ -711,7 +2876,293 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackSmashNBash": [
+            {
+              "DamagePercentage": 0.636,
+              "DamagePercentageGrowth": 0.058,
+              "StunRatio": 0.318,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 109,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 833.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.792,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.655,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 224.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1716,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.261,
+              "DamagePercentageGrowth": 0.115,
+              "StunRatio": 1.043,
+              "StunRatioGrowth": 0.048,
+              "SpRecovery": 357.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2730.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 3.174,
+              "DamagePercentageGrowth": 0.289,
+              "StunRatio": 2.493,
+              "StunRatioGrowth": 0.114,
+              "SpRecovery": 854.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6531.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.608,
+              "DamagePercentageGrowth": 0.147,
+              "StunRatio": 0.614,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 210.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1608.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 44.35
+            },
+            {
+              "DamagePercentage": 4.049,
+              "DamagePercentageGrowth": 0.369,
+              "StunRatio": 1.566,
+              "StunRatioGrowth": 0.072,
+              "SpRecovery": 597.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4562.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 149.08
+            },
+            {
+              "DamagePercentage": 5.013,
+              "DamagePercentageGrowth": 0.456,
+              "StunRatio": 2.346,
+              "StunRatioGrowth": 0.107,
+              "SpRecovery": 731.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5585.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 186.29
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeWaitNSee": [],
+          "DashAttackTremble": [
+            {
+              "DamagePercentage": 0.561,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.281,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 96.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 734.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterDontLookDownOnMe": [
+            {
+              "DamagePercentage": 3.439,
+              "DamagePercentageGrowth": 0.313,
+              "StunRatio": 2.888,
+              "StunRatioGrowth": 0.132,
+              "SpRecovery": 629.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4812.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 174.96
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackHammerTime": [
+            {
+              "DamagePercentage": 0.519,
+              "DamagePercentageGrowth": 0.048,
+              "StunRatio": 0.519,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1358.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.18
+            },
+            {
+              "DamagePercentage": 0.778,
+              "DamagePercentageGrowth": 0.071,
+              "StunRatio": 0.778,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2037.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 59.18
+            },
+            {
+              "DamagePercentage": 0.855,
+              "DamagePercentageGrowth": 0.078,
+              "StunRatio": 0.778,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2037.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 59.18
+            }
+          ],
+          "EXSpecialAttackBoilingFurnace": [
+            {
+              "DamagePercentage": 1.523,
+              "DamagePercentageGrowth": 0.139,
+              "StunRatio": 1.523,
+              "StunRatioGrowth": 0.07,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3987.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 72.48
+            },
+            {
+              "DamagePercentage": 6.06,
+              "DamagePercentageGrowth": 0.551,
+              "StunRatio": 4.94,
+              "StunRatioGrowth": 0.225,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 17096.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 476.12
+            },
+            {
+              "DamagePercentage": 6.666,
+              "DamagePercentageGrowth": 0.606,
+              "StunRatio": 4.94,
+              "StunRatioGrowth": 0.225,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 17096.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 476.12
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackNaturalDisaster": [
+            {
+              "DamagePercentage": 6.36,
+              "DamagePercentageGrowth": 0.579,
+              "StunRatio": 2.17,
+              "StunRatioGrowth": 0.099,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 23971.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 406.13
+            }
+          ],
+          "UltimateHammerquake": [
+            {
+              "DamagePercentage": 15.488,
+              "DamagePercentageGrowth": 1.408,
+              "StunRatio": 10.049,
+              "StunRatioGrowth": 0.457,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 180.03
+            },
+            {
+              "DamagePercentage": 16.94,
+              "DamagePercentageGrowth": 1.54,
+              "StunRatio": 10.965,
+              "StunRatioGrowth": 0.499,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 190.66
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistComingThru": [
+            {
+              "DamagePercentage": 1.838,
+              "DamagePercentageGrowth": 0.168,
+              "StunRatio": 1.838,
+              "StunRatioGrowth": 0.084,
+              "SpRecovery": 629.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4812.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 174.96
+            }
+          ],
+          "DefensiveAssistProtectiveHammer": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.59,
+              "StunRatioGrowth": 0.118,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.273,
+              "StunRatioGrowth": 0.149,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.593,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpHammerBell": [
+            {
+              "DamagePercentage": 3.592,
+              "DamagePercentageGrowth": 0.327,
+              "StunRatio": 3.127,
+              "StunRatioGrowth": 0.143,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10626,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 319.92
+            }
+          ]
+        }
+      }
     },
     "Anton": {
       "id": "1111",
@@ -788,7 +3239,279 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackEnthusiasticDrills": [
+            {
+              "DamagePercentage": 0.678,
+              "DamagePercentageGrowth": 0.062,
+              "StunRatio": 0.339,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 122,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 932.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.923,
+              "DamagePercentageGrowth": 0.084,
+              "StunRatio": 0.753,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 270.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2070.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.098,
+              "DamagePercentageGrowth": 0.1,
+              "StunRatio": 0.933,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 335.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2565.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.291,
+              "DamagePercentageGrowth": 0.209,
+              "StunRatio": 1.814,
+              "StunRatioGrowth": 0.083,
+              "SpRecovery": 653,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4988.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackEnthusiasticDrillsBurstMode": [
+            {
+              "DamagePercentage": 2.409,
+              "DamagePercentageGrowth": 0.219,
+              "StunRatio": 1.66,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5835.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 177.49
+            },
+            {
+              "DamagePercentage": 4.692,
+              "DamagePercentageGrowth": 0.427,
+              "StunRatio": 3.233,
+              "StunRatioGrowth": 0.147,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11365.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 345.73
+            },
+            {
+              "DamagePercentage": 4.569,
+              "DamagePercentageGrowth": 0.416,
+              "StunRatio": 3.148,
+              "StunRatioGrowth": 0.144,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11066,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 336.68
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeLetsMove": [],
+          "DashAttackFireWithFire": [
+            {
+              "DamagePercentage": 0.684,
+              "DamagePercentageGrowth": 0.063,
+              "StunRatio": 0.342,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 123,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 940.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterRetaliation": [
+            {
+              "DamagePercentage": 2.712,
+              "DamagePercentageGrowth": 0.247,
+              "StunRatio": 2.317,
+              "StunRatioGrowth": 0.106,
+              "SpRecovery": 474.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3621.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterOverloadDrillBurstMode": [
+            {
+              "DamagePercentage": 4.654,
+              "DamagePercentageGrowth": 0.424,
+              "StunRatio": 3.518,
+              "StunRatioGrowth": 0.16,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8849.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 269.23
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSpinBro": [
+            {
+              "DamagePercentage": 0.442,
+              "DamagePercentageGrowth": 0.041,
+              "StunRatio": 0.442,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1215.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 44.18
+            }
+          ],
+          "EXSpecialAttackSmashTheHorizonBro": [
+            {
+              "DamagePercentage": 1.951,
+              "DamagePercentageGrowth": 0.178,
+              "StunRatio": 1.951,
+              "StunRatioGrowth": 0.089,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5365.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 195.03
+            }
+          ],
+          "SpecialAttackExplosiveDrillBurstMode": [
+            {
+              "DamagePercentage": 2.314,
+              "DamagePercentageGrowth": 0.211,
+              "StunRatio": 1.184,
+              "StunRatioGrowth": 0.054,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7141.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 217.21
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackGoGoGo": [
+            {
+              "DamagePercentage": 6.407,
+              "DamagePercentageGrowth": 0.583,
+              "StunRatio": 2.417,
+              "StunRatioGrowth": 0.11,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24934.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 441.13
+            }
+          ],
+          "UltimateGoGoGoGoGo": [
+            {
+              "DamagePercentage": 18.164,
+              "DamagePercentageGrowth": 1.652,
+              "StunRatio": 2.434,
+              "StunRatioGrowth": 0.111,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 243.36
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistShoulderToShoulder": [
+            {
+              "DamagePercentage": 2.634,
+              "DamagePercentageGrowth": 0.24,
+              "StunRatio": 1.317,
+              "StunRatioGrowth": 0.06,
+              "SpRecovery": 474.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3621.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "QuickAssistProtectiveDrillBurstMode": [
+            {
+              "DamagePercentage": 3.654,
+              "DamagePercentageGrowth": 0.333,
+              "StunRatio": 2.518,
+              "StunRatioGrowth": 0.115,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8849.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 269.23
+            }
+          ],
+          "DefensiveAssistIronWrist": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpLimitBurst": [
+            {
+              "DamagePercentage": 3.258,
+              "DamagePercentageGrowth": 0.297,
+              "StunRatio": 2.827,
+              "StunRatioGrowth": 0.129,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10144.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 304.22
+            }
+          ]
+        }
+      }
     },
     "Ben": {
       "id": "1121",
@@ -865,7 +3588,238 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackDebtReconciliation": [
+            {
+              "DamagePercentage": 0.659,
+              "DamagePercentageGrowth": 0.06,
+              "StunRatio": 0.471,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 169.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1295.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.89,
+              "DamagePercentageGrowth": 0.172,
+              "StunRatio": 1.569,
+              "StunRatioGrowth": 0.072,
+              "SpRecovery": 564.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4314.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 3.483,
+              "DamagePercentageGrowth": 0.317,
+              "StunRatio": 2.601,
+              "StunRatioGrowth": 0.119,
+              "SpRecovery": 936.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7152.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeMissingInvoice": [],
+          "DashAttackIncomingExpense": [
+            {
+              "DamagePercentage": 1.384,
+              "DamagePercentageGrowth": 0.126,
+              "StunRatio": 0.692,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 249.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1903,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterAccountsSettled": [
+            {
+              "DamagePercentage": 2.257,
+              "DamagePercentageGrowth": 0.206,
+              "StunRatio": 1.967,
+              "StunRatioGrowth": 0.09,
+              "SpRecovery": 348.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2659.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 96.66
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackFiscalFist": [
+            {
+              "DamagePercentage": 0.417,
+              "DamagePercentageGrowth": 0.038,
+              "StunRatio": 0.417,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1146.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.334,
+              "DamagePercentageGrowth": 0.213,
+              "StunRatio": 2.234,
+              "StunRatioGrowth": 0.102,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2293.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "EXSpecialAttackCashflowCounter": [
+            {
+              "DamagePercentage": 4.385,
+              "DamagePercentageGrowth": 0.399,
+              "StunRatio": 2.471,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9427,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 270.99
+            },
+            {
+              "DamagePercentage": 4.385,
+              "DamagePercentageGrowth": 0.399,
+              "StunRatio": 2.471,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9427,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 270.99
+            },
+            {
+              "DamagePercentage": 5.005,
+              "DamagePercentageGrowth": 0.455,
+              "StunRatio": 3.676,
+              "StunRatioGrowth": 0.168,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11253,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 330.71
+            },
+            {
+              "DamagePercentage": 5.512,
+              "DamagePercentageGrowth": 0.502,
+              "StunRatio": 3.676,
+              "StunRatioGrowth": 0.168,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11253,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 330.71
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackSignedAndSealed": [
+            {
+              "DamagePercentage": 6.273,
+              "DamagePercentageGrowth": 0.571,
+              "StunRatio": 3.283,
+              "StunRatioGrowth": 0.15,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24565.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 427.79
+            }
+          ],
+          "UltimateCompletePayback": [
+            {
+              "DamagePercentage": 16.43,
+              "DamagePercentageGrowth": 1.494,
+              "StunRatio": 1.1,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 110
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistJointAccount": [
+            {
+              "DamagePercentage": 0.967,
+              "DamagePercentageGrowth": 0.088,
+              "StunRatio": 0.967,
+              "StunRatioGrowth": 0.044,
+              "SpRecovery": 348.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2659.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 96.66
+            }
+          ],
+          "DefensiveAssistRiskAllocation": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.251,
+              "StunRatioGrowth": 0.103,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.684,
+              "StunRatioGrowth": 0.122,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.084,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpDontBreakContract": [
+            {
+              "DamagePercentage": 3.259,
+              "DamagePercentageGrowth": 0.297,
+              "StunRatio": 2.828,
+              "StunRatioGrowth": 0.129,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10147.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 304.26
+            }
+          ]
+        }
+      }
     },
     "Soukaku": {
       "id": "1131",
@@ -942,7 +3896,310 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackMakingRiceCakes": [
+            {
+              "DamagePercentage": 0.662,
+              "DamagePercentageGrowth": 0.061,
+              "StunRatio": 0.331,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 119.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 910.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.163,
+              "DamagePercentageGrowth": 0.197,
+              "StunRatio": 1.88,
+              "StunRatioGrowth": 0.086,
+              "SpRecovery": 676.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4441.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.931,
+              "DamagePercentageGrowth": 0.267,
+              "StunRatio": 2.217,
+              "StunRatioGrowth": 0.101,
+              "SpRecovery": 798,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5420.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackMakingRiceCakesFrostedBanner": [
+            {
+              "DamagePercentage": 0.766,
+              "DamagePercentageGrowth": 0.07,
+              "StunRatio": 0.466,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 167.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1281.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 46.57
+            },
+            {
+              "DamagePercentage": 2.285,
+              "DamagePercentageGrowth": 0.208,
+              "StunRatio": 1.275,
+              "StunRatioGrowth": 0.058,
+              "SpRecovery": 458.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3506.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 127.43
+            },
+            {
+              "DamagePercentage": 5.114,
+              "DamagePercentageGrowth": 0.465,
+              "StunRatio": 2.633,
+              "StunRatioGrowth": 0.12,
+              "SpRecovery": 947.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7240.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 263.21
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeGrabABite": [],
+          "DashAttack5050": [
+            {
+              "DamagePercentage": 0.767,
+              "DamagePercentageGrowth": 0.07,
+              "StunRatio": 0.384,
+              "StunRatioGrowth": 0.018,
+              "SpRecovery": 138,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1056,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DashAttack5050FrostedBanner": [
+            {
+              "DamagePercentage": 1.315,
+              "DamagePercentageGrowth": 0.12,
+              "StunRatio": 0.801,
+              "StunRatioGrowth": 0.037,
+              "SpRecovery": 288.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2202.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 80.03
+            }
+          ],
+          "DodgeCounterAwayFromMySnacks": [
+            {
+              "DamagePercentage": 2.473,
+              "DamagePercentageGrowth": 0.225,
+              "StunRatio": 2.134,
+              "StunRatioGrowth": 0.097,
+              "SpRecovery": 407.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3118.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 113.3
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackCoolingBento": [
+            {
+              "DamagePercentage": 0.284,
+              "DamagePercentageGrowth": 0.026,
+              "StunRatio": 0.284,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 781,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 28.34
+            },
+            {
+              "DamagePercentage": 1.001,
+              "DamagePercentageGrowth": 0.091,
+              "StunRatio": 1.001,
+              "StunRatioGrowth": 0.046,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2752.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 50.01
+            }
+          ],
+          "EXSpecialAttackFanningMosquitoes": [
+            {
+              "DamagePercentage": 2.624,
+              "DamagePercentageGrowth": 0.239,
+              "StunRatio": 2.258,
+              "StunRatioGrowth": 0.103,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8222.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 244.07
+            },
+            {
+              "DamagePercentage": 1.021,
+              "DamagePercentageGrowth": 0.093,
+              "StunRatio": 0.879,
+              "StunRatioGrowth": 0.04,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3198.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 94.91
+            }
+          ],
+          "SpecialAttackRally": [
+            {
+              "DamagePercentage": 2.501,
+              "DamagePercentageGrowth": 0.228,
+              "StunRatio": 2.751,
+              "StunRatioGrowth": 0.126,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6877.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 125
+            },
+            {
+              "DamagePercentage": 1.401,
+              "DamagePercentageGrowth": 0.128,
+              "StunRatio": 1.401,
+              "StunRatioGrowth": 0.064,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3852.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 70.01
+            },
+            {
+              "DamagePercentage": 2.45,
+              "DamagePercentageGrowth": 0.223,
+              "StunRatio": 2.45,
+              "StunRatioGrowth": 0.112,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6737.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 122.5
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackPuddingSlash": [
+            {
+              "DamagePercentage": 7.458,
+              "DamagePercentageGrowth": 0.678,
+              "StunRatio": 3.468,
+              "StunRatioGrowth": 0.158,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 27824.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 546.2
+            }
+          ],
+          "UltimateJumboPuddingSlash": [
+            {
+              "DamagePercentage": 19.898,
+              "DamagePercentageGrowth": 1.809,
+              "StunRatio": 3.768,
+              "StunRatioGrowth": 0.172,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 376.7
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistASetForTwo": [
+            {
+              "DamagePercentage": 1.134,
+              "DamagePercentageGrowth": 0.104,
+              "StunRatio": 1.134,
+              "StunRatioGrowth": 0.052,
+              "SpRecovery": 407.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3118.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 113.3
+            }
+          ],
+          "DefensiveAssistGuardingTactics": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpSweepingStrike": [
+            {
+              "DamagePercentage": 2.64,
+              "DamagePercentageGrowth": 0.24,
+              "StunRatio": 2.313,
+              "StunRatioGrowth": 0.106,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8159.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 247.57
+            },
+            {
+              "DamagePercentage": 1.132,
+              "DamagePercentageGrowth": 0.103,
+              "StunRatio": 0.991,
+              "StunRatioGrowth": 0.046,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3498,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 106.1
+            }
+          ]
+        }
+      }
     },
     "Lycaon": {
       "id": "1141",
@@ -1019,7 +4276,326 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackMoonHunter": [
+            {
+              "DamagePercentage": 0.292,
+              "DamagePercentageGrowth": 0.027,
+              "StunRatio": 0.146,
+              "StunRatioGrowth": 0.007,
+              "SpRecovery": 50.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 382.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.371,
+              "DamagePercentageGrowth": 0.034,
+              "StunRatio": 0.121,
+              "StunRatioGrowth": 0.006,
+              "SpRecovery": 41.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 316.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 11.48
+            },
+            {
+              "DamagePercentage": 0.349,
+              "DamagePercentageGrowth": 0.032,
+              "StunRatio": 0.303,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 103.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 794.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.564,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.329,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 112.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 860.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.28
+            },
+            {
+              "DamagePercentage": 0.584,
+              "DamagePercentageGrowth": 0.054,
+              "StunRatio": 0.456,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 156.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1196.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.995,
+              "DamagePercentageGrowth": 0.091,
+              "StunRatio": 0.537,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 184.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1408,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 51.13
+            },
+            {
+              "DamagePercentage": 1.52,
+              "DamagePercentageGrowth": 0.139,
+              "StunRatio": 1.12,
+              "StunRatioGrowth": 0.051,
+              "SpRecovery": 383.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2931.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.109,
+              "DamagePercentageGrowth": 0.192,
+              "StunRatio": 1.071,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 367.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2805,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 101.98
+            },
+            {
+              "DamagePercentage": 1.807,
+              "DamagePercentageGrowth": 0.165,
+              "StunRatio": 1.477,
+              "StunRatioGrowth": 0.068,
+              "SpRecovery": 506.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3866.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.776,
+              "DamagePercentageGrowth": 0.253,
+              "StunRatio": 1.631,
+              "StunRatioGrowth": 0.075,
+              "SpRecovery": 558.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4270.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 155.24
+            },
+            {
+              "DamagePercentage": 3.557,
+              "DamagePercentageGrowth": 0.324,
+              "StunRatio": 2.056,
+              "StunRatioGrowth": 0.094,
+              "SpRecovery": 704.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5384.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 195.75
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeSuitablePositioning": [],
+          "DashAttackKeepItClean": [
+            {
+              "DamagePercentage": 0.473,
+              "DamagePercentageGrowth": 0.043,
+              "StunRatio": 0.237,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 81.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 621.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterEtiquetteManual": [
+            {
+              "DamagePercentage": 1.87,
+              "DamagePercentageGrowth": 0.17,
+              "StunRatio": 1.681,
+              "StunRatioGrowth": 0.077,
+              "SpRecovery": 216.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1652.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 60.03
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackTimeToHunt": [
+            {
+              "DamagePercentage": 0.228,
+              "DamagePercentageGrowth": 0.021,
+              "StunRatio": 0.228,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 596.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 21.66
+            },
+            {
+              "DamagePercentage": 0.543,
+              "DamagePercentageGrowth": 0.05,
+              "StunRatio": 0.543,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1421.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 25.83
+            },
+            {
+              "DamagePercentage": 1.103,
+              "DamagePercentageGrowth": 0.101,
+              "StunRatio": 1.103,
+              "StunRatioGrowth": 0.051,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2890.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 52.5
+            }
+          ],
+          "EXSpecialAttackThrillOfTheHunt": [
+            {
+              "DamagePercentage": 2.524,
+              "DamagePercentageGrowth": 0.23,
+              "StunRatio": 2.115,
+              "StunRatioGrowth": 0.097,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6985,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 200.76
+            },
+            {
+              "DamagePercentage": 2.819,
+              "DamagePercentageGrowth": 0.257,
+              "StunRatio": 2.389,
+              "StunRatioGrowth": 0.109,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7738.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 225.42
+            },
+            {
+              "DamagePercentage": 5.371,
+              "DamagePercentageGrowth": 0.489,
+              "StunRatio": 4.529,
+              "StunRatioGrowth": 0.206,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 14792.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 428.48
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackAsYouWish": [
+            {
+              "DamagePercentage": 6.378,
+              "DamagePercentageGrowth": 0.58,
+              "StunRatio": 2.188,
+              "StunRatioGrowth": 0.1,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24018.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 407.86
+            }
+          ],
+          "UltimateMissionComplete": [
+            {
+              "DamagePercentage": 16.941,
+              "DamagePercentageGrowth": 1.541,
+              "StunRatio": 10.966,
+              "StunRatioGrowth": 0.499,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 173.36
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistWolfPack": [
+            {
+              "DamagePercentage": 0.631,
+              "DamagePercentageGrowth": 0.058,
+              "StunRatio": 0.631,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 216.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1652.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 60.03
+            }
+          ],
+          "DefensiveAssistDisruptedHunt": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.59,
+              "StunRatioGrowth": 0.118,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.273,
+              "StunRatioGrowth": 0.149,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.593,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpVengefulCounterattack": [
+            {
+              "DamagePercentage": 2.883,
+              "DamagePercentageGrowth": 0.263,
+              "StunRatio": 2.468,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8635,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 254.76
+            }
+          ]
+        }
+      }
     },
     "Lucy": {
       "id": "1151",
@@ -1096,7 +4672,287 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackLadysBat": [
+            {
+              "DamagePercentage": 0.566,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.283,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 101.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 778.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.778,
+              "DamagePercentageGrowth": 0.071,
+              "StunRatio": 0.65,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 234,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1787.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.889,
+              "DamagePercentageGrowth": 0.172,
+              "StunRatio": 1.574,
+              "StunRatioGrowth": 0.072,
+              "SpRecovery": 566.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4328.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 134.01
+            },
+            {
+              "DamagePercentage": 2.115,
+              "DamagePercentageGrowth": 0.193,
+              "StunRatio": 1.623,
+              "StunRatioGrowth": 0.074,
+              "SpRecovery": 584.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4463.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.726,
+              "DamagePercentageGrowth": 0.248,
+              "StunRatio": 2.08,
+              "StunRatioGrowth": 0.095,
+              "SpRecovery": 748.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5720,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 186.25
+            }
+          ],
+          "GuardBoarsToArms": [
+            {
+              "DamagePercentage": 0.925,
+              "DamagePercentageGrowth": 0.085,
+              "StunRatio": 0.155,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.275,
+              "DamagePercentageGrowth": 0.116,
+              "StunRatio": 0.213,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.75,
+              "DamagePercentageGrowth": 0.16,
+              "StunRatio": 0.292,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "GuardBoarsSpinningSwing": [
+            {
+              "DamagePercentage": 2.5,
+              "DamagePercentageGrowth": 0.228,
+              "StunRatio": 0.2,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeFoulBall": [],
+          "DashAttackFearlessBoar": [
+            {
+              "DamagePercentage": 0.784,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.392,
+              "StunRatioGrowth": 0.018,
+              "SpRecovery": 141.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1078,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterReturningTusk": [
+            {
+              "DamagePercentage": 3.08,
+              "DamagePercentageGrowth": 0.28,
+              "StunRatio": 2.6,
+              "StunRatioGrowth": 0.119,
+              "SpRecovery": 575.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4400,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 159.96
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSolidHit": [
+            {
+              "DamagePercentage": 0.617,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.617,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1696.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 61.65
+            },
+            {
+              "DamagePercentage": 0.692,
+              "DamagePercentageGrowth": 0.063,
+              "StunRatio": 0.692,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1903,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 69.15
+            }
+          ],
+          "EXSpecialAttackHomeRun": [
+            {
+              "DamagePercentage": 5.084,
+              "DamagePercentageGrowth": 0.463,
+              "StunRatio": 3.646,
+              "StunRatioGrowth": 0.166,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16615.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 335.41
+            },
+            {
+              "DamagePercentage": 5.364,
+              "DamagePercentageGrowth": 0.488,
+              "StunRatio": 3.896,
+              "StunRatioGrowth": 0.178,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 17440.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 342.41
+            }
+          ],
+          "CheerOn": []
+        },
+        "chain": {
+          "ChainAttackGrandSlam": [
+            {
+              "DamagePercentage": 4.924,
+              "DamagePercentageGrowth": 0.448,
+              "StunRatio": 0.934,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 20856,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 292.8
+            }
+          ],
+          "UltimateWalkOffHomeRun": [
+            {
+              "DamagePercentage": 17.186,
+              "DamagePercentageGrowth": 1.563,
+              "StunRatio": 2.835,
+              "StunRatioGrowth": 0.129,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 315
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistHitByPitch": [
+            {
+              "DamagePercentage": 1.6,
+              "DamagePercentageGrowth": 0.146,
+              "StunRatio": 1.6,
+              "StunRatioGrowth": 0.073,
+              "SpRecovery": 575.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4400,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 159.96
+            }
+          ],
+          "DefensiveAssistSafeOnBase": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.077,
+              "StunRatioGrowth": 0.095,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.294,
+              "StunRatioGrowth": 0.105,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 0.694,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpScoredARun": [
+            {
+              "DamagePercentage": 3.491,
+              "DamagePercentageGrowth": 0.318,
+              "StunRatio": 3.043,
+              "StunRatioGrowth": 0.139,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10832.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 326.67
+            }
+          ]
+        }
+      }
     },
     "Lighter": {
       "id": "1161",
@@ -1173,7 +5029,348 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackLFormThunderingFist": [
+            {
+              "DamagePercentage": 0.392,
+              "DamagePercentageGrowth": 0.036,
+              "StunRatio": 0.196,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 64.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 492.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.48,
+              "DamagePercentageGrowth": 0.044,
+              "StunRatio": 0.329,
+              "StunRatioGrowth": 0.015,
+              "SpRecovery": 107.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 822.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.553,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.467,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 152.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1166,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.869,
+              "DamagePercentageGrowth": 0.079,
+              "StunRatio": 0.605,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 197.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1512.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.477,
+              "DamagePercentageGrowth": 0.044,
+              "StunRatio": 0.332,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 108.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 830.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.581,
+              "DamagePercentageGrowth": 0.053,
+              "StunRatio": 0.404,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 132.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1009.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.328,
+              "DamagePercentageGrowth": 0.03,
+              "StunRatio": 0.228,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 74.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 569.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.89,
+              "DamagePercentageGrowth": 0.081,
+              "StunRatio": 0.619,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 202.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1548.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.789,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.761,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 249.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1903,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 55.05
+            },
+            {
+              "DamagePercentage": 1.636,
+              "DamagePercentageGrowth": 0.149,
+              "StunRatio": 1.295,
+              "StunRatioGrowth": 0.059,
+              "SpRecovery": 476.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3638.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 123.87
+            },
+            {
+              "DamagePercentage": 1.229,
+              "DamagePercentageGrowth": 0.112,
+              "StunRatio": 0.813,
+              "StunRatioGrowth": 0.037,
+              "SpRecovery": 279.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2139.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 77.7
+            },
+            {
+              "DamagePercentage": 1.046,
+              "DamagePercentageGrowth": 0.096,
+              "StunRatio": 0.795,
+              "StunRatioGrowth": 0.037,
+              "SpRecovery": 273.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2092.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.05
+            },
+            {
+              "DamagePercentage": 1.772,
+              "DamagePercentageGrowth": 0.162,
+              "StunRatio": 1.363,
+              "StunRatioGrowth": 0.062,
+              "SpRecovery": 446,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3407.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 123.87
+            },
+            {
+              "DamagePercentage": 3.643,
+              "DamagePercentageGrowth": 0.332,
+              "StunRatio": 0.855,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 279.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2139.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 77.7
+            },
+            {
+              "DamagePercentage": 1.197,
+              "DamagePercentageGrowth": 0.109,
+              "StunRatio": 0.921,
+              "StunRatioGrowth": 0.042,
+              "SpRecovery": 301.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2301.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 83.66
+            },
+            {
+              "DamagePercentage": 4.354,
+              "DamagePercentageGrowth": 0.396,
+              "StunRatio": 1.324,
+              "StunRatioGrowth": 0.061,
+              "SpRecovery": 360.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2758.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 100.23
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeShadowedSlide": [],
+          "DashAttackChargingSlam": [
+            {
+              "DamagePercentage": 0.899,
+              "DamagePercentageGrowth": 0.082,
+              "StunRatio": 0.45,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 147.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1124.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterBlazingFlash": [
+            {
+              "DamagePercentage": 1.863,
+              "DamagePercentageGrowth": 0.17,
+              "StunRatio": 1.687,
+              "StunRatioGrowth": 0.077,
+              "SpRecovery": 192.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1468.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 53.33
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackVFormSunriseUppercut": [
+            {
+              "DamagePercentage": 0.363,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.363,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 825,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 30
+            }
+          ],
+          "EXSpecialAttackVFormSunriseUppercutFullDistance": [
+            {
+              "DamagePercentage": 4.863,
+              "DamagePercentageGrowth": 0.443,
+              "StunRatio": 4.035,
+              "StunRatioGrowth": 0.184,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 12933.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 367.64
+            },
+            {
+              "DamagePercentage": 2.927,
+              "DamagePercentageGrowth": 0.267,
+              "StunRatio": 2.477,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7672.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 223.26
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackVFormScorchingSun": [
+            {
+              "DamagePercentage": 7.121,
+              "DamagePercentageGrowth": 0.648,
+              "StunRatio": 2.732,
+              "StunRatioGrowth": 0.125,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 25118.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 447.83
+            }
+          ],
+          "UltimateWFormCrownedInferno": [
+            {
+              "DamagePercentage": 15.08,
+              "DamagePercentageGrowth": 1.371,
+              "StunRatio": 9.474,
+              "StunRatioGrowth": 0.431,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 96.69
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistBlazingFlashGuard": [
+            {
+              "DamagePercentage": 0.697,
+              "DamagePercentageGrowth": 0.064,
+              "StunRatio": 0.697,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 228,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1743.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 63.33
+            }
+          ],
+          "DefensiveAssistSwiftBreak": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpChargingSlamStab": [
+            {
+              "DamagePercentage": 2.198,
+              "DamagePercentageGrowth": 0.2,
+              "StunRatio": 1.823,
+              "StunRatioGrowth": 0.083,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6432.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 182.72
+            }
+          ]
+        }
+      }
     },
     "Burnice": {
       "id": "1171",
@@ -1250,7 +5447,286 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackDirectFlameBlend": [
+            {
+              "DamagePercentage": 0.448,
+              "DamagePercentageGrowth": 0.041,
+              "StunRatio": 0.187,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 61,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 467.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 16.94
+            },
+            {
+              "DamagePercentage": 0.435,
+              "DamagePercentageGrowth": 0.04,
+              "StunRatio": 0.308,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 100.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 770,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.717,
+              "DamagePercentageGrowth": 0.066,
+              "StunRatio": 0.478,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 156.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1193.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 43.37
+            },
+            {
+              "DamagePercentage": 0.666,
+              "DamagePercentageGrowth": 0.061,
+              "StunRatio": 0.304,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 99.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 759,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 27.54
+            },
+            {
+              "DamagePercentage": 0.963,
+              "DamagePercentageGrowth": 0.088,
+              "StunRatio": 0.52,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 169.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1298,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 47.19
+            }
+          ],
+          "BasicAttackMixedFlameBlend": [
+            {
+              "DamagePercentage": 1.254,
+              "DamagePercentageGrowth": 0.114,
+              "StunRatio": 0.965,
+              "StunRatioGrowth": 0.044,
+              "SpRecovery": 157.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2411.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 95.98
+            },
+            {
+              "DamagePercentage": 2.328,
+              "DamagePercentageGrowth": 0.212,
+              "StunRatio": 1.791,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 293.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4477,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 171.11
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeFieryPhantomDash": [],
+          "DashAttackDangerousFermentation": [
+            {
+              "DamagePercentage": 0.679,
+              "DamagePercentageGrowth": 0.062,
+              "StunRatio": 0.34,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 111,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 849.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 30.83
+            }
+          ],
+          "DodgeCounterFlutteringSteps": [
+            {
+              "DamagePercentage": 2.197,
+              "DamagePercentageGrowth": 0.2,
+              "StunRatio": 1.944,
+              "StunRatioGrowth": 0.089,
+              "SpRecovery": 138,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.66
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackIntenseHeatAgingMethod": [
+            {
+              "DamagePercentage": 0.578,
+              "DamagePercentageGrowth": 0.053,
+              "StunRatio": 0.578,
+              "StunRatioGrowth": 0.027,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1446.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 52.51
+            },
+            {
+              "DamagePercentage": 0.624,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.624,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1559.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.68
+            }
+          ],
+          "EXSpecialAttackIntenseHeatStirringMethod": [
+            {
+              "DamagePercentage": 5.438,
+              "DamagePercentageGrowth": 0.495,
+              "StunRatio": 3.786,
+              "StunRatioGrowth": 0.173,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 13675.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 411.1
+            },
+            {
+              "DamagePercentage": 0.967,
+              "DamagePercentageGrowth": 0.088,
+              "StunRatio": 0.657,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2400.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 71.55
+            }
+          ],
+          "EXSpecialAttackIntenseHeatStirringMethodDoubleShot": [
+            {
+              "DamagePercentage": 9.581,
+              "DamagePercentageGrowth": 0.871,
+              "StunRatio": 5.857,
+              "StunRatioGrowth": 0.267,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 18397.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 530.24
+            },
+            {
+              "DamagePercentage": 2.871,
+              "DamagePercentageGrowth": 0.261,
+              "StunRatio": 2.078,
+              "StunRatioGrowth": 0.095,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6036.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 183.65
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackFuelFedFlame": [
+            {
+              "DamagePercentage": 6.809,
+              "DamagePercentageGrowth": 0.619,
+              "StunRatio": 2.42,
+              "StunRatioGrowth": 0.11,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24337.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 1002.96
+            }
+          ],
+          "UltimateGloriousInferno": [
+            {
+              "DamagePercentage": 20.122,
+              "DamagePercentageGrowth": 1.83,
+              "StunRatio": 1.064,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 861.16
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistEnergizingSpecialtyDrink": [
+            {
+              "DamagePercentage": 0.844,
+              "DamagePercentageGrowth": 0.077,
+              "StunRatio": 0.844,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 138,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.66
+            }
+          ],
+          "DefensiveAssistSmokyCauldron": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpScorchingDew": [
+            {
+              "DamagePercentage": 3.276,
+              "DamagePercentageGrowth": 0.298,
+              "StunRatio": 2.824,
+              "StunRatioGrowth": 0.129,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9319.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 277.22
+            }
+          ]
+        }
+      }
     },
     "Grace": {
       "id": "1181",
@@ -1327,7 +5803,182 @@
           "atk": 75,
           "anomMas": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackHighPressureSpike": [
+            {
+              "DamagePercentage": 0.551,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.18,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 61.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 470.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.597,
+              "DamagePercentageGrowth": 0.055,
+              "StunRatio": 0.347,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 118.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 910.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.248,
+              "DamagePercentageGrowth": 0.114,
+              "StunRatio": 0.716,
+              "StunRatioGrowth": 0.033,
+              "SpRecovery": 245.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1875.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.6
+            },
+            {
+              "DamagePercentage": 1.863,
+              "DamagePercentageGrowth": 0.17,
+              "StunRatio": 1.072,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 408.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3118.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.403,
+              "DamagePercentageGrowth": 0.037,
+              "StunRatio": 0.403,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 138,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1056,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeSafetyRegulation": [],
+          "DashAttackQuickInspection": [
+            {
+              "DamagePercentage": 0.333,
+              "DamagePercentageGrowth": 0.031,
+              "StunRatio": 0.167,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 57.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 437.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterViolationPenalty": [
+            {
+              "DamagePercentage": 1.642,
+              "DamagePercentageGrowth": 0.15,
+              "StunRatio": 1.505,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 156,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1193.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 43.33
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackObstructionRemoval": [
+            {
+              "DamagePercentage": 0.421,
+              "DamagePercentageGrowth": 0.039,
+              "StunRatio": 0.421,
+              "StunRatioGrowth": 0.02,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1102.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 70.03
+            }
+          ],
+          "EXSpecialAttackSuperchargedObstructionRemoval": [
+            {
+              "DamagePercentage": 1.669,
+              "DamagePercentageGrowth": 0.152,
+              "StunRatio": 1.342,
+              "StunRatioGrowth": 0.061,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5230.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 143.34
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackCollaborativeConstruction": [
+            {
+              "DamagePercentage": 5.713,
+              "DamagePercentageGrowth": 0.52,
+              "StunRatio": 1.523,
+              "StunRatioGrowth": 0.07,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22277.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 344.5
+            }
+          ],
+          "UltimateDemolitionBlastBeware": [
+            {
+              "DamagePercentage": 14.788,
+              "DamagePercentageGrowth": 1.345,
+              "StunRatio": 1.331,
+              "StunRatioGrowth": 0.061,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 895.7
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistIncidentManagement": [
+            {
+              "DamagePercentage": 0.455,
+              "DamagePercentageGrowth": 0.042,
+              "StunRatio": 0.455,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 156,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1193.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 43.33
+            }
+          ],
+          "EvasiveAssistRapidRiskResponse": [],
+          "AssistFollowUpCounterVoltNeedle": [
+            {
+              "DamagePercentage": 3.593,
+              "DamagePercentageGrowth": 0.327,
+              "StunRatio": 3.128,
+              "StunRatioGrowth": 0.143,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10628.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 320.01
+            }
+          ]
+        }
+      }
     },
     "Ellen": {
       "id": "1191",
@@ -1404,7 +6055,292 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackSawTeethTrimming": [
+            {
+              "DamagePercentage": 0.488,
+              "DamagePercentageGrowth": 0.045,
+              "StunRatio": 0.244,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 67.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 610.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.111,
+              "DamagePercentageGrowth": 0.101,
+              "StunRatio": 0.868,
+              "StunRatioGrowth": 0.04,
+              "SpRecovery": 241.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2169.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.973,
+              "DamagePercentageGrowth": 0.271,
+              "StunRatio": 2.404,
+              "StunRatioGrowth": 0.11,
+              "SpRecovery": 668.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6011.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackFlashFreezeTrimming": [
+            {
+              "DamagePercentage": 0.996,
+              "DamagePercentageGrowth": 0.091,
+              "StunRatio": 0.488,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 135.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1221,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 44.35
+            },
+            {
+              "DamagePercentage": 1.84,
+              "DamagePercentageGrowth": 0.168,
+              "StunRatio": 0.902,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 250.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2255,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 81.99
+            },
+            {
+              "DamagePercentage": 4.962,
+              "DamagePercentageGrowth": 0.452,
+              "StunRatio": 2.455,
+              "StunRatioGrowth": 0.112,
+              "SpRecovery": 642.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6138,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 223.17
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeVortex": [],
+          "DashRoamingHunt": [],
+          "DashAttackArcticAmbush": [
+            {
+              "DamagePercentage": 0.623,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.623,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 203.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1556.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.59
+            },
+            {
+              "DamagePercentage": 1.276,
+              "DamagePercentageGrowth": 0.116,
+              "StunRatio": 0.982,
+              "StunRatioGrowth": 0.045,
+              "SpRecovery": 321.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2453,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 89.19
+            },
+            {
+              "DamagePercentage": 1.582,
+              "DamagePercentageGrowth": 0.144,
+              "StunRatio": 1.217,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 398.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3041.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 110.56
+            }
+          ],
+          "FlashFreeze": [],
+          "DashAttackMonstrousWave": [
+            {
+              "DamagePercentage": 0.77,
+              "DamagePercentageGrowth": 0.07,
+              "StunRatio": 0.385,
+              "StunRatioGrowth": 0.018,
+              "SpRecovery": 126,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 962.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DashAttackColdSnap": [
+            {
+              "DamagePercentage": 1.457,
+              "DamagePercentageGrowth": 0.133,
+              "StunRatio": 0.788,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 257.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1971.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 71.63
+            }
+          ],
+          "DodgeCounterReefRock": [
+            {
+              "DamagePercentage": 1.526,
+              "DamagePercentageGrowth": 0.139,
+              "StunRatio": 2.274,
+              "StunRatioGrowth": 0.104,
+              "SpRecovery": 384.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2937,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 106.7
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackDrift": [
+            {
+              "DamagePercentage": 0.505,
+              "DamagePercentageGrowth": 0.046,
+              "StunRatio": 0.505,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1262.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 45.84
+            }
+          ],
+          "EXSpecialAttackTailSwipe": [
+            {
+              "DamagePercentage": 3.772,
+              "DamagePercentageGrowth": 0.343,
+              "StunRatio": 4.051,
+              "StunRatioGrowth": 0.185,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 14036,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 403.73
+            }
+          ],
+          "EXSpecialAttackSharknami": [
+            {
+              "DamagePercentage": 5.533,
+              "DamagePercentageGrowth": 0.503,
+              "StunRatio": 3.717,
+              "StunRatioGrowth": 0.169,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 13070.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 372.19
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackAvalanche": [
+            {
+              "DamagePercentage": 7.946,
+              "DamagePercentageGrowth": 0.723,
+              "StunRatio": 3.557,
+              "StunRatioGrowth": 0.162,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 27181,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 522.83
+            }
+          ],
+          "UltimateEndlessWinter": [
+            {
+              "DamagePercentage": 18.908,
+              "DamagePercentageGrowth": 1.719,
+              "StunRatio": 1.852,
+              "StunRatioGrowth": 0.085,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 168.33
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistSharkSentinel": [
+            {
+              "DamagePercentage": 1.211,
+              "DamagePercentageGrowth": 0.111,
+              "StunRatio": 1.211,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 396.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3027.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 110.03
+            }
+          ],
+          "DefensiveAssistWavefrontImpact": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpSharkCruiser": [
+            {
+              "DamagePercentage": 4.379,
+              "DamagePercentageGrowth": 0.399,
+              "StunRatio": 3.848,
+              "StunRatioGrowth": 0.175,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 12276,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 373.92
+            }
+          ]
+        }
+      }
     },
     "Harumasa": {
       "id": "1201",
@@ -1481,7 +6417,290 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackCloudPiercer": [
+            {
+              "DamagePercentage": 0.424,
+              "DamagePercentageGrowth": 0.039,
+              "StunRatio": 0.265,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 86.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 662.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.398,
+              "DamagePercentageGrowth": 0.037,
+              "StunRatio": 0.443,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 145,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1108.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.709,
+              "DamagePercentageGrowth": 0.065,
+              "StunRatio": 0.661,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 216.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1652.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.901,
+              "DamagePercentageGrowth": 0.082,
+              "StunRatio": 0.896,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 293,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2238.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 49.17
+            },
+            {
+              "DamagePercentage": 1.329,
+              "DamagePercentageGrowth": 0.121,
+              "StunRatio": 1.154,
+              "StunRatioGrowth": 0.053,
+              "SpRecovery": 377.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2887.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 65.84
+            }
+          ],
+          "BasicAttackCloudPiercerDrift": [
+            {
+              "DamagePercentage": 0.695,
+              "DamagePercentageGrowth": 0.064,
+              "StunRatio": 0.487,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 159.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1218.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "BasicAttackFallingFeather": [
+            {
+              "DamagePercentage": 1.054,
+              "DamagePercentageGrowth": 0.096,
+              "StunRatio": 0.527,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 172.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1317.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 33.51
+            }
+          ],
+          "BasicAttackHaOtoNoYa": [
+            {
+              "DamagePercentage": 0.159,
+              "DamagePercentageGrowth": 0.015,
+              "StunRatio": 0,
+              "StunRatioGrowth": 0,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeQuickFlash": [],
+          "DashAttackHitenNoTsuru": [
+            {
+              "DamagePercentage": 0.807,
+              "DamagePercentageGrowth": 0.074,
+              "StunRatio": 0.404,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 132.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1009.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterHiddenEdge": [
+            {
+              "DamagePercentage": 2.196,
+              "DamagePercentageGrowth": 0.2,
+              "StunRatio": 1.943,
+              "StunRatioGrowth": 0.089,
+              "SpRecovery": 275.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 53.64
+            }
+          ],
+          "DashAttackHitenNoTsuruSlash": [
+            {
+              "DamagePercentage": 1.623,
+              "DamagePercentageGrowth": 0.148,
+              "StunRatio": 0.66,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 108,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1650,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 41.97
+            },
+            {
+              "DamagePercentage": 1.666,
+              "DamagePercentageGrowth": 0.152,
+              "StunRatio": 0.459,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 75.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1146.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 29.16
+            },
+            {
+              "DamagePercentage": 1.896,
+              "DamagePercentageGrowth": 0.173,
+              "StunRatio": 0.495,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 81,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1237.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 31.47
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackNowhereToHide": [
+            {
+              "DamagePercentage": 0.523,
+              "DamagePercentageGrowth": 0.048,
+              "StunRatio": 0.523,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1309,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 33.26
+            }
+          ],
+          "EXSpecialAttackNowhereToRun": [
+            {
+              "DamagePercentage": 4.493,
+              "DamagePercentageGrowth": 0.409,
+              "StunRatio": 4.49,
+              "StunRatioGrowth": 0.205,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16478,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 319.11
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackKaiHanare": [
+            {
+              "DamagePercentage": 5.176,
+              "DamagePercentageGrowth": 0.471,
+              "StunRatio": 1.834,
+              "StunRatioGrowth": 0.084,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22871.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 256.33
+            }
+          ],
+          "UltimateZanshin": [
+            {
+              "DamagePercentage": 19.539,
+              "DamagePercentageGrowth": 1.777,
+              "StunRatio": 1.069,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 61.81
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistBracedBow": [
+            {
+              "DamagePercentage": 0.843,
+              "DamagePercentageGrowth": 0.077,
+              "StunRatio": 0.843,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 275.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 53.64
+            }
+          ],
+          "DefensiveAssistYugamae": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.476,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.952,
+              "StunRatioGrowth": 0.135,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.192,
+              "StunRatioGrowth": 0.055,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpYugamaeSlash": [
+            {
+              "DamagePercentage": 3.071,
+              "DamagePercentageGrowth": 0.28,
+              "StunRatio": 2.633,
+              "StunRatioGrowth": 0.12,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8769.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 181.45
+            }
+          ]
+        }
+      }
     },
     "Rina": {
       "id": "1211",
@@ -1558,7 +6777,184 @@
           "atk": 75,
           "pen_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackWhackTheDimwit": [
+            {
+              "DamagePercentage": 0.44,
+              "DamagePercentageGrowth": 0.04,
+              "StunRatio": 0.245,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 83.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 640.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.114,
+              "DamagePercentageGrowth": 0.102,
+              "StunRatio": 0.884,
+              "StunRatioGrowth": 0.041,
+              "SpRecovery": 302.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1652.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.171,
+              "DamagePercentageGrowth": 0.107,
+              "StunRatio": 0.966,
+              "StunRatioGrowth": 0.044,
+              "SpRecovery": 331,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3861,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 83.63
+            },
+            {
+              "DamagePercentage": 1.839,
+              "DamagePercentageGrowth": 0.168,
+              "StunRatio": 1.468,
+              "StunRatioGrowth": 0.067,
+              "SpRecovery": 559,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3418.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 104.74
+            }
+          ],
+          "BasicAttackShooTheFool": [
+            {
+              "DamagePercentage": 3.151,
+              "DamagePercentageGrowth": 0.287,
+              "StunRatio": 3.151,
+              "StunRatioGrowth": 0.144,
+              "SpRecovery": 1080.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8252.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 300.03
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeDressAdjustment": [],
+          "DashAttackSuddenSurprise": [
+            {
+              "DamagePercentage": 1.05,
+              "DamagePercentageGrowth": 0.096,
+              "StunRatio": 0.525,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 180,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1375,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterBangbooCallback": [
+            {
+              "DamagePercentage": 2.276,
+              "DamagePercentageGrowth": 0.207,
+              "StunRatio": 2.276,
+              "StunRatioGrowth": 0.104,
+              "SpRecovery": 420.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3212,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 116.7
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackBeatTheBlockhead": [
+            {
+              "DamagePercentage": 0.613,
+              "DamagePercentageGrowth": 0.056,
+              "StunRatio": 0.613,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1606,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 58.35
+            }
+          ],
+          "EXSpecialAttackDimwitDisappearingTrick": [
+            {
+              "DamagePercentage": 5.46,
+              "DamagePercentageGrowth": 0.497,
+              "StunRatio": 4.445,
+              "StunRatioGrowth": 0.203,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11459.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 471.62
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackCodeOfConduct": [
+            {
+              "DamagePercentage": 10.13,
+              "DamagePercentageGrowth": 0.921,
+              "StunRatio": 1.751,
+              "StunRatioGrowth": 0.08,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22874.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 366.2
+            }
+          ],
+          "UltimateTheQueensAttendants": [
+            {
+              "DamagePercentage": 21.167,
+              "DamagePercentageGrowth": 1.925,
+              "StunRatio": 1.138,
+              "StunRatioGrowth": 0.052,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 108.37
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistDupleMeterAllemande": [
+            {
+              "DamagePercentage": 1.226,
+              "DamagePercentageGrowth": 0.112,
+              "StunRatio": 1.226,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 420.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3212,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 116.7
+            }
+          ],
+          "EvasiveAssistTripleMeterCourante": [],
+          "AssistFollowUpQuadrupleMeterGavotte": [
+            {
+              "DamagePercentage": 3.494,
+              "DamagePercentageGrowth": 0.318,
+              "StunRatio": 3.036,
+              "StunRatioGrowth": 0.138,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10351,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 310.92
+            }
+          ]
+        }
+      }
     },
     "Yanagi": {
       "id": "1221",
@@ -1635,7 +7031,285 @@
           "atk": 75,
           "anomMas": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackTsukuyomiKagura": [],
+          "StanceJougen": [
+            {
+              "DamagePercentage": 0.566,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.278,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 100.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 695.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.997,
+              "DamagePercentageGrowth": 0.091,
+              "StunRatio": 0.681,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 247.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1702.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.131,
+              "DamagePercentageGrowth": 0.103,
+              "StunRatio": 0.694,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 252.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1735.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 79.91
+            },
+            {
+              "DamagePercentage": 1.266,
+              "DamagePercentageGrowth": 0.116,
+              "StunRatio": 0.776,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 282.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1941.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 89.42
+            },
+            {
+              "DamagePercentage": 2.369,
+              "DamagePercentageGrowth": 0.216,
+              "StunRatio": 1.452,
+              "StunRatioGrowth": 0.066,
+              "SpRecovery": 528,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3630,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 167.35
+            }
+          ],
+          "StanceKagen": [
+            {
+              "DamagePercentage": 1.131,
+              "DamagePercentageGrowth": 0.103,
+              "StunRatio": 0.555,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 201.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1388.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.292,
+              "DamagePercentageGrowth": 0.118,
+              "StunRatio": 0.931,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 338.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2329.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.728,
+              "DamagePercentageGrowth": 0.067,
+              "StunRatio": 0.446,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 162.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1116.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 51.38
+            },
+            {
+              "DamagePercentage": 1.077,
+              "DamagePercentageGrowth": 0.098,
+              "StunRatio": 0.661,
+              "StunRatioGrowth": 0.031,
+              "SpRecovery": 240.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1652.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.07
+            },
+            {
+              "DamagePercentage": 2.718,
+              "DamagePercentageGrowth": 0.248,
+              "StunRatio": 1.667,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 605.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4166.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 192.04
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeWanderingBreeze": [],
+          "DashAttackFleetingFlight": [
+            {
+              "DamagePercentage": 0.504,
+              "DamagePercentageGrowth": 0.046,
+              "StunRatio": 0.454,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 165,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1135.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterRapidRetaliation": [
+            {
+              "DamagePercentage": 2.316,
+              "DamagePercentageGrowth": 0.211,
+              "StunRatio": 1.832,
+              "StunRatioGrowth": 0.084,
+              "SpRecovery": 306.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2106.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.52
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackRuten": [
+            {
+              "DamagePercentage": 1.174,
+              "DamagePercentageGrowth": 0.107,
+              "StunRatio": 1.057,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2642.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 96
+            }
+          ],
+          "EXSpecialAttackGekkaRuten": [
+            {
+              "DamagePercentage": 1.638,
+              "DamagePercentageGrowth": 0.149,
+              "StunRatio": 1.271,
+              "StunRatioGrowth": 0.058,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4193.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 143.5
+            },
+            {
+              "DamagePercentage": 3.778,
+              "DamagePercentageGrowth": 0.344,
+              "StunRatio": 1.096,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 7634,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 268.54
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackCelestialHarmony": [
+            {
+              "DamagePercentage": 5.931,
+              "DamagePercentageGrowth": 0.54,
+              "StunRatio": 1.783,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 21411.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 359.58
+            }
+          ],
+          "UltimateRaieiTenge": [
+            {
+              "DamagePercentage": 15.118,
+              "DamagePercentageGrowth": 1.375,
+              "StunRatio": 0.975,
+              "StunRatioGrowth": 0.045,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 904.39
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistBladeOfElegance": [
+            {
+              "DamagePercentage": 0.936,
+              "DamagePercentageGrowth": 0.086,
+              "StunRatio": 0.842,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 306.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2106.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.52
+            }
+          ],
+          "DefensiveAssistRadiantReversal": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.442,
+              "StunRatioGrowth": 0.111,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.086,
+              "StunRatioGrowth": 0.141,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.502,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpWeepingWillowStab": [
+            {
+              "DamagePercentage": 4.071,
+              "DamagePercentageGrowth": 0.371,
+              "StunRatio": 3.206,
+              "StunRatioGrowth": 0.146,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10307,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 312.23
+            }
+          ]
+        }
+      }
     },
     "ZhuYuan": {
       "id": "1241",
@@ -1712,7 +7386,274 @@
           "atk": 75,
           "crit_dmg_": 0.288
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackDontMove": [
+            {
+              "DamagePercentage": 0.431,
+              "DamagePercentageGrowth": 0.04,
+              "StunRatio": 0.216,
+              "StunRatioGrowth": 0.01,
+              "SpRecovery": 70.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 539,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.264,
+              "DamagePercentageGrowth": 0.115,
+              "StunRatio": 0.973,
+              "StunRatioGrowth": 0.045,
+              "SpRecovery": 318.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2431,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 104.77
+            },
+            {
+              "DamagePercentage": 1.373,
+              "DamagePercentageGrowth": 0.125,
+              "StunRatio": 0.947,
+              "StunRatioGrowth": 0.044,
+              "SpRecovery": 309.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2367.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.51,
+              "DamagePercentageGrowth": 0.138,
+              "StunRatio": 1.243,
+              "StunRatioGrowth": 0.057,
+              "SpRecovery": 406.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3107.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 59.12
+            },
+            {
+              "DamagePercentage": 1.622,
+              "DamagePercentageGrowth": 0.148,
+              "StunRatio": 1.392,
+              "StunRatioGrowth": 0.064,
+              "SpRecovery": 455.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3478.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 60.05
+            }
+          ],
+          "BasicAttackPleaseDoNotResist": [
+            {
+              "DamagePercentage": 0.537,
+              "DamagePercentageGrowth": 0.049,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 99.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 759,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.537,
+              "DamagePercentageGrowth": 0.049,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 183.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1402.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.609,
+              "DamagePercentageGrowth": 0.147,
+              "StunRatio": 1.787,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 490.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3748.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.359,
+              "DamagePercentageGrowth": 0.124,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 99.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 759,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 54.15
+            },
+            {
+              "DamagePercentage": 1.359,
+              "DamagePercentageGrowth": 0.124,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 183.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1402.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 54.15
+            },
+            {
+              "DamagePercentage": 4.077,
+              "DamagePercentageGrowth": 0.371,
+              "StunRatio": 1.787,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 490.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3748.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 162.45
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeTacticalDetour": [],
+          "DashAttackFirepowerOffensive": [
+            {
+              "DamagePercentage": 0.551,
+              "DamagePercentageGrowth": 0.051,
+              "StunRatio": 0.276,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 90.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 690.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 50
+            }
+          ],
+          "DashAttackOverwhelmingFirepower": [
+            {
+              "DamagePercentage": 0.537,
+              "DamagePercentageGrowth": 0.049,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 117.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 896.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.359,
+              "DamagePercentageGrowth": 0.124,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 234.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1790.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 54.15
+            }
+          ],
+          "DodgeCounterFireBlast": [
+            {
+              "DamagePercentage": 1.768,
+              "DamagePercentageGrowth": 0.161,
+              "StunRatio": 1.614,
+              "StunRatioGrowth": 0.074,
+              "SpRecovery": 168.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1287,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 46.7
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackBuckshotBlast": [
+            {
+              "DamagePercentage": 0.184,
+              "DamagePercentageGrowth": 0.017,
+              "StunRatio": 0.184,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 459.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 16.65
+            }
+          ],
+          "EXSpecialAttackFullBarrage": [
+            {
+              "DamagePercentage": 5.874,
+              "DamagePercentageGrowth": 0.534,
+              "StunRatio": 4.8,
+              "StunRatioGrowth": 0.219,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 17371.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 485.12
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackEradicationMode": [
+            {
+              "DamagePercentage": 5.875,
+              "DamagePercentageGrowth": 0.535,
+              "StunRatio": 1.486,
+              "StunRatioGrowth": 0.068,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22002.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 334.5
+            }
+          ],
+          "UltimateMaxEradicationMode": [
+            {
+              "DamagePercentage": 19.776,
+              "DamagePercentageGrowth": 1.798,
+              "StunRatio": 1.251,
+              "StunRatioGrowth": 0.0627,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 103.33
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistCoveringShot": [
+            {
+              "DamagePercentage": 0.514,
+              "DamagePercentageGrowth": 0.047,
+              "StunRatio": 0.514,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 168.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1287,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 46.7
+            }
+          ],
+          "EvasiveAssistGuardedBackup": [],
+          "AssistFollowUpDefensiveCounter": [
+            {
+              "DamagePercentage": 3.558,
+              "DamagePercentageGrowth": 0.324,
+              "StunRatio": 3.086,
+              "StunRatioGrowth": 0.141,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 10076,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 301.97
+            }
+          ]
+        }
+      }
     },
     "QingYi": {
       "id": "1251",
@@ -1789,7 +7730,287 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackPenultimate": [
+            {
+              "DamagePercentage": 0.472,
+              "DamagePercentageGrowth": 0.043,
+              "StunRatio": 0.236,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 77.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 591.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.103,
+              "DamagePercentageGrowth": 0.101,
+              "StunRatio": 0.552,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 180.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1380.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.221,
+              "DamagePercentageGrowth": 0.111,
+              "StunRatio": 0.822,
+              "StunRatioGrowth": 0.038,
+              "SpRecovery": 268.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2392.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.176,
+              "DamagePercentageGrowth": 0.016,
+              "StunRatio": 0.191,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 48,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 368.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 13.33
+            },
+            {
+              "DamagePercentage": 1.064,
+              "DamagePercentageGrowth": 0.097,
+              "StunRatio": 1.063,
+              "StunRatioGrowth": 0.049,
+              "SpRecovery": 347.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2656.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.54
+            },
+            {
+              "DamagePercentage": 2.344,
+              "DamagePercentageGrowth": 0.214,
+              "StunRatio": 2.047,
+              "StunRatioGrowth": 0.094,
+              "SpRecovery": 669.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5117.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 153.99
+            }
+          ],
+          "BasicAttackEnchantedBlossoms": [
+            {
+              "DamagePercentage": 0.856,
+              "DamagePercentageGrowth": 0.078,
+              "StunRatio": 0.856,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 279.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2139.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 77.74
+            }
+          ],
+          "FlashConnect": [],
+          "BasicAttackEnchantedMoonlitBlossoms": [
+            {
+              "DamagePercentage": 4.487,
+              "DamagePercentageGrowth": 0.408,
+              "StunRatio": 2.719,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 684.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5230.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 190.13
+            },
+            {
+              "DamagePercentage": 3.944,
+              "DamagePercentageGrowth": 0.359,
+              "StunRatio": 2.176,
+              "StunRatioGrowth": 0.099,
+              "SpRecovery": 547.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4185.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 152.14
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeSwanSong": [],
+          "DashAttackBreach": [
+            {
+              "DamagePercentage": 0.495,
+              "DamagePercentageGrowth": 0.045,
+              "StunRatio": 0.248,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 81,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 618.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterLingeringSentiments": [
+            {
+              "DamagePercentage": 2.84,
+              "DamagePercentageGrowth": 0.259,
+              "StunRatio": 1.904,
+              "StunRatioGrowth": 0.087,
+              "SpRecovery": 438.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3346.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 121.66
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSunlitGlory": [
+            {
+              "DamagePercentage": 0.624,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.624,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1559.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.68
+            }
+          ],
+          "EXSpecialAttackMoonlitBegonia": [
+            {
+              "DamagePercentage": 1.507,
+              "DamagePercentageGrowth": 0.137,
+              "StunRatio": 1.111,
+              "StunRatioGrowth": 0.051,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4086.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 124.65
+            },
+            {
+              "DamagePercentage": 2.11,
+              "DamagePercentageGrowth": 0.192,
+              "StunRatio": 1.555,
+              "StunRatioGrowth": 0.071,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5720,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 174.51
+            },
+            {
+              "DamagePercentage": 2.411,
+              "DamagePercentageGrowth": 0.22,
+              "StunRatio": 1.777,
+              "StunRatioGrowth": 0.081,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6536.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 199.44
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackTranquilSerenade": [
+            {
+              "DamagePercentage": 6.479,
+              "DamagePercentageGrowth": 0.589,
+              "StunRatio": 2.09,
+              "StunRatioGrowth": 0.095,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 23512.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 389.46
+            }
+          ],
+          "UltimateEightSoundsOfGanzhou": [
+            {
+              "DamagePercentage": 16.707,
+              "DamagePercentageGrowth": 1.519,
+              "StunRatio": 10.971,
+              "StunRatioGrowth": 0.499,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 215.03
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistWindThroughThePines": [
+            {
+              "DamagePercentage": 1.339,
+              "DamagePercentageGrowth": 0.122,
+              "StunRatio": 1.339,
+              "StunRatioGrowth": 0.061,
+              "SpRecovery": 438.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3346.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 121.66
+            }
+          ],
+          "DefensiveAssistGracefulEmbellishment": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.493,
+              "StunRatioGrowth": 0.114,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.043,
+              "StunRatioGrowth": 0.139,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.283,
+              "StunRatioGrowth": 0.059,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpSongOfTheClearRiver": [
+            {
+              "DamagePercentage": 3.764,
+              "DamagePercentageGrowth": 0.343,
+              "StunRatio": 2.79,
+              "StunRatioGrowth": 0.127,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4540.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 320.01
+            }
+          ]
+        }
+      }
     },
     "Jane": {
       "id": "1261",
@@ -1866,7 +8087,313 @@
           "atk": 75,
           "anomMas": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackDancingBlades": [
+            {
+              "DamagePercentage": 0.361,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.153,
+              "StunRatioGrowth": 0.007,
+              "SpRecovery": 50.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 382.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 21.34
+            },
+            {
+              "DamagePercentage": 0.623,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.443,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 144.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1105.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 52.06
+            },
+            {
+              "DamagePercentage": 0.835,
+              "DamagePercentageGrowth": 0.076,
+              "StunRatio": 0.595,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 194.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1487.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 68.78
+            },
+            {
+              "DamagePercentage": 1.634,
+              "DamagePercentageGrowth": 0.149,
+              "StunRatio": 1.097,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 358.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2741.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 127.45
+            },
+            {
+              "DamagePercentage": 0.988,
+              "DamagePercentageGrowth": 0.09,
+              "StunRatio": 0.687,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 224.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1716,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.71
+            },
+            {
+              "DamagePercentage": 2.913,
+              "DamagePercentageGrowth": 0.265,
+              "StunRatio": 2,
+              "StunRatioGrowth": 0.091,
+              "SpRecovery": 654.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4999.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 226.62
+            }
+          ],
+          "Passion": [],
+          "BasicAttackSalchowJump": [
+            {
+              "DamagePercentage": 3.008,
+              "DamagePercentageGrowth": 0.274,
+              "StunRatio": 2.292,
+              "StunRatioGrowth": 0.105,
+              "SpRecovery": 749.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5728.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 273.4
+            },
+            {
+              "DamagePercentage": 1.613,
+              "DamagePercentageGrowth": 0.147,
+              "StunRatio": 1.229,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 402,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3071.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 146.56
+            }
+          ]
+        },
+        "dodge": {
+          "DodgePhantom": [],
+          "DashAttackEdgeJump": [
+            {
+              "DamagePercentage": 0.715,
+              "DamagePercentageGrowth": 0.065,
+              "StunRatio": 0.358,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 117,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 893.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 32.5
+            },
+            {
+              "DamagePercentage": 0.715,
+              "DamagePercentageGrowth": 0.065,
+              "StunRatio": 0.358,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 117,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 893.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 32.5
+            }
+          ],
+          "DashAttackPhantomThrust": [
+            {
+              "DamagePercentage": 1.045,
+              "DamagePercentageGrowth": 0.095,
+              "StunRatio": 0.523,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 171,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1306.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 47.48
+            }
+          ],
+          "DodgeCounterSwiftShadow": [
+            {
+              "DamagePercentage": 3.412,
+              "DamagePercentageGrowth": 0.311,
+              "StunRatio": 2.292,
+              "StunRatioGrowth": 0.105,
+              "SpRecovery": 390,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2981,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 177.67
+            },
+            {
+              "DamagePercentage": 3.412,
+              "DamagePercentageGrowth": 0.311,
+              "StunRatio": 2.292,
+              "StunRatioGrowth": 0.105,
+              "SpRecovery": 390,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2981,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 177.67
+            }
+          ],
+          "DodgeCounterSwiftShadowDance": [
+            {
+              "DamagePercentage": 3.87,
+              "DamagePercentageGrowth": 0.352,
+              "StunRatio": 2.475,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 449.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3437.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 194.31
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackAerialSweep": [
+            {
+              "DamagePercentage": 0.578,
+              "DamagePercentageGrowth": 0.053,
+              "StunRatio": 0.578,
+              "StunRatioGrowth": 0.027,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1443.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 52.5
+            }
+          ],
+          "EXSpecialAttackAerialSweepClearout": [
+            {
+              "DamagePercentage": 5.747,
+              "DamagePercentageGrowth": 0.523,
+              "StunRatio": 4.681,
+              "StunRatioGrowth": 0.213,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 17030.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 473.96
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackFlowersOfSin": [
+            {
+              "DamagePercentage": 6.326,
+              "DamagePercentageGrowth": 0.576,
+              "StunRatio": 2.376,
+              "StunRatioGrowth": 0.108,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24887.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 439.46
+            }
+          ],
+          "UltimateFinalCurtain": [
+            {
+              "DamagePercentage": 14.706,
+              "DamagePercentageGrowth": 1.337,
+              "StunRatio": 1.865,
+              "StunRatioGrowth": 0.085,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 966.58
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistDarkThorn": [
+            {
+              "DamagePercentage": 1.192,
+              "DamagePercentageGrowth": 0.109,
+              "StunRatio": 1.192,
+              "StunRatioGrowth": 0.055,
+              "SpRecovery": 390,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2981,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 108.33
+            }
+          ],
+          "QuickAssistLutzJump": [
+            {
+              "DamagePercentage": 1.375,
+              "DamagePercentageGrowth": 0.125,
+              "StunRatio": 1.375,
+              "StunRatioGrowth": 0.063,
+              "SpRecovery": 449.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3437.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 124.96
+            }
+          ],
+          "DefensiveAssistLastDefense": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpGaleSweep": [
+            {
+              "DamagePercentage": 3.455,
+              "DamagePercentageGrowth": 0.315,
+              "StunRatio": 2.99,
+              "StunRatioGrowth": 0.136,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9801,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 292.92
+            }
+          ]
+        }
+      }
     },
     "Seth": {
       "id": "1271",
@@ -1943,7 +8470,240 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackLightningStrike": [
+            {
+              "DamagePercentage": 0.362,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.181,
+              "StunRatioGrowth": 0.009,
+              "SpRecovery": 65.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 497.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.565,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.451,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 162.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1240.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.933,
+              "DamagePercentageGrowth": 0.176,
+              "StunRatio": 1.513,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 544.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4160.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.974,
+              "DamagePercentageGrowth": 0.089,
+              "StunRatio": 0.805,
+              "StunRatioGrowth": 0.037,
+              "SpRecovery": 289.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2213.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 80.41
+            }
+          ],
+          "BasicAttackLightningStrikeElectrified": [
+            {
+              "DamagePercentage": 3.828,
+              "DamagePercentageGrowth": 0.348,
+              "StunRatio": 1.617,
+              "StunRatioGrowth": 0.074,
+              "SpRecovery": 582.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4446.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 161.68
+            },
+            {
+              "DamagePercentage": 4.242,
+              "DamagePercentageGrowth": 0.386,
+              "StunRatio": 1.455,
+              "StunRatioGrowth": 0.067,
+              "SpRecovery": 476,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3638.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 132.2
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeEvasionManeuver": [],
+          "DashAttackThunderAssault": [
+            {
+              "DamagePercentage": 1.1,
+              "DamagePercentageGrowth": 0.1,
+              "StunRatio": 0.55,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 198,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1512.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterRetreatToAdvance": [
+            {
+              "DamagePercentage": 2.3,
+              "DamagePercentageGrowth": 0.21,
+              "StunRatio": 2,
+              "StunRatioGrowth": 0.091,
+              "SpRecovery": 360,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2750,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 100
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackThunderShieldRush": [
+            {
+              "DamagePercentage": 0.692,
+              "DamagePercentageGrowth": 0.063,
+              "StunRatio": 0.692,
+              "StunRatioGrowth": 0.032,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1903,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 69.18
+            }
+          ],
+          "EXSpecialAttackThunderShieldRushHighVoltage": [
+            {
+              "DamagePercentage": 6.46,
+              "DamagePercentageGrowth": 0.588,
+              "StunRatio": 5.404,
+              "StunRatioGrowth": 0.246,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 20671.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 593.16
+            },
+            {
+              "DamagePercentage": 9.998,
+              "DamagePercentageGrowth": 0.909,
+              "StunRatio": 8.49,
+              "StunRatioGrowth": 0.386,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 31641.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 924.38
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackFinalJudgement": [
+            {
+              "DamagePercentage": 7.041,
+              "DamagePercentageGrowth": 0.641,
+              "StunRatio": 3.051,
+              "StunRatioGrowth": 0.139,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 26677.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 504.53
+            }
+          ],
+          "UltimateJusticePrevails": [
+            {
+              "DamagePercentage": 20.243,
+              "DamagePercentageGrowth": 1.841,
+              "StunRatio": 4.033,
+              "StunRatioGrowth": 0.184,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 403.29
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistArmedSupport": [
+            {
+              "DamagePercentage": 1,
+              "DamagePercentageGrowth": 0.091,
+              "StunRatio": 1,
+              "StunRatioGrowth": 0.046,
+              "SpRecovery": 360,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2750,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 100
+            }
+          ],
+          "DefensiveAssistThundershield": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpPublicSecurityRuling": [
+            {
+              "DamagePercentage": 4.285,
+              "DamagePercentageGrowth": 0.39,
+              "StunRatio": 3.78,
+              "StunRatioGrowth": 0.172,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 13169.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 403.22
+            }
+          ]
+        }
+      }
     },
     "Piper": {
       "id": "1281",
@@ -2020,7 +8780,253 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackLoadUpAndRollOut": [
+            {
+              "DamagePercentage": 0.59,
+              "DamagePercentageGrowth": 0.054,
+              "StunRatio": 0.295,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 106.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 811.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 29.48
+            },
+            {
+              "DamagePercentage": 0.788,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.645,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 231.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1773.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 64.4
+            },
+            {
+              "DamagePercentage": 1.501,
+              "DamagePercentageGrowth": 0.137,
+              "StunRatio": 1.219,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 438.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3352.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 121.89
+            },
+            {
+              "DamagePercentage": 3.206,
+              "DamagePercentageGrowth": 0.292,
+              "StunRatio": 2.522,
+              "StunRatioGrowth": 0.115,
+              "SpRecovery": 907.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6935.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 252.11
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeHandbrakeDrift": [],
+          "DashAttackPedalToTheMetal": [
+            {
+              "DamagePercentage": 0.901,
+              "DamagePercentageGrowth": 0.082,
+              "StunRatio": 0.451,
+              "StunRatioGrowth": 0.021,
+              "SpRecovery": 162.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1240.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 45.01
+            }
+          ],
+          "DodgeCounterPowerDrift": [
+            {
+              "DamagePercentage": 2.69,
+              "DamagePercentageGrowth": 0.245,
+              "StunRatio": 2.3,
+              "StunRatioGrowth": 0.105,
+              "SpRecovery": 467.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3575,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 129.96
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackTireSpin": [
+            {
+              "DamagePercentage": 2.717,
+              "DamagePercentageGrowth": 0.247,
+              "StunRatio": 2.717,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3737.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 271.66
+            }
+          ],
+          "SpecialAttackOneTrillionTons": [
+            {
+              "DamagePercentage": 0.934,
+              "DamagePercentageGrowth": 0.085,
+              "StunRatio": 0.934,
+              "StunRatioGrowth": 0.043,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2568.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 93.33
+            },
+            {
+              "DamagePercentage": 1.034,
+              "DamagePercentageGrowth": 0.094,
+              "StunRatio": 1.034,
+              "StunRatioGrowth": 0.047,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2843.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 103.36
+            },
+            {
+              "DamagePercentage": 2.35,
+              "DamagePercentageGrowth": 0.214,
+              "StunRatio": 2.35,
+              "StunRatioGrowth": 0.107,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 6462.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 235
+            }
+          ],
+          "EXSpecialAttackEngineSpin": [
+            {
+              "DamagePercentage": 1.871,
+              "DamagePercentageGrowth": 0.171,
+              "StunRatio": 1.096,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3709.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 161.25
+            }
+          ],
+          "EXSpecialAttackReallyHeavy": [
+            {
+              "DamagePercentage": 6.129,
+              "DamagePercentageGrowth": 0.558,
+              "StunRatio": 3.968,
+              "StunRatioGrowth": 0.181,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 12619.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 532.55
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackBuckleUp": [
+            {
+              "DamagePercentage": 6.523,
+              "DamagePercentageGrowth": 0.593,
+              "StunRatio": 2.533,
+              "StunRatioGrowth": 0.116,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 25253.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 452.79
+            }
+          ],
+          "UltimateHoldOnTight": [
+            {
+              "DamagePercentage": 16.604,
+              "DamagePercentageGrowth": 1.51,
+              "StunRatio": 3.283,
+              "StunRatioGrowth": 0.15,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 1127.54
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistBrakeTap": [
+            {
+              "DamagePercentage": 1.3,
+              "DamagePercentageGrowth": 0.119,
+              "StunRatio": 1.3,
+              "StunRatioGrowth": 0.06,
+              "SpRecovery": 467.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3575,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 129.96
+            }
+          ],
+          "DefensiveAssistEmergencyBrake": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.467,
+              "StunRatioGrowth": 0.113,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.117,
+              "StunRatioGrowth": 0.142,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.517,
+              "StunRatioGrowth": 0.069,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpOvertakingManeuver": [
+            {
+              "DamagePercentage": 4.005,
+              "DamagePercentageGrowth": 0.365,
+              "StunRatio": 3.52,
+              "StunRatioGrowth": 0.16,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 12344.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 376.22
+            }
+          ]
+        }
+      }
     },
     "Astra": {
       "id": "1311",
@@ -2097,7 +9103,198 @@
           "atk": 75,
           "enerRegen": 36
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackCapriccio": [
+            {
+              "DamagePercentage": 0.438,
+              "DamagePercentageGrowth": 0.04,
+              "StunRatio": 0.413,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 67.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1031.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 37.45
+            },
+            {
+              "DamagePercentage": 0.591,
+              "DamagePercentageGrowth": 0.054,
+              "StunRatio": 0.564,
+              "StunRatioGrowth": 0.026,
+              "SpRecovery": 92.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1410.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 51.25
+            },
+            {
+              "DamagePercentage": 1.209,
+              "DamagePercentageGrowth": 0.11,
+              "StunRatio": 1.148,
+              "StunRatioGrowth": 0.053,
+              "SpRecovery": 187.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2871,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 104.31
+            },
+            {
+              "DamagePercentage": 2.707,
+              "DamagePercentageGrowth": 0.247,
+              "StunRatio": 2.194,
+              "StunRatioGrowth": 0.1,
+              "SpRecovery": 359,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5483.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 199.39
+            }
+          ],
+          "BasicAttackInterlude": [
+            {
+              "DamagePercentage": 0.55,
+              "DamagePercentageGrowth": 0.05,
+              "StunRatio": 0.484,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 63.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 484,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.59
+            }
+          ],
+          "BasicAttackChorus": [],
+          "BasicAttackFinale": []
+        },
+        "dodge": {
+          "DodgeMiniWaltz": [],
+          "DashAttackLunarEclipseMelody": [
+            {
+              "DamagePercentage": 0.807,
+              "DamagePercentageGrowth": 0.074,
+              "StunRatio": 0.404,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 132,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1009.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 36.64
+            }
+          ],
+          "DodgeCounterUmbrellaWaltz": [
+            {
+              "DamagePercentage": 1.1,
+              "DamagePercentageGrowth": 0.1,
+              "StunRatio": 0.968,
+              "StunRatioGrowth": 0.044,
+              "SpRecovery": 126.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 968,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 35.18
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackWindchimesOaths": [
+            {
+              "DamagePercentage": 0.55,
+              "DamagePercentageGrowth": 0.05,
+              "StunRatio": 0.484,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 484,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.59
+            }
+          ],
+          "IdyllicCadenza": [],
+          "Chord": [
+            {
+              "DamagePercentage": 0.46,
+              "DamagePercentageGrowth": 0.042,
+              "StunRatio": 0,
+              "StunRatioGrowth": 0,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 29.77
+            },
+            {
+              "DamagePercentage": 0.24,
+              "DamagePercentageGrowth": 0.022,
+              "StunRatio": 0,
+              "StunRatioGrowth": 0,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 10.32
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackTipsyConcerto": [
+            {
+              "DamagePercentage": 6.718,
+              "DamagePercentageGrowth": 0.611,
+              "StunRatio": 2.329,
+              "StunRatioGrowth": 0.106,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 24109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 411.16
+            }
+          ],
+          "UltimateFantasianSonata": [
+            {
+              "DamagePercentage": 19.598,
+              "DamagePercentageGrowth": 1.782,
+              "StunRatio": 2.383,
+              "StunRatioGrowth": 0.109,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 216.63
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistOneLuminousSky": [
+            {
+              "DamagePercentage": 0.55,
+              "DamagePercentageGrowth": 0.05,
+              "StunRatio": 0.484,
+              "StunRatioGrowth": 0.022,
+              "SpRecovery": 63.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 484,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.59
+            }
+          ],
+          "EvasiveAssistTwoHearts": [],
+          "AssistFollowUpThreeLifetimesOfFate": [
+            {
+              "DamagePercentage": 3.046,
+              "DamagePercentageGrowth": 0.277,
+              "StunRatio": 2.61,
+              "StunRatioGrowth": 0.119,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8703.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 257.01
+            }
+          ]
+        }
+      }
     },
     "Evelyn": {
       "id": "1321",
@@ -2174,7 +9371,279 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackRazorWire": [
+            {
+              "DamagePercentage": 0.512,
+              "DamagePercentageGrowth": 0.047,
+              "StunRatio": 0.256,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 83.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 640.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.621,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.538,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 176.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1344.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.782,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.621,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 203.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1553.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.867,
+              "DamagePercentageGrowth": 0.17,
+              "StunRatio": 1.53,
+              "StunRatioGrowth": 0.07,
+              "SpRecovery": 500.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3825.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 139.03
+            },
+            {
+              "DamagePercentage": 2.234,
+              "DamagePercentageGrowth": 0.204,
+              "StunRatio": 1.683,
+              "StunRatioGrowth": 0.077,
+              "SpRecovery": 550.5,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4207.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 152.91
+            }
+          ],
+          "PassiveBind": [],
+          "BasicAttackGarroteFirstForm": [
+            {
+              "DamagePercentage": 2.264,
+              "DamagePercentageGrowth": 0.206,
+              "StunRatio": 1.211,
+              "StunRatioGrowth": 0.056,
+              "SpRecovery": 396.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3027.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 110.03
+            }
+          ],
+          "BasicAttackGarroteSecondForm": [
+            {
+              "DamagePercentage": 2.452,
+              "DamagePercentageGrowth": 0.223,
+              "StunRatio": 1.248,
+              "StunRatioGrowth": 0.057,
+              "SpRecovery": 408.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3118.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 113.36
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeArcStep": [],
+          "DashAttackPiercingAmbush": [
+            {
+              "DamagePercentage": 0.605,
+              "DamagePercentageGrowth": 0.055,
+              "StunRatio": 0.303,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 99,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 756.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterStranglingReversal": [
+            {
+              "DamagePercentage": 2.102,
+              "DamagePercentageGrowth": 0.192,
+              "StunRatio": 1.871,
+              "StunRatioGrowth": 0.086,
+              "SpRecovery": 252.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1927.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 70.03
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackLockedPosition": [
+            {
+              "DamagePercentage": 0.523,
+              "DamagePercentageGrowth": 0.048,
+              "StunRatio": 0.523,
+              "StunRatioGrowth": 0.024,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2612.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 47.48
+            }
+          ],
+          "SpecialAttackBindingSunderFirstForm": [
+            {
+              "DamagePercentage": 0.404,
+              "DamagePercentageGrowth": 0.037,
+              "StunRatio": 0.404,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2015.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 36.64
+            },
+            {
+              "DamagePercentage": 0.34,
+              "DamagePercentageGrowth": 0.031,
+              "StunRatio": 0.34,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1696.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 30.84
+            }
+          ],
+          "EXSpecialAttackBindingSunderFinalForm": [
+            {
+              "DamagePercentage": 5.412,
+              "DamagePercentageGrowth": 0.492,
+              "StunRatio": 4.371,
+              "StunRatioGrowth": 0.199,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16134.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 444.62
+            },
+            {
+              "DamagePercentage": 0.596,
+              "DamagePercentageGrowth": 0.055,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1718.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.2
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackLunaluxSnare": [
+            {
+              "DamagePercentage": 8.293,
+              "DamagePercentageGrowth": 0.754,
+              "StunRatio": 2.366,
+              "StunRatioGrowth": 0.108,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16942.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 290.17
+            }
+          ],
+          "UltimateLunaluxGarroteTimbre": [
+            {
+              "DamagePercentage": 19.885,
+              "DamagePercentageGrowth": 1.808,
+              "StunRatio": 2.604,
+              "StunRatioGrowth": 0.119,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 236.7
+            }
+          ],
+          "UltimateLunaluxGarroteShadow": []
+        },
+        "assist": {
+          "QuickAssistFierceBlade": [
+            {
+              "DamagePercentage": 0.771,
+              "DamagePercentageGrowth": 0.071,
+              "StunRatio": 0.771,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 252.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1927.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 70.03
+            }
+          ],
+          "DefensiveAssistSilentProtection": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpCourseDisruption": [
+            {
+              "DamagePercentage": 2.916,
+              "DamagePercentageGrowth": 0.266,
+              "StunRatio": 2.49,
+              "StunRatioGrowth": 0.114,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 8357.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 245.67
+            }
+          ]
+        }
+      }
     },
     "Pulchra": {
       "id": "1351",
@@ -2251,7 +9720,197 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackSwiftStrike": [
+            {
+              "DamagePercentage": 0.357,
+              "DamagePercentageGrowth": 0.033,
+              "StunRatio": 0.285,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 102.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 783.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 28.48
+            },
+            {
+              "DamagePercentage": 0.941,
+              "DamagePercentageGrowth": 0.086,
+              "StunRatio": 0.753,
+              "StunRatioGrowth": 0.035,
+              "SpRecovery": 270.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2070.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 75.22
+            },
+            {
+              "DamagePercentage": 1.676,
+              "DamagePercentageGrowth": 0.153,
+              "StunRatio": 1.341,
+              "StunRatioGrowth": 0.061,
+              "SpRecovery": 482.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3687.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 134.05
+            }
+          ],
+          "BasicAttackLeapingStrike": [
+            {
+              "DamagePercentage": 1.35,
+              "DamagePercentageGrowth": 0.123,
+              "StunRatio": 1.08,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 388.8,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2970,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 107.97
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeReversalShot": [],
+          "DashAttackFirstStrikeAdvantage": [
+            {
+              "DamagePercentage": 0.483,
+              "DamagePercentageGrowth": 0.044,
+              "StunRatio": 0.242,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 87,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 665.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 24.14
+            }
+          ],
+          "DodgeCounterRelentlessRetribution": [
+            {
+              "DamagePercentage": 2.018,
+              "DamagePercentageGrowth": 0.184,
+              "StunRatio": 1.783,
+              "StunRatioGrowth": 0.082,
+              "SpRecovery": 281.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2153.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 78.29
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackRendingClaw": [
+            {
+              "DamagePercentage": 0.251,
+              "DamagePercentageGrowth": 0.023,
+              "StunRatio": 0.501,
+              "StunRatioGrowth": 0.023,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1377.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 25
+            }
+          ],
+          "SpecialAttackRendingClawNightmareShadow": [
+            {
+              "DamagePercentage": 0.463,
+              "DamagePercentageGrowth": 0.043,
+              "StunRatio": 0.29,
+              "StunRatioGrowth": 0.014,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.36
+            },
+            {
+              "DamagePercentage": 0.535,
+              "DamagePercentageGrowth": 0.049,
+              "StunRatio": 0.348,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 17.36
+            }
+          ],
+          "EXSpecialAttackRendingClawFlashstep": [
+            {
+              "DamagePercentage": 3.477,
+              "DamagePercentageGrowth": 0.317,
+              "StunRatio": 2.117,
+              "StunRatioGrowth": 0.097,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 14264.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 255.48
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackHeyDidntExpectThatRight": [
+            {
+              "DamagePercentage": 5.341,
+              "DamagePercentageGrowth": 0.486,
+              "StunRatio": 1.351,
+              "StunRatioGrowth": 0.062,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 22002.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 334.53
+            }
+          ],
+          "UltimateOhTimeToPlay": [
+            {
+              "DamagePercentage": 13.938,
+              "DamagePercentageGrowth": 1.268,
+              "StunRatio": 8.823,
+              "StunRatioGrowth": 0.402,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 114.96
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistContractBodyguard": [
+            {
+              "DamagePercentage": 0.783,
+              "DamagePercentageGrowth": 0.072,
+              "StunRatio": 0.783,
+              "StunRatioGrowth": 0.036,
+              "SpRecovery": 281.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2153.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 78.29
+            }
+          ],
+          "EvasiveAssistContractOutsourcedCombat": [],
+          "AssistFollowUpIndependentPricing": [
+            {
+              "DamagePercentage": 3.071,
+              "DamagePercentageGrowth": 0.28,
+              "StunRatio": 2.653,
+              "StunRatioGrowth": 0.121,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 9594.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 286.17
+            }
+          ]
+        }
+      }
     },
     "Trigger": {
       "id": "1361",
@@ -2328,7 +9987,277 @@
           "atk": 75,
           "impact": 18
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackColdBoreShot": [
+            {
+              "DamagePercentage": 0.345,
+              "DamagePercentageGrowth": 0.032,
+              "StunRatio": 0.173,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 98.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 756.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.569,
+              "DamagePercentageGrowth": 0.052,
+              "StunRatio": 0.285,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 200.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1531.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 1.109,
+              "DamagePercentageGrowth": 0.101,
+              "StunRatio": 0.608,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 328.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2508,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 2.43,
+              "DamagePercentageGrowth": 0.221,
+              "StunRatio": 1.769,
+              "StunRatioGrowth": 0.081,
+              "SpRecovery": 697.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5329.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 174.41
+            }
+          ],
+          "BasicAttackSilencedShot": [
+            {
+              "DamagePercentage": 0.476,
+              "DamagePercentageGrowth": 0.044,
+              "StunRatio": 0.238,
+              "StunRatioGrowth": 0.011,
+              "SpRecovery": 136.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 4160.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 108.03
+            },
+            {
+              "DamagePercentage": 2.339,
+              "DamagePercentageGrowth": 0.213,
+              "StunRatio": 1.488,
+              "StunRatioGrowth": 0.068,
+              "SpRecovery": 695.7,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 5315.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 193.22
+            },
+            {
+              "DamagePercentage": 1.312,
+              "DamagePercentageGrowth": 0.12,
+              "StunRatio": 0.656,
+              "StunRatioGrowth": 0.03,
+              "SpRecovery": 448.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3429.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 119.26
+            }
+          ],
+          "BasicAttackHarmonizingShot": [
+            {
+              "DamagePercentage": 0.479,
+              "DamagePercentageGrowth": 0.044,
+              "StunRatio": 0.359,
+              "StunRatioGrowth": 0.017,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 10.86
+            }
+          ],
+          "BasicAttackHarmonizingShotTartarus": [
+            {
+              "DamagePercentage": 0.226,
+              "DamagePercentageGrowth": 0.021,
+              "StunRatio": 0.17,
+              "StunRatioGrowth": 0.008,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 20.49
+            },
+            {
+              "DamagePercentage": 0.452,
+              "DamagePercentageGrowth": 0.042,
+              "StunRatio": 0.34,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 40.98
+            }
+          ]
+        },
+        "dodge": {
+          "DodgePhantomConcealment": [],
+          "DashAttackVengefulSpecter": [
+            {
+              "DamagePercentage": 0.514,
+              "DamagePercentageGrowth": 0.047,
+              "StunRatio": 0.257,
+              "StunRatioGrowth": 0.012,
+              "SpRecovery": 84.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 643.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "DodgeCounterCondemnedSoul": [
+            {
+              "DamagePercentage": 2.197,
+              "DamagePercentageGrowth": 0.2,
+              "StunRatio": 1.944,
+              "StunRatioGrowth": 0.089,
+              "SpRecovery": 276,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.66
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackSpectralFlash": [
+            {
+              "DamagePercentage": 0.715,
+              "DamagePercentageGrowth": 0.065,
+              "StunRatio": 0.715,
+              "StunRatioGrowth": 0.033,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1787.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 65
+            }
+          ],
+          "EXSpecialAttackFlashBurial": [
+            {
+              "DamagePercentage": 6.344,
+              "DamagePercentageGrowth": 0.577,
+              "StunRatio": 4.327,
+              "StunRatioGrowth": 0.197,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 21084.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 356.66
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackStygianGuide": [
+            {
+              "DamagePercentage": 5.747,
+              "DamagePercentageGrowth": 0.523,
+              "StunRatio": 1.358,
+              "StunRatioGrowth": 0.062,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 21681,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 322.86
+            }
+          ],
+          "UltimateUnderworldRequiem": [
+            {
+              "DamagePercentage": 14.805,
+              "DamagePercentageGrowth": 1.346,
+              "StunRatio": 9.22,
+              "StunRatioGrowth": 0.42,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.66
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistColdBoreCoverFire": [
+            {
+              "DamagePercentage": 0.844,
+              "DamagePercentageGrowth": 0.077,
+              "StunRatio": 0.844,
+              "StunRatioGrowth": 0.039,
+              "SpRecovery": 276,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2109.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 76.66
+            }
+          ],
+          "DefensiveAssistDelayingDemise": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpPiercingThunder": [
+            {
+              "DamagePercentage": 4.329,
+              "DamagePercentageGrowth": 0.394,
+              "StunRatio": 3.274,
+              "StunRatioGrowth": 0.149,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2774.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 369.51
+            }
+          ]
+        }
+      }
     },
     "Soldier0Anby": {
       "id": "1381",
@@ -2405,7 +10334,264 @@
           "atk": 75,
           "crit_": 0.144
         }
-      ]
+      ],
+      "skillParams": {
+        "basic": {
+          "BasicAttackPenetratingShock": [
+            {
+              "DamagePercentage": 0.327,
+              "DamagePercentageGrowth": 0.03,
+              "StunRatio": 0.279,
+              "StunRatioGrowth": 0.013,
+              "SpRecovery": 91.2,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 698.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 25.32
+            },
+            {
+              "DamagePercentage": 0.622,
+              "DamagePercentageGrowth": 0.057,
+              "StunRatio": 0.545,
+              "StunRatioGrowth": 0.025,
+              "SpRecovery": 178.4,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1364,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 49.54
+            },
+            {
+              "DamagePercentage": 0.801,
+              "DamagePercentageGrowth": 0.073,
+              "StunRatio": 0.719,
+              "StunRatioGrowth": 0.033,
+              "SpRecovery": 235,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1795.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 65.27
+            },
+            {
+              "DamagePercentage": 0.399,
+              "DamagePercentageGrowth": 0.037,
+              "StunRatio": 0.621,
+              "StunRatioGrowth": 0.029,
+              "SpRecovery": 203.1,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1553.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 56.4
+            },
+            {
+              "DamagePercentage": 1.545,
+              "DamagePercentageGrowth": 0.141,
+              "StunRatio": 1.377,
+              "StunRatioGrowth": 0.063,
+              "SpRecovery": 450.6,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3443,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 125.16
+            },
+            {
+              "DamagePercentage": 1.485,
+              "DamagePercentageGrowth": 0.135,
+              "StunRatio": 1.309,
+              "StunRatioGrowth": 0.06,
+              "SpRecovery": 428.3,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 3272.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 118.95
+            }
+          ]
+        },
+        "dodge": {
+          "DodgeStrobe": [],
+          "DashAttackTorrent": [
+            {
+              "DamagePercentage": 0.825,
+              "DamagePercentageGrowth": 0.075,
+              "StunRatio": 0.413,
+              "StunRatioGrowth": 0.019,
+              "SpRecovery": 135,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1031.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 37.48
+            }
+          ],
+          "DodgeCounterGroundFlashCounter": [
+            {
+              "DamagePercentage": 2.506,
+              "DamagePercentageGrowth": 0.228,
+              "StunRatio": 2.182,
+              "StunRatioGrowth": 0.1,
+              "SpRecovery": 353.9,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2706,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 98.3
+            }
+          ]
+        },
+        "special": {
+          "SpecialAttackCelestialThunder": [
+            {
+              "DamagePercentage": 0.596,
+              "DamagePercentageGrowth": 0.055,
+              "StunRatio": 0.596,
+              "StunRatioGrowth": 0.028,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 1490.5,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 54.16
+            }
+          ],
+          "SpecialAttackAzureFlash": [
+            {
+              "DamagePercentage": 1.672,
+              "DamagePercentageGrowth": 0.152,
+              "StunRatio": 0,
+              "StunRatioGrowth": 0,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0.43,
+              "DamagePercentageGrowth": 0.04,
+              "StunRatio": 0.331,
+              "StunRatioGrowth": 0.016,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 827.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 30.03
+            }
+          ],
+          "SpecialAttackThunderSmite": [
+            {
+              "DamagePercentage": 1.881,
+              "DamagePercentageGrowth": 0.171,
+              "StunRatio": 0,
+              "StunRatioGrowth": 0,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "EXSpecialAttackSunderingBolt": [
+            {
+              "DamagePercentage": 3.796,
+              "DamagePercentageGrowth": 0.346,
+              "StunRatio": 4.586,
+              "StunRatioGrowth": 0.209,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 16755.75,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 464.96
+            }
+          ]
+        },
+        "chain": {
+          "ChainAttackLeapingThunderstrike": [
+            {
+              "DamagePercentage": 5.638,
+              "DamagePercentageGrowth": 0.513,
+              "StunRatio": 1.981,
+              "StunRatioGrowth": 0.091,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 23240.25,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 379.5
+            }
+          ],
+          "UltimateVoidstrike": [
+            {
+              "DamagePercentage": 17.349,
+              "DamagePercentageGrowth": 1.578,
+              "StunRatio": 2.769,
+              "StunRatioGrowth": 0.126,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 251.66
+            }
+          ]
+        },
+        "assist": {
+          "QuickAssistCloudFlash": [
+            {
+              "DamagePercentage": 1.082,
+              "DamagePercentageGrowth": 0.099,
+              "StunRatio": 1.082,
+              "StunRatioGrowth": 0.05,
+              "SpRecovery": 177,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 2706,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 98.3
+            }
+          ],
+          "DefensiveAssistCounterSurge": [
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 2.713,
+              "StunRatioGrowth": 0.124,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 3.428,
+              "StunRatioGrowth": 0.156,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            },
+            {
+              "DamagePercentage": 0,
+              "DamagePercentageGrowth": 0,
+              "StunRatio": 1.668,
+              "StunRatioGrowth": 0.076,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 0,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 0
+            }
+          ],
+          "AssistFollowUpConductingBlow": [
+            {
+              "DamagePercentage": 4.071,
+              "DamagePercentageGrowth": 0.371,
+              "StunRatio": 3.562,
+              "StunRatioGrowth": 0.162,
+              "SpRecovery": 0,
+              "SpRecoveryGrowth": 0,
+              "FeverRecovery": 11451,
+              "FeverRecoveryGrowth": 0,
+              "AttributeInfliction": 346.92
+            }
+          ]
+        }
+      }
     }
   },
   "wengine": {

--- a/libs/zzz/stats/src/char.ts
+++ b/libs/zzz/stats/src/char.ts
@@ -4,6 +4,7 @@ import type {
   CharacterKey,
   CharacterRarityKey,
   FactionKey,
+  SkillKey,
   SpecialityKey,
 } from '@genshin-optimizer/zzz/consts'
 import { allStats } from './allStats'
@@ -28,6 +29,18 @@ export type CharacterDatum = {
   }
   promotionStats: Array<{ hp: number; atk: number; def: number }>
   coreStats: Array<Partial<Record<BaseStatKey, number>>>
+  skillParams: Record<SkillKey, Record<string, SkillParam[]>>
+}
+export type SkillParam = {
+  DamagePercentage: number
+  DamagePercentageGrowth: number
+  StunRatio: number
+  StunRatioGrowth: number
+  SpRecovery: number
+  SpRecoveryGrowth: number
+  FeverRecovery: number
+  FeverRecoveryGrowth: number
+  AttributeInfliction: number
 }
 
 export function getCharStat(ck: CharacterKey) {

--- a/libs/zzz/stats/src/executors/gen-stats/src/characterData.ts
+++ b/libs/zzz/stats/src/executors/gen-stats/src/characterData.ts
@@ -1,7 +1,15 @@
-import { objMap } from '@genshin-optimizer/common/util'
-import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
-import { charactersDetailedJSONData } from '@genshin-optimizer/zzz/dm'
-import type { CharacterDatum } from '../../../char'
+import {
+  nameToKey,
+  notEmpty,
+  objMap,
+  verifyObjKeys,
+} from '@genshin-optimizer/common/util'
+import { type CharacterKey, allSkillKeys } from '@genshin-optimizer/zzz/consts'
+import {
+  charactersDetailedJSONData,
+  hakushinSkillMap,
+} from '@genshin-optimizer/zzz/dm'
+import { type CharacterDatum } from '../../../char'
 
 export type CharactersData = Record<CharacterKey, CharacterDatum>
 export function getCharactersData(): CharactersData {
@@ -16,15 +24,73 @@ export function getCharactersData(): CharactersData {
       stats,
       promotionStats,
       coreStats,
-    }) => ({
-      id,
-      rarity,
-      attribute,
-      specialty,
-      faction,
-      stats,
-      promotionStats,
-      coreStats,
-    })
+      skills,
+    }) => {
+      const skillParams = Object.fromEntries(
+        Object.entries(skills).map(([key, skill]) => {
+          // Only record each skill once.
+          // Many skills show up twice, e.g. once for dmg, once for daze
+          // But we have all the dmg, daze, anom info in the params
+          const ids: Record<string, boolean> = {}
+          return [
+            hakushinSkillMap[key],
+            Object.fromEntries(
+              skill.Description.map((desc) => [
+                nameToKey(desc.Name),
+                (desc.Param ?? []).flatMap((par) =>
+                  Object.entries(par.Param ?? {})
+                    .map(
+                      ([
+                        id,
+                        {
+                          DamagePercentage,
+                          DamagePercentageGrowth,
+                          StunRatio,
+                          StunRatioGrowth,
+                          SpRecovery,
+                          SpRecoveryGrowth,
+                          FeverRecovery,
+                          FeverRecoveryGrowth,
+                          AttributeInfliction,
+                        },
+                      ]) => {
+                        if (!ids[id]) {
+                          ids[id] = true
+                          return {
+                            DamagePercentage,
+                            DamagePercentageGrowth,
+                            StunRatio,
+                            StunRatioGrowth,
+                            SpRecovery,
+                            SpRecoveryGrowth,
+                            FeverRecovery,
+                            FeverRecoveryGrowth,
+                            AttributeInfliction,
+                          }
+                        }
+                        return undefined
+                      }
+                    )
+                    .filter(notEmpty)
+                ),
+              ])
+            ),
+          ]
+        })
+      )
+      verifyObjKeys(skillParams, allSkillKeys)
+
+      return {
+        id,
+        rarity,
+        attribute,
+        specialty,
+        faction,
+        stats,
+        promotionStats,
+        coreStats,
+        skillParams,
+      }
+    }
   )
 }

--- a/libs/zzz/stats/src/generators/gen-map/all-generator.ts
+++ b/libs/zzz/stats/src/generators/gen-map/all-generator.ts
@@ -1,15 +1,15 @@
-import { allWengineKeys } from '@genshin-optimizer/zzz/consts'
+import { allCharacterKeys, allWengineKeys } from '@genshin-optimizer/zzz/consts'
 import { type Tree } from '@nx/devkit'
 import genIndex from './genIndex'
 import genMap from './genMap'
 export default async function genMapGenerator(tree: Tree) {
-  // for (const map of allCharacterKeys)
-  //   await genMap(tree, { map_type: 'char', map })
+  for (const map of allCharacterKeys)
+    await genMap(tree, { map_type: 'char', map })
   // for (const map of allDiscSetKeys)
   //   await genMap(tree, { map_type: 'disc', map })
   for (const map of allWengineKeys)
     await genMap(tree, { map_type: 'wengine', map })
-  // await genIndex(tree, 'char')
+  await genIndex(tree, 'char')
   // await genIndex(tree, 'disc')
   await genIndex(tree, 'wengine')
 }

--- a/libs/zzz/stats/src/generators/gen-map/genIndex.ts
+++ b/libs/zzz/stats/src/generators/gen-map/genIndex.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from 'fs'
+import { formatText } from '@genshin-optimizer/common/pipeline'
 import {
   allCharacterKeys,
   allDiscSetKeys,
@@ -6,7 +7,6 @@ import {
 } from '@genshin-optimizer/zzz/consts'
 import type { Tree } from '@nx/devkit'
 import { workspaceRoot } from '@nx/devkit'
-import * as prettier from 'prettier'
 
 export default async function genIndex(tree: Tree, map_type: string) {
   const file_location = `${workspaceRoot}/libs/zzz/stats/src/mappedStats/${map_type}/index.ts`
@@ -24,9 +24,7 @@ export default async function genIndex(tree: Tree, map_type: string) {
 }
 
 async function writeIndex(path: string, keys: readonly string[]) {
-  const prettierRc = await prettier.resolveConfig(path)
-  const index = prettier.format(
-    `// WARNING: Generated file, do not modify
+  const index = `// WARNING: Generated file, do not modify
 ${keys.map((key) => `import ${key} from './maps/${key}'`).join('\n')}
 
 const maps = {
@@ -34,8 +32,7 @@ const maps = {
 }
 export default maps
 
-  `,
-    { ...prettierRc, parser: 'typescript' }
-  )
-  writeFileSync(path, index)
+  `
+  const formatted = await formatText(path, index)
+  writeFileSync(path, formatted)
 }

--- a/libs/zzz/stats/src/generators/gen-map/genMap.ts
+++ b/libs/zzz/stats/src/generators/gen-map/genMap.ts
@@ -44,7 +44,19 @@ const key: CharacterKey = '${charKey}'
 const data_gen = getCharStat(key)
 
 const dm =
-  ${JSON.stringify(objMap(allStats.char[charKey].skillParams, (param, skillKey) => objMap(param, (_skillParams, key) => `data_gen.skillParams['${skillKey}']['${key}']`))).replace(/"(data_gen.skillParams\[.*?\]\[.*?\])"/g, (_match, contents) => contents)} as const
+  ${JSON.stringify(
+    objMap(allStats.char[charKey].skillParams, (param, skillKey) =>
+      objMap(
+        param,
+        (_skillParams, key) => `data_gen.skillParams['${skillKey}']['${key}']`
+      )
+    )
+  )
+    // Remove the double quotes inserted by stringify
+    .replace(
+      /"(data_gen.skillParams\[.*?\]\[.*?\])"/g,
+      (_match, contents) => contents
+    )} as const
 
 export default dm
 

--- a/libs/zzz/stats/src/mappedStats/char/index.ts
+++ b/libs/zzz/stats/src/mappedStats/char/index.ts
@@ -1,0 +1,67 @@
+// WARNING: Generated file, do not modify
+import Anby from './maps/Anby'
+import Anton from './maps/Anton'
+import Astra from './maps/Astra'
+import Ben from './maps/Ben'
+import Billy from './maps/Billy'
+import Burnice from './maps/Burnice'
+import Caesar from './maps/Caesar'
+import Corin from './maps/Corin'
+import Ellen from './maps/Ellen'
+import Evelyn from './maps/Evelyn'
+import Grace from './maps/Grace'
+import Harumasa from './maps/Harumasa'
+import Jane from './maps/Jane'
+import Koleda from './maps/Koleda'
+import Lighter from './maps/Lighter'
+import Lucy from './maps/Lucy'
+import Lycaon from './maps/Lycaon'
+import Miyabi from './maps/Miyabi'
+import Nekomata from './maps/Nekomata'
+import Nicole from './maps/Nicole'
+import Piper from './maps/Piper'
+import Pulchra from './maps/Pulchra'
+import QingYi from './maps/QingYi'
+import Rina from './maps/Rina'
+import Seth from './maps/Seth'
+import Soldier0Anby from './maps/Soldier0Anby'
+import Soldier11 from './maps/Soldier11'
+import Soukaku from './maps/Soukaku'
+import Trigger from './maps/Trigger'
+import Yanagi from './maps/Yanagi'
+import ZhuYuan from './maps/ZhuYuan'
+
+const maps = {
+  Anby,
+  Anton,
+  Astra,
+  Ben,
+  Billy,
+  Burnice,
+  Caesar,
+  Corin,
+  Ellen,
+  Evelyn,
+  Grace,
+  Harumasa,
+  Jane,
+  Koleda,
+  Lighter,
+  Lucy,
+  Lycaon,
+  Miyabi,
+  Nekomata,
+  Nicole,
+  Piper,
+  Pulchra,
+  QingYi,
+  Rina,
+  Seth,
+  Soldier0Anby,
+  Soldier11,
+  Soukaku,
+  Trigger,
+  Yanagi,
+  ZhuYuan,
+}
+export default maps

--- a/libs/zzz/stats/src/mappedStats/char/maps/Anby.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Anby.ts
@@ -1,0 +1,41 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Anby'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackTurboVolt: data_gen.skillParams['basic']['BasicAttackTurboVolt'],
+    BasicAttackThunderbolt:
+      data_gen.skillParams['basic']['BasicAttackThunderbolt'],
+  },
+  dodge: {
+    DodgeSlide: data_gen.skillParams['dodge']['DodgeSlide'],
+    DashAttackTaserBlast: data_gen.skillParams['dodge']['DashAttackTaserBlast'],
+    DodgeCounterThunderclap:
+      data_gen.skillParams['dodge']['DodgeCounterThunderclap'],
+  },
+  special: {
+    SpecialAttackForkLightning:
+      data_gen.skillParams['special']['SpecialAttackForkLightning'],
+    EXSpecialAttackLightningBolt:
+      data_gen.skillParams['special']['EXSpecialAttackLightningBolt'],
+  },
+  chain: {
+    ChainAttackElectroEngine:
+      data_gen.skillParams['chain']['ChainAttackElectroEngine'],
+    UltimateOverdriveEngine:
+      data_gen.skillParams['chain']['UltimateOverdriveEngine'],
+  },
+  assist: {
+    QuickAssistThunderfall:
+      data_gen.skillParams['assist']['QuickAssistThunderfall'],
+    DefensiveAssistFlash:
+      data_gen.skillParams['assist']['DefensiveAssistFlash'],
+    AssistFollowUpLightningWhirl:
+      data_gen.skillParams['assist']['AssistFollowUpLightningWhirl'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Anton.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Anton.ts
@@ -1,0 +1,47 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Anton'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackEnthusiasticDrills:
+      data_gen.skillParams['basic']['BasicAttackEnthusiasticDrills'],
+    BasicAttackEnthusiasticDrillsBurstMode:
+      data_gen.skillParams['basic']['BasicAttackEnthusiasticDrillsBurstMode'],
+  },
+  dodge: {
+    DodgeLetsMove: data_gen.skillParams['dodge']['DodgeLetsMove'],
+    DashAttackFireWithFire:
+      data_gen.skillParams['dodge']['DashAttackFireWithFire'],
+    DodgeCounterRetaliation:
+      data_gen.skillParams['dodge']['DodgeCounterRetaliation'],
+    DodgeCounterOverloadDrillBurstMode:
+      data_gen.skillParams['dodge']['DodgeCounterOverloadDrillBurstMode'],
+  },
+  special: {
+    SpecialAttackSpinBro:
+      data_gen.skillParams['special']['SpecialAttackSpinBro'],
+    EXSpecialAttackSmashTheHorizonBro:
+      data_gen.skillParams['special']['EXSpecialAttackSmashTheHorizonBro'],
+    SpecialAttackExplosiveDrillBurstMode:
+      data_gen.skillParams['special']['SpecialAttackExplosiveDrillBurstMode'],
+  },
+  chain: {
+    ChainAttackGoGoGo: data_gen.skillParams['chain']['ChainAttackGoGoGo'],
+    UltimateGoGoGoGoGo: data_gen.skillParams['chain']['UltimateGoGoGoGoGo'],
+  },
+  assist: {
+    QuickAssistShoulderToShoulder:
+      data_gen.skillParams['assist']['QuickAssistShoulderToShoulder'],
+    QuickAssistProtectiveDrillBurstMode:
+      data_gen.skillParams['assist']['QuickAssistProtectiveDrillBurstMode'],
+    DefensiveAssistIronWrist:
+      data_gen.skillParams['assist']['DefensiveAssistIronWrist'],
+    AssistFollowUpLimitBurst:
+      data_gen.skillParams['assist']['AssistFollowUpLimitBurst'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Astra.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Astra.ts
@@ -1,0 +1,43 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Astra'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackCapriccio: data_gen.skillParams['basic']['BasicAttackCapriccio'],
+    BasicAttackInterlude: data_gen.skillParams['basic']['BasicAttackInterlude'],
+    BasicAttackChorus: data_gen.skillParams['basic']['BasicAttackChorus'],
+    BasicAttackFinale: data_gen.skillParams['basic']['BasicAttackFinale'],
+  },
+  dodge: {
+    DodgeMiniWaltz: data_gen.skillParams['dodge']['DodgeMiniWaltz'],
+    DashAttackLunarEclipseMelody:
+      data_gen.skillParams['dodge']['DashAttackLunarEclipseMelody'],
+    DodgeCounterUmbrellaWaltz:
+      data_gen.skillParams['dodge']['DodgeCounterUmbrellaWaltz'],
+  },
+  special: {
+    SpecialAttackWindchimesOaths:
+      data_gen.skillParams['special']['SpecialAttackWindchimesOaths'],
+    IdyllicCadenza: data_gen.skillParams['special']['IdyllicCadenza'],
+    Chord: data_gen.skillParams['special']['Chord'],
+  },
+  chain: {
+    ChainAttackTipsyConcerto:
+      data_gen.skillParams['chain']['ChainAttackTipsyConcerto'],
+    UltimateFantasianSonata:
+      data_gen.skillParams['chain']['UltimateFantasianSonata'],
+  },
+  assist: {
+    QuickAssistOneLuminousSky:
+      data_gen.skillParams['assist']['QuickAssistOneLuminousSky'],
+    EvasiveAssistTwoHearts:
+      data_gen.skillParams['assist']['EvasiveAssistTwoHearts'],
+    AssistFollowUpThreeLifetimesOfFate:
+      data_gen.skillParams['assist']['AssistFollowUpThreeLifetimesOfFate'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Ben.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Ben.ts
@@ -1,0 +1,41 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Ben'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackDebtReconciliation:
+      data_gen.skillParams['basic']['BasicAttackDebtReconciliation'],
+  },
+  dodge: {
+    DodgeMissingInvoice: data_gen.skillParams['dodge']['DodgeMissingInvoice'],
+    DashAttackIncomingExpense:
+      data_gen.skillParams['dodge']['DashAttackIncomingExpense'],
+    DodgeCounterAccountsSettled:
+      data_gen.skillParams['dodge']['DodgeCounterAccountsSettled'],
+  },
+  special: {
+    SpecialAttackFiscalFist:
+      data_gen.skillParams['special']['SpecialAttackFiscalFist'],
+    EXSpecialAttackCashflowCounter:
+      data_gen.skillParams['special']['EXSpecialAttackCashflowCounter'],
+  },
+  chain: {
+    ChainAttackSignedAndSealed:
+      data_gen.skillParams['chain']['ChainAttackSignedAndSealed'],
+    UltimateCompletePayback:
+      data_gen.skillParams['chain']['UltimateCompletePayback'],
+  },
+  assist: {
+    QuickAssistJointAccount:
+      data_gen.skillParams['assist']['QuickAssistJointAccount'],
+    DefensiveAssistRiskAllocation:
+      data_gen.skillParams['assist']['DefensiveAssistRiskAllocation'],
+    AssistFollowUpDontBreakContract:
+      data_gen.skillParams['assist']['AssistFollowUpDontBreakContract'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Billy.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Billy.ts
@@ -1,0 +1,41 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Billy'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackFullFirepower:
+      data_gen.skillParams['basic']['BasicAttackFullFirepower'],
+  },
+  dodge: {
+    DodgeRiskyBusiness: data_gen.skillParams['dodge']['DodgeRiskyBusiness'],
+    DashAttackStarlightSanction:
+      data_gen.skillParams['dodge']['DashAttackStarlightSanction'],
+    DodgeCounterFairFight:
+      data_gen.skillParams['dodge']['DodgeCounterFairFight'],
+  },
+  special: {
+    SpecialAttackStandStill:
+      data_gen.skillParams['special']['SpecialAttackStandStill'],
+    EXSpecialAttackClearanceTime:
+      data_gen.skillParams['special']['EXSpecialAttackClearanceTime'],
+  },
+  chain: {
+    ChainAttackStarlightMirage:
+      data_gen.skillParams['chain']['ChainAttackStarlightMirage'],
+    UltimateStarlightShineBright:
+      data_gen.skillParams['chain']['UltimateStarlightShineBright'],
+  },
+  assist: {
+    QuickAssistPowerOfTeamwork:
+      data_gen.skillParams['assist']['QuickAssistPowerOfTeamwork'],
+    EvasiveAssistFlashSpin:
+      data_gen.skillParams['assist']['EvasiveAssistFlashSpin'],
+    AssistFollowUpFatalShot:
+      data_gen.skillParams['assist']['AssistFollowUpFatalShot'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Burnice.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Burnice.ts
@@ -1,0 +1,50 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Burnice'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackDirectFlameBlend:
+      data_gen.skillParams['basic']['BasicAttackDirectFlameBlend'],
+    BasicAttackMixedFlameBlend:
+      data_gen.skillParams['basic']['BasicAttackMixedFlameBlend'],
+  },
+  dodge: {
+    DodgeFieryPhantomDash:
+      data_gen.skillParams['dodge']['DodgeFieryPhantomDash'],
+    DashAttackDangerousFermentation:
+      data_gen.skillParams['dodge']['DashAttackDangerousFermentation'],
+    DodgeCounterFlutteringSteps:
+      data_gen.skillParams['dodge']['DodgeCounterFlutteringSteps'],
+  },
+  special: {
+    SpecialAttackIntenseHeatAgingMethod:
+      data_gen.skillParams['special']['SpecialAttackIntenseHeatAgingMethod'],
+    EXSpecialAttackIntenseHeatStirringMethod:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackIntenseHeatStirringMethod'
+      ],
+    EXSpecialAttackIntenseHeatStirringMethodDoubleShot:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackIntenseHeatStirringMethodDoubleShot'
+      ],
+  },
+  chain: {
+    ChainAttackFuelFedFlame:
+      data_gen.skillParams['chain']['ChainAttackFuelFedFlame'],
+    UltimateGloriousInferno:
+      data_gen.skillParams['chain']['UltimateGloriousInferno'],
+  },
+  assist: {
+    QuickAssistEnergizingSpecialtyDrink:
+      data_gen.skillParams['assist']['QuickAssistEnergizingSpecialtyDrink'],
+    DefensiveAssistSmokyCauldron:
+      data_gen.skillParams['assist']['DefensiveAssistSmokyCauldron'],
+    AssistFollowUpScorchingDew:
+      data_gen.skillParams['assist']['AssistFollowUpScorchingDew'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Caesar.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Caesar.ts
@@ -1,0 +1,45 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Caesar'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackRampagingSlash:
+      data_gen.skillParams['basic']['BasicAttackRampagingSlash'],
+    BasicAttackDeadEnd: data_gen.skillParams['basic']['BasicAttackDeadEnd'],
+  },
+  dodge: {
+    DodgeAdrift: data_gen.skillParams['dodge']['DodgeAdrift'],
+    DashAttackHogRush: data_gen.skillParams['dodge']['DashAttackHogRush'],
+    DodgeCounterEyeForAnEye:
+      data_gen.skillParams['dodge']['DodgeCounterEyeForAnEye'],
+  },
+  special: {
+    SpecialAttackShockwaveShieldBash:
+      data_gen.skillParams['special']['SpecialAttackShockwaveShieldBash'],
+    SpecialAttackRoaringThrust:
+      data_gen.skillParams['special']['SpecialAttackRoaringThrust'],
+    EXSpecialAttackParryCounter:
+      data_gen.skillParams['special']['EXSpecialAttackParryCounter'],
+    EXSpecialAttackOverpoweredShieldBash:
+      data_gen.skillParams['special']['EXSpecialAttackOverpoweredShieldBash'],
+    StanceSwitch: data_gen.skillParams['special']['StanceSwitch'],
+  },
+  chain: {
+    ChainAttackRoadRageSlam:
+      data_gen.skillParams['chain']['ChainAttackRoadRageSlam'],
+    UltimateSavageSmash: data_gen.skillParams['chain']['UltimateSavageSmash'],
+  },
+  assist: {
+    QuickAssistLaneChange:
+      data_gen.skillParams['assist']['QuickAssistLaneChange'],
+    DefensiveAssistAegisShield:
+      data_gen.skillParams['assist']['DefensiveAssistAegisShield'],
+    AssistFollowUpAidingBlade:
+      data_gen.skillParams['assist']['AssistFollowUpAidingBlade'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Corin.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Corin.ts
@@ -1,0 +1,37 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Corin'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackWipeout: data_gen.skillParams['basic']['BasicAttackWipeout'],
+  },
+  dodge: {
+    DodgeShoo: data_gen.skillParams['dodge']['DodgeShoo'],
+    DashAttackOopsyDaisy: data_gen.skillParams['dodge']['DashAttackOopsyDaisy'],
+    DodgeCounterNope: data_gen.skillParams['dodge']['DodgeCounterNope'],
+  },
+  special: {
+    SpecialAttackCleanSweep:
+      data_gen.skillParams['special']['SpecialAttackCleanSweep'],
+    EXSpecialAttackSkirtAlert:
+      data_gen.skillParams['special']['EXSpecialAttackSkirtAlert'],
+  },
+  chain: {
+    ChainAttackSorry: data_gen.skillParams['chain']['ChainAttackSorry'],
+    UltimateVeryVerySorry:
+      data_gen.skillParams['chain']['UltimateVeryVerySorry'],
+  },
+  assist: {
+    QuickAssistEmergencyMeasures:
+      data_gen.skillParams['assist']['QuickAssistEmergencyMeasures'],
+    DefensiveAssistPPleaseAllowMe:
+      data_gen.skillParams['assist']['DefensiveAssistPPleaseAllowMe'],
+    AssistFollowUpQuickSweep:
+      data_gen.skillParams['assist']['AssistFollowUpQuickSweep'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Ellen.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Ellen.ts
@@ -1,0 +1,47 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Ellen'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackSawTeethTrimming:
+      data_gen.skillParams['basic']['BasicAttackSawTeethTrimming'],
+    BasicAttackFlashFreezeTrimming:
+      data_gen.skillParams['basic']['BasicAttackFlashFreezeTrimming'],
+  },
+  dodge: {
+    DodgeVortex: data_gen.skillParams['dodge']['DodgeVortex'],
+    DashRoamingHunt: data_gen.skillParams['dodge']['DashRoamingHunt'],
+    DashAttackArcticAmbush:
+      data_gen.skillParams['dodge']['DashAttackArcticAmbush'],
+    FlashFreeze: data_gen.skillParams['dodge']['FlashFreeze'],
+    DashAttackMonstrousWave:
+      data_gen.skillParams['dodge']['DashAttackMonstrousWave'],
+    DashAttackColdSnap: data_gen.skillParams['dodge']['DashAttackColdSnap'],
+    DodgeCounterReefRock: data_gen.skillParams['dodge']['DodgeCounterReefRock'],
+  },
+  special: {
+    SpecialAttackDrift: data_gen.skillParams['special']['SpecialAttackDrift'],
+    EXSpecialAttackTailSwipe:
+      data_gen.skillParams['special']['EXSpecialAttackTailSwipe'],
+    EXSpecialAttackSharknami:
+      data_gen.skillParams['special']['EXSpecialAttackSharknami'],
+  },
+  chain: {
+    ChainAttackAvalanche: data_gen.skillParams['chain']['ChainAttackAvalanche'],
+    UltimateEndlessWinter:
+      data_gen.skillParams['chain']['UltimateEndlessWinter'],
+  },
+  assist: {
+    QuickAssistSharkSentinel:
+      data_gen.skillParams['assist']['QuickAssistSharkSentinel'],
+    DefensiveAssistWavefrontImpact:
+      data_gen.skillParams['assist']['DefensiveAssistWavefrontImpact'],
+    AssistFollowUpSharkCruiser:
+      data_gen.skillParams['assist']['AssistFollowUpSharkCruiser'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Evelyn.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Evelyn.ts
@@ -1,0 +1,49 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Evelyn'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackRazorWire: data_gen.skillParams['basic']['BasicAttackRazorWire'],
+    PassiveBind: data_gen.skillParams['basic']['PassiveBind'],
+    BasicAttackGarroteFirstForm:
+      data_gen.skillParams['basic']['BasicAttackGarroteFirstForm'],
+    BasicAttackGarroteSecondForm:
+      data_gen.skillParams['basic']['BasicAttackGarroteSecondForm'],
+  },
+  dodge: {
+    DodgeArcStep: data_gen.skillParams['dodge']['DodgeArcStep'],
+    DashAttackPiercingAmbush:
+      data_gen.skillParams['dodge']['DashAttackPiercingAmbush'],
+    DodgeCounterStranglingReversal:
+      data_gen.skillParams['dodge']['DodgeCounterStranglingReversal'],
+  },
+  special: {
+    SpecialAttackLockedPosition:
+      data_gen.skillParams['special']['SpecialAttackLockedPosition'],
+    SpecialAttackBindingSunderFirstForm:
+      data_gen.skillParams['special']['SpecialAttackBindingSunderFirstForm'],
+    EXSpecialAttackBindingSunderFinalForm:
+      data_gen.skillParams['special']['EXSpecialAttackBindingSunderFinalForm'],
+  },
+  chain: {
+    ChainAttackLunaluxSnare:
+      data_gen.skillParams['chain']['ChainAttackLunaluxSnare'],
+    UltimateLunaluxGarroteTimbre:
+      data_gen.skillParams['chain']['UltimateLunaluxGarroteTimbre'],
+    UltimateLunaluxGarroteShadow:
+      data_gen.skillParams['chain']['UltimateLunaluxGarroteShadow'],
+  },
+  assist: {
+    QuickAssistFierceBlade:
+      data_gen.skillParams['assist']['QuickAssistFierceBlade'],
+    DefensiveAssistSilentProtection:
+      data_gen.skillParams['assist']['DefensiveAssistSilentProtection'],
+    AssistFollowUpCourseDisruption:
+      data_gen.skillParams['assist']['AssistFollowUpCourseDisruption'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Grace.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Grace.ts
@@ -1,0 +1,44 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Grace'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackHighPressureSpike:
+      data_gen.skillParams['basic']['BasicAttackHighPressureSpike'],
+  },
+  dodge: {
+    DodgeSafetyRegulation:
+      data_gen.skillParams['dodge']['DodgeSafetyRegulation'],
+    DashAttackQuickInspection:
+      data_gen.skillParams['dodge']['DashAttackQuickInspection'],
+    DodgeCounterViolationPenalty:
+      data_gen.skillParams['dodge']['DodgeCounterViolationPenalty'],
+  },
+  special: {
+    SpecialAttackObstructionRemoval:
+      data_gen.skillParams['special']['SpecialAttackObstructionRemoval'],
+    EXSpecialAttackSuperchargedObstructionRemoval:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackSuperchargedObstructionRemoval'
+      ],
+  },
+  chain: {
+    ChainAttackCollaborativeConstruction:
+      data_gen.skillParams['chain']['ChainAttackCollaborativeConstruction'],
+    UltimateDemolitionBlastBeware:
+      data_gen.skillParams['chain']['UltimateDemolitionBlastBeware'],
+  },
+  assist: {
+    QuickAssistIncidentManagement:
+      data_gen.skillParams['assist']['QuickAssistIncidentManagement'],
+    EvasiveAssistRapidRiskResponse:
+      data_gen.skillParams['assist']['EvasiveAssistRapidRiskResponse'],
+    AssistFollowUpCounterVoltNeedle:
+      data_gen.skillParams['assist']['AssistFollowUpCounterVoltNeedle'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Harumasa.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Harumasa.ts
@@ -1,0 +1,46 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Harumasa'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackCloudPiercer:
+      data_gen.skillParams['basic']['BasicAttackCloudPiercer'],
+    BasicAttackCloudPiercerDrift:
+      data_gen.skillParams['basic']['BasicAttackCloudPiercerDrift'],
+    BasicAttackFallingFeather:
+      data_gen.skillParams['basic']['BasicAttackFallingFeather'],
+    BasicAttackHaOtoNoYa: data_gen.skillParams['basic']['BasicAttackHaOtoNoYa'],
+  },
+  dodge: {
+    DodgeQuickFlash: data_gen.skillParams['dodge']['DodgeQuickFlash'],
+    DashAttackHitenNoTsuru:
+      data_gen.skillParams['dodge']['DashAttackHitenNoTsuru'],
+    DodgeCounterHiddenEdge:
+      data_gen.skillParams['dodge']['DodgeCounterHiddenEdge'],
+    DashAttackHitenNoTsuruSlash:
+      data_gen.skillParams['dodge']['DashAttackHitenNoTsuruSlash'],
+  },
+  special: {
+    SpecialAttackNowhereToHide:
+      data_gen.skillParams['special']['SpecialAttackNowhereToHide'],
+    EXSpecialAttackNowhereToRun:
+      data_gen.skillParams['special']['EXSpecialAttackNowhereToRun'],
+  },
+  chain: {
+    ChainAttackKaiHanare: data_gen.skillParams['chain']['ChainAttackKaiHanare'],
+    UltimateZanshin: data_gen.skillParams['chain']['UltimateZanshin'],
+  },
+  assist: {
+    QuickAssistBracedBow:
+      data_gen.skillParams['assist']['QuickAssistBracedBow'],
+    DefensiveAssistYugamae:
+      data_gen.skillParams['assist']['DefensiveAssistYugamae'],
+    AssistFollowUpYugamaeSlash:
+      data_gen.skillParams['assist']['AssistFollowUpYugamaeSlash'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Jane.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Jane.ts
@@ -1,0 +1,47 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Jane'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackDancingBlades:
+      data_gen.skillParams['basic']['BasicAttackDancingBlades'],
+    Passion: data_gen.skillParams['basic']['Passion'],
+    BasicAttackSalchowJump:
+      data_gen.skillParams['basic']['BasicAttackSalchowJump'],
+  },
+  dodge: {
+    DodgePhantom: data_gen.skillParams['dodge']['DodgePhantom'],
+    DashAttackEdgeJump: data_gen.skillParams['dodge']['DashAttackEdgeJump'],
+    DashAttackPhantomThrust:
+      data_gen.skillParams['dodge']['DashAttackPhantomThrust'],
+    DodgeCounterSwiftShadow:
+      data_gen.skillParams['dodge']['DodgeCounterSwiftShadow'],
+    DodgeCounterSwiftShadowDance:
+      data_gen.skillParams['dodge']['DodgeCounterSwiftShadowDance'],
+  },
+  special: {
+    SpecialAttackAerialSweep:
+      data_gen.skillParams['special']['SpecialAttackAerialSweep'],
+    EXSpecialAttackAerialSweepClearout:
+      data_gen.skillParams['special']['EXSpecialAttackAerialSweepClearout'],
+  },
+  chain: {
+    ChainAttackFlowersOfSin:
+      data_gen.skillParams['chain']['ChainAttackFlowersOfSin'],
+    UltimateFinalCurtain: data_gen.skillParams['chain']['UltimateFinalCurtain'],
+  },
+  assist: {
+    QuickAssistDarkThorn:
+      data_gen.skillParams['assist']['QuickAssistDarkThorn'],
+    QuickAssistLutzJump: data_gen.skillParams['assist']['QuickAssistLutzJump'],
+    DefensiveAssistLastDefense:
+      data_gen.skillParams['assist']['DefensiveAssistLastDefense'],
+    AssistFollowUpGaleSweep:
+      data_gen.skillParams['assist']['AssistFollowUpGaleSweep'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Koleda.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Koleda.ts
@@ -1,0 +1,39 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Koleda'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackSmashNBash:
+      data_gen.skillParams['basic']['BasicAttackSmashNBash'],
+  },
+  dodge: {
+    DodgeWaitNSee: data_gen.skillParams['dodge']['DodgeWaitNSee'],
+    DashAttackTremble: data_gen.skillParams['dodge']['DashAttackTremble'],
+    DodgeCounterDontLookDownOnMe:
+      data_gen.skillParams['dodge']['DodgeCounterDontLookDownOnMe'],
+  },
+  special: {
+    SpecialAttackHammerTime:
+      data_gen.skillParams['special']['SpecialAttackHammerTime'],
+    EXSpecialAttackBoilingFurnace:
+      data_gen.skillParams['special']['EXSpecialAttackBoilingFurnace'],
+  },
+  chain: {
+    ChainAttackNaturalDisaster:
+      data_gen.skillParams['chain']['ChainAttackNaturalDisaster'],
+    UltimateHammerquake: data_gen.skillParams['chain']['UltimateHammerquake'],
+  },
+  assist: {
+    QuickAssistComingThru:
+      data_gen.skillParams['assist']['QuickAssistComingThru'],
+    DefensiveAssistProtectiveHammer:
+      data_gen.skillParams['assist']['DefensiveAssistProtectiveHammer'],
+    AssistFollowUpHammerBell:
+      data_gen.skillParams['assist']['AssistFollowUpHammerBell'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Lighter.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Lighter.ts
@@ -1,0 +1,43 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Lighter'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackLFormThunderingFist:
+      data_gen.skillParams['basic']['BasicAttackLFormThunderingFist'],
+  },
+  dodge: {
+    DodgeShadowedSlide: data_gen.skillParams['dodge']['DodgeShadowedSlide'],
+    DashAttackChargingSlam:
+      data_gen.skillParams['dodge']['DashAttackChargingSlam'],
+    DodgeCounterBlazingFlash:
+      data_gen.skillParams['dodge']['DodgeCounterBlazingFlash'],
+  },
+  special: {
+    SpecialAttackVFormSunriseUppercut:
+      data_gen.skillParams['special']['SpecialAttackVFormSunriseUppercut'],
+    EXSpecialAttackVFormSunriseUppercutFullDistance:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackVFormSunriseUppercutFullDistance'
+      ],
+  },
+  chain: {
+    ChainAttackVFormScorchingSun:
+      data_gen.skillParams['chain']['ChainAttackVFormScorchingSun'],
+    UltimateWFormCrownedInferno:
+      data_gen.skillParams['chain']['UltimateWFormCrownedInferno'],
+  },
+  assist: {
+    QuickAssistBlazingFlashGuard:
+      data_gen.skillParams['assist']['QuickAssistBlazingFlashGuard'],
+    DefensiveAssistSwiftBreak:
+      data_gen.skillParams['assist']['DefensiveAssistSwiftBreak'],
+    AssistFollowUpChargingSlamStab:
+      data_gen.skillParams['assist']['AssistFollowUpChargingSlamStab'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Lucy.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Lucy.ts
@@ -1,0 +1,43 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Lucy'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackLadysBat: data_gen.skillParams['basic']['BasicAttackLadysBat'],
+    GuardBoarsToArms: data_gen.skillParams['basic']['GuardBoarsToArms'],
+    GuardBoarsSpinningSwing:
+      data_gen.skillParams['basic']['GuardBoarsSpinningSwing'],
+  },
+  dodge: {
+    DodgeFoulBall: data_gen.skillParams['dodge']['DodgeFoulBall'],
+    DashAttackFearlessBoar:
+      data_gen.skillParams['dodge']['DashAttackFearlessBoar'],
+    DodgeCounterReturningTusk:
+      data_gen.skillParams['dodge']['DodgeCounterReturningTusk'],
+  },
+  special: {
+    SpecialAttackSolidHit:
+      data_gen.skillParams['special']['SpecialAttackSolidHit'],
+    EXSpecialAttackHomeRun:
+      data_gen.skillParams['special']['EXSpecialAttackHomeRun'],
+    CheerOn: data_gen.skillParams['special']['CheerOn'],
+  },
+  chain: {
+    ChainAttackGrandSlam: data_gen.skillParams['chain']['ChainAttackGrandSlam'],
+    UltimateWalkOffHomeRun:
+      data_gen.skillParams['chain']['UltimateWalkOffHomeRun'],
+  },
+  assist: {
+    QuickAssistHitByPitch:
+      data_gen.skillParams['assist']['QuickAssistHitByPitch'],
+    DefensiveAssistSafeOnBase:
+      data_gen.skillParams['assist']['DefensiveAssistSafeOnBase'],
+    AssistFollowUpScoredARun:
+      data_gen.skillParams['assist']['AssistFollowUpScoredARun'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Lycaon.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Lycaon.ts
@@ -1,0 +1,40 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Lycaon'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackMoonHunter:
+      data_gen.skillParams['basic']['BasicAttackMoonHunter'],
+  },
+  dodge: {
+    DodgeSuitablePositioning:
+      data_gen.skillParams['dodge']['DodgeSuitablePositioning'],
+    DashAttackKeepItClean:
+      data_gen.skillParams['dodge']['DashAttackKeepItClean'],
+    DodgeCounterEtiquetteManual:
+      data_gen.skillParams['dodge']['DodgeCounterEtiquetteManual'],
+  },
+  special: {
+    SpecialAttackTimeToHunt:
+      data_gen.skillParams['special']['SpecialAttackTimeToHunt'],
+    EXSpecialAttackThrillOfTheHunt:
+      data_gen.skillParams['special']['EXSpecialAttackThrillOfTheHunt'],
+  },
+  chain: {
+    ChainAttackAsYouWish: data_gen.skillParams['chain']['ChainAttackAsYouWish'],
+    UltimateMissionComplete:
+      data_gen.skillParams['chain']['UltimateMissionComplete'],
+  },
+  assist: {
+    QuickAssistWolfPack: data_gen.skillParams['assist']['QuickAssistWolfPack'],
+    DefensiveAssistDisruptedHunt:
+      data_gen.skillParams['assist']['DefensiveAssistDisruptedHunt'],
+    AssistFollowUpVengefulCounterattack:
+      data_gen.skillParams['assist']['AssistFollowUpVengefulCounterattack'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Miyabi.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Miyabi.ts
@@ -1,0 +1,40 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Miyabi'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackKazahana: data_gen.skillParams['basic']['BasicAttackKazahana'],
+    BasicAttackShimotsuki:
+      data_gen.skillParams['basic']['BasicAttackShimotsuki'],
+  },
+  dodge: {
+    DodgeMizutori: data_gen.skillParams['dodge']['DodgeMizutori'],
+    DashAttackFuyubachi: data_gen.skillParams['dodge']['DashAttackFuyubachi'],
+    DodgeCounterKanSuzume:
+      data_gen.skillParams['dodge']['DodgeCounterKanSuzume'],
+  },
+  special: {
+    SpecialAttackMiyuki: data_gen.skillParams['special']['SpecialAttackMiyuki'],
+    EXSpecialAttackHisetsu:
+      data_gen.skillParams['special']['EXSpecialAttackHisetsu'],
+  },
+  chain: {
+    ChainAttackSpringsCall:
+      data_gen.skillParams['chain']['ChainAttackSpringsCall'],
+    UltimateLingeringSnow:
+      data_gen.skillParams['chain']['UltimateLingeringSnow'],
+  },
+  assist: {
+    QuickAssistDancingPetals:
+      data_gen.skillParams['assist']['QuickAssistDancingPetals'],
+    DefensiveAssistDriftingPetals:
+      data_gen.skillParams['assist']['DefensiveAssistDriftingPetals'],
+    AssistFollowUpFallingPetals:
+      data_gen.skillParams['assist']['AssistFollowUpFallingPetals'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Nekomata.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Nekomata.ts
@@ -1,0 +1,39 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Nekomata'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackKittySlash:
+      data_gen.skillParams['basic']['BasicAttackKittySlash'],
+    BasicAttackCrimsonBlade:
+      data_gen.skillParams['basic']['BasicAttackCrimsonBlade'],
+  },
+  dodge: {
+    DodgeCantTouchMeow: data_gen.skillParams['dodge']['DodgeCantTouchMeow'],
+    DashAttackOverHere: data_gen.skillParams['dodge']['DashAttackOverHere'],
+    DodgeCounterPhantomClaws:
+      data_gen.skillParams['dodge']['DodgeCounterPhantomClaws'],
+  },
+  special: {
+    SpecialAttackSurpriseAttack:
+      data_gen.skillParams['special']['SpecialAttackSurpriseAttack'],
+    EXSpecialAttackSuperSurpriseAttack:
+      data_gen.skillParams['special']['EXSpecialAttackSuperSurpriseAttack'],
+  },
+  chain: {
+    ChainAttackClawSwipe: data_gen.skillParams['chain']['ChainAttackClawSwipe'],
+    UltimateClawSmash: data_gen.skillParams['chain']['UltimateClawSmash'],
+  },
+  assist: {
+    QuickAssistCatsPaw: data_gen.skillParams['assist']['QuickAssistCatsPaw'],
+    DefensiveAssistDesperateDefense:
+      data_gen.skillParams['assist']['DefensiveAssistDesperateDefense'],
+    AssistFollowUpShadowStrike:
+      data_gen.skillParams['assist']['AssistFollowUpShadowStrike'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Nicole.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Nicole.ts
@@ -1,0 +1,46 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Nicole'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackCunningCombo:
+      data_gen.skillParams['basic']['BasicAttackCunningCombo'],
+    BasicAttackDoAsIPlease:
+      data_gen.skillParams['basic']['BasicAttackDoAsIPlease'],
+  },
+  dodge: {
+    DodgeSpeedDemon: data_gen.skillParams['dodge']['DodgeSpeedDemon'],
+    DashAttackJackInTheBox:
+      data_gen.skillParams['dodge']['DashAttackJackInTheBox'],
+    DodgeCounterDivertedBombard:
+      data_gen.skillParams['dodge']['DodgeCounterDivertedBombard'],
+    DashAttackDoAsIPlease:
+      data_gen.skillParams['dodge']['DashAttackDoAsIPlease'],
+  },
+  special: {
+    SpecialAttackSugarcoatedBullet:
+      data_gen.skillParams['special']['SpecialAttackSugarcoatedBullet'],
+    EXSpecialAttackStuffedSugarcoatedBullet:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackStuffedSugarcoatedBullet'
+      ],
+  },
+  chain: {
+    ChainAttackEtherShellacking:
+      data_gen.skillParams['chain']['ChainAttackEtherShellacking'],
+    UltimateEtherGrenade: data_gen.skillParams['chain']['UltimateEtherGrenade'],
+  },
+  assist: {
+    QuickAssistEmergencyBombard:
+      data_gen.skillParams['assist']['QuickAssistEmergencyBombard'],
+    DefensiveAssistTheHareStrikesBack:
+      data_gen.skillParams['assist']['DefensiveAssistTheHareStrikesBack'],
+    AssistFollowUpWindowOfOpportunity:
+      data_gen.skillParams['assist']['AssistFollowUpWindowOfOpportunity'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Piper.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Piper.ts
@@ -1,0 +1,42 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Piper'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackLoadUpAndRollOut:
+      data_gen.skillParams['basic']['BasicAttackLoadUpAndRollOut'],
+  },
+  dodge: {
+    DodgeHandbrakeDrift: data_gen.skillParams['dodge']['DodgeHandbrakeDrift'],
+    DashAttackPedalToTheMetal:
+      data_gen.skillParams['dodge']['DashAttackPedalToTheMetal'],
+    DodgeCounterPowerDrift:
+      data_gen.skillParams['dodge']['DodgeCounterPowerDrift'],
+  },
+  special: {
+    SpecialAttackTireSpin:
+      data_gen.skillParams['special']['SpecialAttackTireSpin'],
+    SpecialAttackOneTrillionTons:
+      data_gen.skillParams['special']['SpecialAttackOneTrillionTons'],
+    EXSpecialAttackEngineSpin:
+      data_gen.skillParams['special']['EXSpecialAttackEngineSpin'],
+    EXSpecialAttackReallyHeavy:
+      data_gen.skillParams['special']['EXSpecialAttackReallyHeavy'],
+  },
+  chain: {
+    ChainAttackBuckleUp: data_gen.skillParams['chain']['ChainAttackBuckleUp'],
+    UltimateHoldOnTight: data_gen.skillParams['chain']['UltimateHoldOnTight'],
+  },
+  assist: {
+    QuickAssistBrakeTap: data_gen.skillParams['assist']['QuickAssistBrakeTap'],
+    DefensiveAssistEmergencyBrake:
+      data_gen.skillParams['assist']['DefensiveAssistEmergencyBrake'],
+    AssistFollowUpOvertakingManeuver:
+      data_gen.skillParams['assist']['AssistFollowUpOvertakingManeuver'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Pulchra.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Pulchra.ts
@@ -1,0 +1,46 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Pulchra'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackSwiftStrike:
+      data_gen.skillParams['basic']['BasicAttackSwiftStrike'],
+    BasicAttackLeapingStrike:
+      data_gen.skillParams['basic']['BasicAttackLeapingStrike'],
+  },
+  dodge: {
+    DodgeReversalShot: data_gen.skillParams['dodge']['DodgeReversalShot'],
+    DashAttackFirstStrikeAdvantage:
+      data_gen.skillParams['dodge']['DashAttackFirstStrikeAdvantage'],
+    DodgeCounterRelentlessRetribution:
+      data_gen.skillParams['dodge']['DodgeCounterRelentlessRetribution'],
+  },
+  special: {
+    SpecialAttackRendingClaw:
+      data_gen.skillParams['special']['SpecialAttackRendingClaw'],
+    SpecialAttackRendingClawNightmareShadow:
+      data_gen.skillParams['special'][
+        'SpecialAttackRendingClawNightmareShadow'
+      ],
+    EXSpecialAttackRendingClawFlashstep:
+      data_gen.skillParams['special']['EXSpecialAttackRendingClawFlashstep'],
+  },
+  chain: {
+    ChainAttackHeyDidntExpectThatRight:
+      data_gen.skillParams['chain']['ChainAttackHeyDidntExpectThatRight'],
+    UltimateOhTimeToPlay: data_gen.skillParams['chain']['UltimateOhTimeToPlay'],
+  },
+  assist: {
+    QuickAssistContractBodyguard:
+      data_gen.skillParams['assist']['QuickAssistContractBodyguard'],
+    EvasiveAssistContractOutsourcedCombat:
+      data_gen.skillParams['assist']['EvasiveAssistContractOutsourcedCombat'],
+    AssistFollowUpIndependentPricing:
+      data_gen.skillParams['assist']['AssistFollowUpIndependentPricing'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/QingYi.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/QingYi.ts
@@ -1,0 +1,45 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'QingYi'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackPenultimate:
+      data_gen.skillParams['basic']['BasicAttackPenultimate'],
+    BasicAttackEnchantedBlossoms:
+      data_gen.skillParams['basic']['BasicAttackEnchantedBlossoms'],
+    FlashConnect: data_gen.skillParams['basic']['FlashConnect'],
+    BasicAttackEnchantedMoonlitBlossoms:
+      data_gen.skillParams['basic']['BasicAttackEnchantedMoonlitBlossoms'],
+  },
+  dodge: {
+    DodgeSwanSong: data_gen.skillParams['dodge']['DodgeSwanSong'],
+    DashAttackBreach: data_gen.skillParams['dodge']['DashAttackBreach'],
+    DodgeCounterLingeringSentiments:
+      data_gen.skillParams['dodge']['DodgeCounterLingeringSentiments'],
+  },
+  special: {
+    SpecialAttackSunlitGlory:
+      data_gen.skillParams['special']['SpecialAttackSunlitGlory'],
+    EXSpecialAttackMoonlitBegonia:
+      data_gen.skillParams['special']['EXSpecialAttackMoonlitBegonia'],
+  },
+  chain: {
+    ChainAttackTranquilSerenade:
+      data_gen.skillParams['chain']['ChainAttackTranquilSerenade'],
+    UltimateEightSoundsOfGanzhou:
+      data_gen.skillParams['chain']['UltimateEightSoundsOfGanzhou'],
+  },
+  assist: {
+    QuickAssistWindThroughThePines:
+      data_gen.skillParams['assist']['QuickAssistWindThroughThePines'],
+    DefensiveAssistGracefulEmbellishment:
+      data_gen.skillParams['assist']['DefensiveAssistGracefulEmbellishment'],
+    AssistFollowUpSongOfTheClearRiver:
+      data_gen.skillParams['assist']['AssistFollowUpSongOfTheClearRiver'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Rina.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Rina.ts
@@ -1,0 +1,43 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Rina'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackWhackTheDimwit:
+      data_gen.skillParams['basic']['BasicAttackWhackTheDimwit'],
+    BasicAttackShooTheFool:
+      data_gen.skillParams['basic']['BasicAttackShooTheFool'],
+  },
+  dodge: {
+    DodgeDressAdjustment: data_gen.skillParams['dodge']['DodgeDressAdjustment'],
+    DashAttackSuddenSurprise:
+      data_gen.skillParams['dodge']['DashAttackSuddenSurprise'],
+    DodgeCounterBangbooCallback:
+      data_gen.skillParams['dodge']['DodgeCounterBangbooCallback'],
+  },
+  special: {
+    SpecialAttackBeatTheBlockhead:
+      data_gen.skillParams['special']['SpecialAttackBeatTheBlockhead'],
+    EXSpecialAttackDimwitDisappearingTrick:
+      data_gen.skillParams['special']['EXSpecialAttackDimwitDisappearingTrick'],
+  },
+  chain: {
+    ChainAttackCodeOfConduct:
+      data_gen.skillParams['chain']['ChainAttackCodeOfConduct'],
+    UltimateTheQueensAttendants:
+      data_gen.skillParams['chain']['UltimateTheQueensAttendants'],
+  },
+  assist: {
+    QuickAssistDupleMeterAllemande:
+      data_gen.skillParams['assist']['QuickAssistDupleMeterAllemande'],
+    EvasiveAssistTripleMeterCourante:
+      data_gen.skillParams['assist']['EvasiveAssistTripleMeterCourante'],
+    AssistFollowUpQuadrupleMeterGavotte:
+      data_gen.skillParams['assist']['AssistFollowUpQuadrupleMeterGavotte'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Seth.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Seth.ts
@@ -1,0 +1,45 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Seth'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackLightningStrike:
+      data_gen.skillParams['basic']['BasicAttackLightningStrike'],
+    BasicAttackLightningStrikeElectrified:
+      data_gen.skillParams['basic']['BasicAttackLightningStrikeElectrified'],
+  },
+  dodge: {
+    DodgeEvasionManeuver: data_gen.skillParams['dodge']['DodgeEvasionManeuver'],
+    DashAttackThunderAssault:
+      data_gen.skillParams['dodge']['DashAttackThunderAssault'],
+    DodgeCounterRetreatToAdvance:
+      data_gen.skillParams['dodge']['DodgeCounterRetreatToAdvance'],
+  },
+  special: {
+    SpecialAttackThunderShieldRush:
+      data_gen.skillParams['special']['SpecialAttackThunderShieldRush'],
+    EXSpecialAttackThunderShieldRushHighVoltage:
+      data_gen.skillParams['special'][
+        'EXSpecialAttackThunderShieldRushHighVoltage'
+      ],
+  },
+  chain: {
+    ChainAttackFinalJudgement:
+      data_gen.skillParams['chain']['ChainAttackFinalJudgement'],
+    UltimateJusticePrevails:
+      data_gen.skillParams['chain']['UltimateJusticePrevails'],
+  },
+  assist: {
+    QuickAssistArmedSupport:
+      data_gen.skillParams['assist']['QuickAssistArmedSupport'],
+    DefensiveAssistThundershield:
+      data_gen.skillParams['assist']['DefensiveAssistThundershield'],
+    AssistFollowUpPublicSecurityRuling:
+      data_gen.skillParams['assist']['AssistFollowUpPublicSecurityRuling'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Soldier0Anby.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Soldier0Anby.ts
@@ -1,0 +1,43 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Soldier0Anby'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackPenetratingShock:
+      data_gen.skillParams['basic']['BasicAttackPenetratingShock'],
+  },
+  dodge: {
+    DodgeStrobe: data_gen.skillParams['dodge']['DodgeStrobe'],
+    DashAttackTorrent: data_gen.skillParams['dodge']['DashAttackTorrent'],
+    DodgeCounterGroundFlashCounter:
+      data_gen.skillParams['dodge']['DodgeCounterGroundFlashCounter'],
+  },
+  special: {
+    SpecialAttackCelestialThunder:
+      data_gen.skillParams['special']['SpecialAttackCelestialThunder'],
+    SpecialAttackAzureFlash:
+      data_gen.skillParams['special']['SpecialAttackAzureFlash'],
+    SpecialAttackThunderSmite:
+      data_gen.skillParams['special']['SpecialAttackThunderSmite'],
+    EXSpecialAttackSunderingBolt:
+      data_gen.skillParams['special']['EXSpecialAttackSunderingBolt'],
+  },
+  chain: {
+    ChainAttackLeapingThunderstrike:
+      data_gen.skillParams['chain']['ChainAttackLeapingThunderstrike'],
+    UltimateVoidstrike: data_gen.skillParams['chain']['UltimateVoidstrike'],
+  },
+  assist: {
+    QuickAssistCloudFlash:
+      data_gen.skillParams['assist']['QuickAssistCloudFlash'],
+    DefensiveAssistCounterSurge:
+      data_gen.skillParams['assist']['DefensiveAssistCounterSurge'],
+    AssistFollowUpConductingBlow:
+      data_gen.skillParams['assist']['AssistFollowUpConductingBlow'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Soldier11.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Soldier11.ts
@@ -1,0 +1,45 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Soldier11'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackWarmupSparks:
+      data_gen.skillParams['basic']['BasicAttackWarmupSparks'],
+    BasicAttackFireSuppression:
+      data_gen.skillParams['basic']['BasicAttackFireSuppression'],
+  },
+  dodge: {
+    DodgeTemperedFire: data_gen.skillParams['dodge']['DodgeTemperedFire'],
+    DashAttackBlazingFire:
+      data_gen.skillParams['dodge']['DashAttackBlazingFire'],
+    DashAttackFireSuppression:
+      data_gen.skillParams['dodge']['DashAttackFireSuppression'],
+    DodgeCounterBackdraft:
+      data_gen.skillParams['dodge']['DodgeCounterBackdraft'],
+  },
+  special: {
+    SpecialAttackRagingFire:
+      data_gen.skillParams['special']['SpecialAttackRagingFire'],
+    EXSpecialAttackFerventFire:
+      data_gen.skillParams['special']['EXSpecialAttackFerventFire'],
+  },
+  chain: {
+    ChainAttackUpliftingFlame:
+      data_gen.skillParams['chain']['ChainAttackUpliftingFlame'],
+    UltimateBellowingFlame:
+      data_gen.skillParams['chain']['UltimateBellowingFlame'],
+  },
+  assist: {
+    QuickAssistCoveringFire:
+      data_gen.skillParams['assist']['QuickAssistCoveringFire'],
+    DefensiveAssistHoldTheLine:
+      data_gen.skillParams['assist']['DefensiveAssistHoldTheLine'],
+    AssistFollowUpReignition:
+      data_gen.skillParams['assist']['AssistFollowUpReignition'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Soukaku.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Soukaku.ts
@@ -1,0 +1,45 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Soukaku'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackMakingRiceCakes:
+      data_gen.skillParams['basic']['BasicAttackMakingRiceCakes'],
+    BasicAttackMakingRiceCakesFrostedBanner:
+      data_gen.skillParams['basic']['BasicAttackMakingRiceCakesFrostedBanner'],
+  },
+  dodge: {
+    DodgeGrabABite: data_gen.skillParams['dodge']['DodgeGrabABite'],
+    DashAttack5050: data_gen.skillParams['dodge']['DashAttack5050'],
+    DashAttack5050FrostedBanner:
+      data_gen.skillParams['dodge']['DashAttack5050FrostedBanner'],
+    DodgeCounterAwayFromMySnacks:
+      data_gen.skillParams['dodge']['DodgeCounterAwayFromMySnacks'],
+  },
+  special: {
+    SpecialAttackCoolingBento:
+      data_gen.skillParams['special']['SpecialAttackCoolingBento'],
+    EXSpecialAttackFanningMosquitoes:
+      data_gen.skillParams['special']['EXSpecialAttackFanningMosquitoes'],
+    SpecialAttackRally: data_gen.skillParams['special']['SpecialAttackRally'],
+  },
+  chain: {
+    ChainAttackPuddingSlash:
+      data_gen.skillParams['chain']['ChainAttackPuddingSlash'],
+    UltimateJumboPuddingSlash:
+      data_gen.skillParams['chain']['UltimateJumboPuddingSlash'],
+  },
+  assist: {
+    QuickAssistASetForTwo:
+      data_gen.skillParams['assist']['QuickAssistASetForTwo'],
+    DefensiveAssistGuardingTactics:
+      data_gen.skillParams['assist']['DefensiveAssistGuardingTactics'],
+    AssistFollowUpSweepingStrike:
+      data_gen.skillParams['assist']['AssistFollowUpSweepingStrike'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Trigger.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Trigger.ts
@@ -1,0 +1,48 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Trigger'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackColdBoreShot:
+      data_gen.skillParams['basic']['BasicAttackColdBoreShot'],
+    BasicAttackSilencedShot:
+      data_gen.skillParams['basic']['BasicAttackSilencedShot'],
+    BasicAttackHarmonizingShot:
+      data_gen.skillParams['basic']['BasicAttackHarmonizingShot'],
+    BasicAttackHarmonizingShotTartarus:
+      data_gen.skillParams['basic']['BasicAttackHarmonizingShotTartarus'],
+  },
+  dodge: {
+    DodgePhantomConcealment:
+      data_gen.skillParams['dodge']['DodgePhantomConcealment'],
+    DashAttackVengefulSpecter:
+      data_gen.skillParams['dodge']['DashAttackVengefulSpecter'],
+    DodgeCounterCondemnedSoul:
+      data_gen.skillParams['dodge']['DodgeCounterCondemnedSoul'],
+  },
+  special: {
+    SpecialAttackSpectralFlash:
+      data_gen.skillParams['special']['SpecialAttackSpectralFlash'],
+    EXSpecialAttackFlashBurial:
+      data_gen.skillParams['special']['EXSpecialAttackFlashBurial'],
+  },
+  chain: {
+    ChainAttackStygianGuide:
+      data_gen.skillParams['chain']['ChainAttackStygianGuide'],
+    UltimateUnderworldRequiem:
+      data_gen.skillParams['chain']['UltimateUnderworldRequiem'],
+  },
+  assist: {
+    QuickAssistColdBoreCoverFire:
+      data_gen.skillParams['assist']['QuickAssistColdBoreCoverFire'],
+    DefensiveAssistDelayingDemise:
+      data_gen.skillParams['assist']['DefensiveAssistDelayingDemise'],
+    AssistFollowUpPiercingThunder:
+      data_gen.skillParams['assist']['AssistFollowUpPiercingThunder'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/Yanagi.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/Yanagi.ts
@@ -1,0 +1,41 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'Yanagi'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackTsukuyomiKagura:
+      data_gen.skillParams['basic']['BasicAttackTsukuyomiKagura'],
+    StanceJougen: data_gen.skillParams['basic']['StanceJougen'],
+    StanceKagen: data_gen.skillParams['basic']['StanceKagen'],
+  },
+  dodge: {
+    DodgeWanderingBreeze: data_gen.skillParams['dodge']['DodgeWanderingBreeze'],
+    DashAttackFleetingFlight:
+      data_gen.skillParams['dodge']['DashAttackFleetingFlight'],
+    DodgeCounterRapidRetaliation:
+      data_gen.skillParams['dodge']['DodgeCounterRapidRetaliation'],
+  },
+  special: {
+    SpecialAttackRuten: data_gen.skillParams['special']['SpecialAttackRuten'],
+    EXSpecialAttackGekkaRuten:
+      data_gen.skillParams['special']['EXSpecialAttackGekkaRuten'],
+  },
+  chain: {
+    ChainAttackCelestialHarmony:
+      data_gen.skillParams['chain']['ChainAttackCelestialHarmony'],
+    UltimateRaieiTenge: data_gen.skillParams['chain']['UltimateRaieiTenge'],
+  },
+  assist: {
+    QuickAssistBladeOfElegance:
+      data_gen.skillParams['assist']['QuickAssistBladeOfElegance'],
+    DefensiveAssistRadiantReversal:
+      data_gen.skillParams['assist']['DefensiveAssistRadiantReversal'],
+    AssistFollowUpWeepingWillowStab:
+      data_gen.skillParams['assist']['AssistFollowUpWeepingWillowStab'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/char/maps/ZhuYuan.ts
+++ b/libs/zzz/stats/src/mappedStats/char/maps/ZhuYuan.ts
@@ -1,0 +1,44 @@
+import type { CharacterKey } from '@genshin-optimizer/zzz/consts'
+import { getCharStat } from '../../../char'
+
+const key: CharacterKey = 'ZhuYuan'
+const data_gen = getCharStat(key)
+
+const dm = {
+  basic: {
+    BasicAttackDontMove: data_gen.skillParams['basic']['BasicAttackDontMove'],
+    BasicAttackPleaseDoNotResist:
+      data_gen.skillParams['basic']['BasicAttackPleaseDoNotResist'],
+  },
+  dodge: {
+    DodgeTacticalDetour: data_gen.skillParams['dodge']['DodgeTacticalDetour'],
+    DashAttackFirepowerOffensive:
+      data_gen.skillParams['dodge']['DashAttackFirepowerOffensive'],
+    DashAttackOverwhelmingFirepower:
+      data_gen.skillParams['dodge']['DashAttackOverwhelmingFirepower'],
+    DodgeCounterFireBlast:
+      data_gen.skillParams['dodge']['DodgeCounterFireBlast'],
+  },
+  special: {
+    SpecialAttackBuckshotBlast:
+      data_gen.skillParams['special']['SpecialAttackBuckshotBlast'],
+    EXSpecialAttackFullBarrage:
+      data_gen.skillParams['special']['EXSpecialAttackFullBarrage'],
+  },
+  chain: {
+    ChainAttackEradicationMode:
+      data_gen.skillParams['chain']['ChainAttackEradicationMode'],
+    UltimateMaxEradicationMode:
+      data_gen.skillParams['chain']['UltimateMaxEradicationMode'],
+  },
+  assist: {
+    QuickAssistCoveringShot:
+      data_gen.skillParams['assist']['QuickAssistCoveringShot'],
+    EvasiveAssistGuardedBackup:
+      data_gen.skillParams['assist']['EvasiveAssistGuardedBackup'],
+    AssistFollowUpDefensiveCounter:
+      data_gen.skillParams['assist']['AssistFollowUpDefensiveCounter'],
+  },
+} as const
+
+export default dm

--- a/libs/zzz/stats/src/mappedStats/index.ts
+++ b/libs/zzz/stats/src/mappedStats/index.ts
@@ -1,5 +1,7 @@
+import char from './char'
 import wengine from './wengine'
 
 export const mappedStats = {
+  char,
   wengine,
 }


### PR DESCRIPTION
## Describe your changes

Add support for skillParams for agent skills in stats, mappedStats and dmg util in formula

Daze and Anomaly utils will need to be updated to use SkillParam shape as well

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded character profiles: Each character now includes comprehensive skill details—categorized into basic, dodge, special, chain, and assist—providing richer insights into their abilities.
  - Improved damage calculations: Updated formulas now leverage enhanced skill parameters for more precise performance metrics.
  - Enhanced data presentation: Character mapping has been refined to offer a more intuitive view of statistics and abilities for a better overall gameplay experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->