### PR TITLE
ZO: Change how mv_mult_ is applied

### DIFF
--- a/libs/zzz/formula/src/data/char/sheets/Evelyn.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Evelyn.ts
@@ -123,10 +123,8 @@ const sheet = register(
         cmpGE(
           own.final.crit_,
           percent(dm.ability.crit_threshold),
-          dm.ability.dmg_mult_,
-          percent(1)
-        ),
-        percent(1)
+          percent(dm.ability.dmg_mult_)
+        )
       )
     )
   ),

--- a/libs/zzz/formula/src/data/char/util.ts
+++ b/libs/zzz/formula/src/data/char/util.ts
@@ -1,5 +1,6 @@
 import { crawlObject, layeredAssignment } from '@genshin-optimizer/common/util'
 import {
+  cmpEq,
   cmpGE,
   constant,
   prod,
@@ -72,7 +73,11 @@ function dmgDazeAndAnom(
     skillParam.DamagePercentage,
     prod(own.char[abilityScalingType], skillParam.DamagePercentageGrowth)
   )
-  const dmgBase = prod(own.final[stat], dmgMulti, own.dmg.mv_mult_)
+  const dmgBase = prod(
+    own.final[stat],
+    dmgMulti,
+    cmpEq(own.dmg.mv_mult_, 0, percent(1), own.dmg.mv_mult_)
+  )
   const dazeBase = sum(
     skillParam.StunRatio,
     prod(own.char[abilityScalingType], skillParam.StunRatioGrowth)
@@ -119,7 +124,11 @@ export function dmgDazeAndAnomMerge(
       sum(...skillParam.map((sp) => sp.DamagePercentageGrowth))
     )
   )
-  const dmgBase = prod(own.final[stat], dmgMulti, own.dmg.mv_mult_)
+  const dmgBase = prod(
+    own.final[stat],
+    dmgMulti,
+    cmpEq(own.dmg.mv_mult_, 0, percent(1), own.dmg.mv_mult_)
+  )
   const dazeBase = sum(
     ...skillParam.map((sp) => sp.StunRatio),
     prod(


### PR DESCRIPTION
## Describe your changes

As it is, when registering any `mv_mult_` buffs with a condition, you had to add 100% if it's false. With this, you won't have to specify the 100% if false, shows the buffs correctly in the UI and any additional multipliers will work correctly with each other.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation logic to prevent damage values from being nullified when certain multipliers are zero, ensuring consistent and expected results for damage-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->