### PR TITLE
ZO: Fix evelyn's mv_mult_ buff

### DIFF
--- a/libs/zzz/formula/src/data/char/sheets/Evelyn.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Evelyn.ts
@@ -120,7 +120,13 @@ const sheet = register(
           team.common.count.withSpecialty('support')
         ),
         1,
-        dm.ability.dmg_mult_
+        cmpGE(
+          own.final.crit_,
+          percent(dm.ability.crit_threshold),
+          dm.ability.dmg_mult_,
+          percent(1)
+        ),
+        percent(1)
       )
     )
   ),


### PR DESCRIPTION
## Describe your changes

Fixes Evelyn's `mv_mult_` buff applying 0% mult, so Chain and Ult damage become 0

## Issue or discord link

- https://discord.com/channels/785153694478893126/1252702983561543750/1388062966670295090

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Damage multiplier for a specific buff now also depends on the character's critical rate meeting a threshold, in addition to team composition.

* **Bug Fixes**
  * Improved accuracy of buff application by adding a critical rate condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->