### PR TITLE
GI: Fix Escoffier c1 conditional not working

### DIFF
--- a/libs/gi/sheets/src/Characters/Escoffier/index.tsx
+++ b/libs/gi/sheets/src/Characters/Escoffier/index.tsx
@@ -126,7 +126,11 @@ const c1AfterSkillBurst_cryo_critDMG_ = greaterEq(
   greaterEq(
     input.asc,
     4,
-    equal(hydroCryoTeammates, 4, dm.constellation1.cryo_critDMG_)
+    equal(
+      hydroCryoTeammates,
+      4,
+      equal(condC1AfterSkillBurst, 'on', dm.constellation1.cryo_critDMG_)
+    )
   )
 )
 


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the conditions for receiving the constellation 1 cryo critical damage bonus to require both having exactly four hydro or cryo teammates and the constellation 1 effect being active after using skill or burst.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->