### PR TITLE
GO: Fix Tenacity of the millelith shield strength value

### DIFF
--- a/libs/gi/sheets/src/Artifacts/TenacityOfTheMillelith/index.tsx
+++ b/libs/gi/sheets/src/Artifacts/TenacityOfTheMillelith/index.tsx
@@ -26,7 +26,7 @@ const [set4Atk, set4AtkInactive] = nonStackBuff('totm4', 'atk_', percent(0.2))
 const [set4Shield, set4ShieldInactive] = nonStackBuff(
   'totm4',
   'shield_',
-  percent(0.2)
+  percent(0.3)
 )
 
 export const data: Data = dataObjForArtifactSheet(key, {


### PR DESCRIPTION
## Describe your changes

- Fix for TOFM shield strength from 20% to 30%

## Issue or discord link

https://discord.com/channels/785153694478893126/1360873912468115466

## Testing/validation

![image](https://github.com/user-attachments/assets/563e6925-53cc-4d17-bbdc-0b4e98134675)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced character defense by increasing the shield strength when equipping four pieces of the "Tenacity of the Millelith" artifact set, providing a more robust protective barrier in gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->