### PR TITLE
Fix missing return on withAll

### DIFF
--- a/libs/pando/engine/src/node/read.ts
+++ b/libs/pando/engine/src/node/read.ts
@@ -55,7 +55,10 @@ export class TypedRead<T extends Tag> implements BaseRead {
       ownKeys: (_) => keys,
       get: (old, p: T[C] & string) =>
         old[p] ?? (old[p] = transform(this.with(cat, p), p)),
-      set: (old, p: T[C] & string, v) => (old[p] = v),
+      set: (old, p: T[C] & string, v) => {
+        old[p] = v
+        return true
+      },
       getOwnPropertyDescriptor: (old, p: T[C] & string) => ({
         enumerable: true,
         configurable: true,


### PR DESCRIPTION
## Describe your changes

Add missing `return true` to Proxy set method

## Issue or discord link

- https://discord.com/channels/785153694478893126/1288975477981057124/1384539109640638497

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved internal handling of property assignments to ensure correct behavior when updating values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->