### PR TITLE
CI: Add version to run name for clarity on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Check Formatting (Changed Files)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          yarn biome ci --changed
+          yarn biome ci --changed --no-errors-on-unmatched
       - name: Check Formatting
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -1,4 +1,5 @@
 name: New Release
+run-name: New Release ${{ inputs.version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/new-zo-release.yml
+++ b/.github/workflows/new-zo-release.yml
@@ -1,10 +1,11 @@
 name: New ZO Release
+run-name: New ZO Release ${{ inputs.version }}
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version'
+        description: 'Version. Provide as `xx.yy.zz`. The `+zo` metadata suffix will be automatically added for you.'
         type: string
 
 jobs:


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Currently all releases have the same name
![image](https://github.com/user-attachments/assets/90bf15ae-b5ce-4ef5-b270-2e271224d3af)

With this change, they would have the version in the name, making it easier to determine what version to bump to when starting the action. Similar to how our build actions have different run names
![image](https://github.com/user-attachments/assets/57e0298f-b645-4320-aa67-033b4a38f60c)


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow run names to dynamically include the provided version number for release processes.
  - Clarified the version input description for the "New ZO Release" workflow to specify the required format and automatic metadata addition.
  - Improved formatting checks during pull requests to reduce false errors on unmatched files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->