### PR TITLE
GO: Fix issue with Sturdy Bone passive appearing after changing weapon

### DIFF
--- a/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
@@ -11,15 +11,17 @@ const normal_dmgInc_arr = [-1, 0.16, 0.2, 0.24, 0.28, 0.32]
 
 const [condAfterSprintPath, condAfterSprint] = cond(key, 'afterSprint')
 const normal_dmgInc = equal(
-  condAfterSprint,
-  'on',
-  prod(
-    subscript(input.weapon.refinement, normal_dmgInc_arr, { unit: '%' }),
-    input.total.atk
+  input.weapon.key,
+  key,
+  equal(
+    condAfterSprint,
+    'on',
+    prod(
+      subscript(input.weapon.refinement, normal_dmgInc_arr, { unit: '%' }),
+      input.total.atk
+    )
   )
 )
-
-const dmg = equal(input.weapon.key, key, normal_dmgInc)
 
 const data = dataObjForWeaponSheet(
   key,
@@ -28,7 +30,7 @@ const data = dataObjForWeaponSheet(
       normal_dmgInc,
     },
   },
-  { dmg }
+  { normal_dmgInc }
 )
 const sheet: IWeaponSheet = {
   document: [

--- a/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
@@ -11,8 +11,8 @@ const normal_dmgInc_arr = [-1, 0.16, 0.2, 0.24, 0.28, 0.32]
 
 const [condAfterSprintPath, condAfterSprint] = cond(key, 'afterSprint')
 const normal_dmgInc = equal(
-  'on',
   condAfterSprint,
+  'on',
   prod(
     subscript(input.weapon.refinement, normal_dmgInc_arr, { unit: '%' }),
     input.total.atk

--- a/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
+++ b/libs/gi/sheets/src/Weapons/Sword/SturdyBone/index.tsx
@@ -11,13 +11,15 @@ const normal_dmgInc_arr = [-1, 0.16, 0.2, 0.24, 0.28, 0.32]
 
 const [condAfterSprintPath, condAfterSprint] = cond(key, 'afterSprint')
 const normal_dmgInc = equal(
-  condAfterSprint,
   'on',
+  condAfterSprint,
   prod(
     subscript(input.weapon.refinement, normal_dmgInc_arr, { unit: '%' }),
     input.total.atk
   )
 )
+
+const dmg = equal(input.weapon.key, key, normal_dmgInc)
 
 const data = dataObjForWeaponSheet(
   key,
@@ -26,7 +28,7 @@ const data = dataObjForWeaponSheet(
       normal_dmgInc,
     },
   },
-  { normal_dmgInc }
+  { dmg }
 )
 const sheet: IWeaponSheet = {
   document: [


### PR DESCRIPTION
## Describe your changes

- Added a equal func for dmg to only appear when wep is equipped

## Issue or discord link

https://discord.com/channels/785153694478893126/1370842985650196640

## Testing/validation

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated damage calculation logic to ensure damage bonuses are only applied when the correct weapon is equipped. This change does not affect the appearance or usage of the feature but improves its internal accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->