### PR TITLE
ZO: Fix modal not opening when creating a new char on char page

### DIFF
--- a/libs/zzz/page-characters/src/index.tsx
+++ b/libs/zzz/page-characters/src/index.tsx
@@ -102,7 +102,9 @@ export default function PageCharacter() {
     return characterKeyRaw as CharacterKey
   }, [characterKeyRaw, navigate])
   const character = useCharacter(characterKey ?? undefined)
-  const charOpt = useCharOpt(characterKey ?? undefined)
+  const charOpt =
+    useCharOpt(characterKey ?? undefined) ??
+    (characterKey && database.charOpts.getOrCreate(characterKey))
   const tag = useMemo<Tag>(
     () => ({
       src: characterKey,
@@ -121,10 +123,6 @@ export default function PageCharacter() {
       (_, r) => (r === 'new' || r === 'remove') && forceUpdate()
     )
   }, [forceUpdate, database])
-
-  useEffect(() => {
-    if (characterKey && !charOpt) database.charOpts.getOrCreate(characterKey)
-  }, [characterKey, charOpt, database.charOpts])
 
   const editCharacter = useCallback(
     (characterKey: CharacterKey) => {

--- a/libs/zzz/page-characters/src/index.tsx
+++ b/libs/zzz/page-characters/src/index.tsx
@@ -122,6 +122,10 @@ export default function PageCharacter() {
     )
   }, [forceUpdate, database])
 
+  useEffect(() => {
+    if (characterKey && !charOpt) database.charOpts.getOrCreate(characterKey)
+  }, [characterKey, charOpt, database.charOpts])
+
   const editCharacter = useCallback(
     (characterKey: CharacterKey) => {
       const character = database.chars.get(characterKey)
@@ -227,7 +231,6 @@ export default function PageCharacter() {
     onChangeAsc: (ascending: boolean) =>
       database.displayCharacter.set({ ascending }),
   }
-
   return (
     <Box display="flex" flexDirection="column" gap={2}>
       {characterKey && character && charOpt && (


### PR DESCRIPTION
## Describe your changes

- Due to charOpt being a requirement for the modal to show, this wasn't happening because charOpt was not set on a new character that was added from character page. Useeffect was used her to add new char to charopt and also add existing chars to charopt ( if they aren't there already )

## Issue or discord link

https://discord.com/channels/785153694478893126/1353253559495299134

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability in loading character options, ensuring they are created or retrieved automatically when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->