### PR TITLE
ZO: Fix flat energy regen from core stats being too high

### DIFF
--- a/libs/zzz/dm/src/dm/character/character.ts
+++ b/libs/zzz/dm/src/dm/character/character.ts
@@ -232,7 +232,9 @@ export const charactersDetailedJSONData = Object.fromEntries(
                 coreStatMap[Name],
                 isPercentStat(coreStatMap[Name])
                   ? Value / PERCENT_SCALING
-                  : Value,
+                  : coreStatMap[Name] === 'enerRegen'
+                    ? Value / FLAT_SCALING
+                    : Value,
               ])
             ) as Partial<
               Record<(typeof coreStatMap)[keyof typeof coreStatMap], number>

--- a/libs/zzz/stats/Data/Characters/Astra.json
+++ b/libs/zzz/stats/Data/Characters/Astra.json
@@ -25,12 +25,12 @@
     { "hp": 2375, "atk": 184, "def": 166 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Ben.json
+++ b/libs/zzz/stats/Data/Characters/Ben.json
@@ -25,12 +25,12 @@
     { "hp": 2366, "atk": 168, "def": 200 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Burnice.json
+++ b/libs/zzz/stats/Data/Characters/Burnice.json
@@ -25,12 +25,12 @@
     { "hp": 2033, "atk": 222, "def": 166 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Lucy.json
+++ b/libs/zzz/stats/Data/Characters/Lucy.json
@@ -25,12 +25,12 @@
     { "hp": 2214, "atk": 169, "def": 169 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Nicole.json
+++ b/libs/zzz/stats/Data/Characters/Nicole.json
@@ -25,12 +25,12 @@
     { "hp": 2247, "atk": 167, "def": 172 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Piper.json
+++ b/libs/zzz/stats/Data/Characters/Piper.json
@@ -25,12 +25,12 @@
     { "hp": 1925, "atk": 195, "def": 169 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Seth.json
+++ b/libs/zzz/stats/Data/Characters/Seth.json
@@ -25,12 +25,12 @@
     { "hp": 2401, "atk": 165, "def": 206 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/Data/Characters/Soukaku.json
+++ b/libs/zzz/stats/Data/Characters/Soukaku.json
@@ -25,12 +25,12 @@
     { "hp": 2214, "atk": 171, "def": 165 }
   ],
   "coreStats": [
-    { "atk": 0, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 12 },
-    { "atk": 25, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 24 },
-    { "atk": 50, "enerRegen": 36 },
-    { "atk": 75, "enerRegen": 36 }
+    { "atk": 0, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.12 },
+    { "atk": 25, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.24 },
+    { "atk": 50, "enerRegen": 0.36 },
+    { "atk": 75, "enerRegen": 0.36 }
   ],
   "skillParams": {
     "basic": {

--- a/libs/zzz/stats/src/allStat_gen.json
+++ b/libs/zzz/stats/src/allStat_gen.json
@@ -798,27 +798,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -4399,27 +4399,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -4793,27 +4793,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -5743,27 +5743,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -6756,27 +6756,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -10702,27 +10702,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -11146,27 +11146,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {
@@ -12157,27 +12157,27 @@
       "coreStats": [
         {
           "atk": 0,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 12
+          "enerRegen": 0.12
         },
         {
           "atk": 25,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 24
+          "enerRegen": 0.24
         },
         {
           "atk": 50,
-          "enerRegen": 36
+          "enerRegen": 0.36
         },
         {
           "atk": 75,
-          "enerRegen": 36
+          "enerRegen": 0.36
         }
       ],
       "skillParams": {


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- https://discord.com/channels/785153694478893126/1378242220884234311

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the scale of energy regeneration ("enerRegen") values for several characters, changing them from whole numbers to decimal fractions for improved accuracy and consistency in character stats display. No other stats or fields were affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->