### PR TITLE
GO: Fix Escoffier C2 and weapon nonstacking

### DIFF
--- a/libs/gi/sheets/src/Characters/Escoffier/index.tsx
+++ b/libs/gi/sheets/src/Characters/Escoffier/index.tsx
@@ -10,6 +10,7 @@ import {
   subscript,
   sum,
   tally,
+  target,
   unequal,
 } from '@genshin-optimizer/gi/wr'
 import { cond, st, stg } from '../../SheetUtil'
@@ -135,10 +136,20 @@ const c1AfterSkillBurst_cryo_critDMG_ = greaterEq(
 )
 
 const [condC2StacksPath, condC2Stacks] = cond(key, 'c2Stacks')
-const c2Stacks_cryo_dmgInc = greaterEq(
+const c2Stacks_cryo_dmgIncDisp = greaterEq(
   input.constellation,
   2,
-  prod(percent(dm.constellation2.dmgInc), input.total.atk)
+  equal(
+    condC2Stacks,
+    'on',
+    prod(percent(dm.constellation2.dmgInc), input.total.atk)
+  ),
+  { path: 'cryo_dmgInc', isTeamBuff: true }
+)
+const c2Stacks_cryo_dmgInc = unequal(
+  target.charKey,
+  key,
+  c2Stacks_cryo_dmgIncDisp
 )
 
 const dmgFormulas = {
@@ -404,7 +415,7 @@ const sheet: TalentSheet = {
         on: {
           fields: [
             {
-              node: c2Stacks_cryo_dmgInc,
+              node: c2Stacks_cryo_dmgIncDisp,
             },
             {
               text: st('triggerQuota'),

--- a/libs/gi/sheets/src/Weapons/Polearm/SymphonistOfScents/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Polearm/SymphonistOfScents/index.tsx
@@ -1,6 +1,12 @@
 import type { WeaponKey } from '@genshin-optimizer/gi/consts'
-import { equal, input, subscript, sum, unequal } from '@genshin-optimizer/gi/wr'
-import { cond, st, stg } from '../../../SheetUtil'
+import {
+  equalStr,
+  input,
+  subscript,
+  sum,
+  unequal,
+} from '@genshin-optimizer/gi/wr'
+import { cond, nonStackBuff, st, stg } from '../../../SheetUtil'
 import type { IWeaponSheet } from '../../IWeaponSheet'
 import { WeaponSheet, headerTemplate } from '../../WeaponSheet'
 import { dataObjForWeaponSheet } from '../../util'
@@ -19,9 +25,10 @@ const offField_atk_ = unequal(
 )
 
 const [condHealingPath, condHealing] = cond(key, 'healing')
-const healing_atk_ = equal(
-  condHealing,
-  'on',
+const nonstackWrite = equalStr(condHealing, 'on', input.charKey)
+const [healing_atk_, healing_atk_inactive] = nonStackBuff(
+  'symphonist',
+  'atk_',
   subscript(input.weapon.refinement, team_atk_arr)
 )
 
@@ -29,7 +36,10 @@ const data = dataObjForWeaponSheet(key, {
   premod: {
     atk_: sum(atk_, offField_atk_),
   },
-  teamBuff: { premod: { atk_: healing_atk_ } },
+  teamBuff: {
+    premod: { atk_: healing_atk_ },
+    nonStacking: { symphonist: nonstackWrite },
+  },
 })
 
 const sheet: IWeaponSheet = {
@@ -56,6 +66,9 @@ const sheet: IWeaponSheet = {
           fields: [
             {
               node: healing_atk_,
+            },
+            {
+              node: healing_atk_inactive,
             },
             {
               text: stg('duration'),

--- a/libs/gi/wr/src/formula.ts
+++ b/libs/gi/wr/src/formula.ts
@@ -86,6 +86,7 @@ const allNonstackBuffs = [
   'hakushindendro',
   'ttds',
   'wolf',
+  'symphonist',
 ] as const
 export type NonStackBuff = (typeof allNonstackBuffs)[number]
 const allMoves = [


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Escoffier's constellation 2 effect to distinguish between the displayed Cryo damage buff and its conditional team application.
  - Improved Symphonist of Scents weapon buff logic to ensure non-stacking behavior for team buffs.

- **Bug Fixes**
  - Buffs from Symphonist of Scents now correctly track activation and prevent stacking across the team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->