### PR TITLE
GO: Invert how Skirk C2 applies ATK so stats page matches, and change C6 getting buffed by Burst

### DIFF
--- a/libs/gi/localization/assets/locales/en/char_Skirk.json
+++ b/libs/gi/localization/assets/locales/en/char_Skirk.json
@@ -4,6 +4,7 @@
   "a4Cond": "Death's Crossing stacks",
   "c2AddlSerpentFactor": "Maximum Serpent's Subtlety factored",
   "c2Cond": "After using <strong>Havoc: Extinction</strong> while in <strong>Seven-Phase Flash</strong> mode",
+  "c2Atk_blurb": "The above ATK buff will not be applied to Skirk's Normal Attack, Elemental Burst, nor her C6 Burst DMG",
   "c6BurstDmg": "Burst DMG",
   "c6NormalDmg": "Normal Attack DMG",
   "c6ChargedDmg": "Charged Attack DMG"

--- a/libs/gi/sheets/src/Characters/Skirk/index.tsx
+++ b/libs/gi/sheets/src/Characters/Skirk/index.tsx
@@ -191,11 +191,14 @@ const a4DeathStacks_burst_mult_ = threshold(
   one
 )
 
-const burstSerpentOver_burst_dmgInc = prod(
-  burstSerpentOver,
-  subscript(input.total.burstIndex, dm.burst.serpentBonus, { unit: '%' }),
-  a4DeathStacks_burst_mult_,
-  input.total.atk
+const burstSerpentOver_burst_dmgInc = infoMut(
+  prod(
+    burstSerpentOver,
+    subscript(input.total.burstIndex, dm.burst.serpentBonus, { unit: '%' }),
+    a4DeathStacks_burst_mult_,
+    input.total.atk
+  ),
+  { path: 'burst_dmgInc' }
 )
 
 const a0SkillBoost = greaterEq(
@@ -221,6 +224,12 @@ const c2_atk_ = greaterEq(
 )
 const c2_inverted_atk_ = infoMut(prod(c2_atk_, -1), { path: 'atk_' })
 const c2_inverted_atk_data = { premod: { atk_: c2_inverted_atk_ } }
+const burstData = {
+  premod: {
+    atk_: c2_inverted_atk_,
+    burst_dmgInc: burstSerpentOver_burst_dmgInc,
+  },
+}
 
 const burstSerpentOver_burst_dmgIncDisp = prod(
   burstSerpentOver,
@@ -292,14 +301,14 @@ const dmgFormulas = {
       'atk',
       dm.burst.skillDmg,
       'burst',
-      c2_inverted_atk_data,
+      burstData,
       a4DeathStacks_burst_mult_
     ),
     finalDmg: dmgNode(
       'atk',
       dm.burst.finalDmg,
       'burst',
-      c2_inverted_atk_data,
+      burstData,
       a4DeathStacks_burst_mult_
     ),
   },
@@ -319,7 +328,6 @@ const dmgFormulas = {
     ),
   },
   constellation6: {
-    // TODO: Check if this is affected by a4 stacks
     burstDmg: greaterEq(
       input.constellation,
       6,
@@ -379,7 +387,6 @@ export const data = dataObjForCharacterSheet(key, dmgFormulas, {
   premod: {
     skillBoost: skillC5,
     burstBoost: burstC3,
-    burst_dmgInc: burstSerpentOver_burst_dmgInc,
     normal_dmg_: burstVoidAbsorb_normal_dmg_,
     atk_: sum(c2_atk_, c4DeathStacks_atk_),
   },


### PR DESCRIPTION
## Describe your changes

Before, Skirk's C2 ATK buff was only applied to relevant hits, to prevent people accidentally optimizing for impossible scenarios. This made the stats page not line up in-game.

This PR inverts that by applying the C2 ATK buff to everything and removing it from those impossible situations. This is actually more correct as well, in the really weird case that someone would use a weapon like Skyward Blade with a damage instance while in this state (while simultaneously having C2)

Removed C6 scaling off of Serpent Subtlety stacks

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new descriptive note in Skirk's English character details to clarify how her ATK buff works.

- **Improvements**
  - Adjusted Skirk's attack bonus calculations and display to more accurately reflect the effects of her constellation abilities.
  - Updated talent sheet and damage formulas for Skirk to provide clearer information and improved consistency in how attack modifiers are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->