### PR TITLE
ZO: Sum initial and combat Crit DMG for Sanby

### DIFF
--- a/libs/zzz/formula/src/data/char/sheets/Soldier0Anby.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Soldier0Anby.ts
@@ -1,4 +1,4 @@
-import { cmpGE, prod } from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
 import {
@@ -34,7 +34,9 @@ const sheet = register(
     'core_markedWithSilverStar_crit_dmg_',
     ownBuff.final.crit_dmg_.addWithDmgType(
       'aftershock',
-      core_markedWithSilverStar.ifOn(prod(own.initial.crit_dmg_, percent(0.3))) // TODO: Replace this with proper core indexing once sheets are added
+      core_markedWithSilverStar.ifOn(
+        prod(sum(own.initial.crit_dmg_, own.combat.crit_dmg_), percent(0.3))
+      ) // TODO: Replace this with proper core indexing once sheets are added
     )
   ),
 


### PR DESCRIPTION
## Describe your changes

Fixes issue, where combat crit dmg is not taken into account for her core passive

## Issue or discord link

- https://discord.com/channels/785153694478893126/1353253559495299134/1382278809562382377

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the calculation for the critical damage bonus from the Silver Star buff to account for both initial and current combat critical damage, ensuring more accurate bonus scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->