### PR TITLE
Fix tally bug

### DIFF
--- a/libs/gi/sheets/src/Characters/dataUtil.tsx
+++ b/libs/gi/sheets/src/Characters/dataUtil.tsx
@@ -332,12 +332,9 @@ export function dataObjForCharacterSheet(
     data.display!['reaction'] = reactions[element]
   }
   if (region) data.teamBuff!.tally![region] = constant(1)
-  if (weaponType !== 'catalyst') {
-    if (!data.display!['basic']) data.display!['basic'] = {}
+  if (weaponType !== 'catalyst')
     data.display!['basic']!['physical_dmg_'] = input.total.physical_dmg_
-  }
 
-  let foundSpecial: boolean | undefined
   for (const stat of [...allMainStatKeys, 'def' as const]) {
     const list: NumNode[] = []
     const lvlCurveBase = lvlCurves.find((lc) => lc.key === stat)
@@ -357,8 +354,7 @@ export function dataObjForCharacterSheet(
     if (stat === 'atk' || stat === 'def' || stat === 'hp')
       data.base![stat] = result
     else {
-      if (foundSpecial) throw new Error('Multiple Char Special')
-      foundSpecial = true
+      if (data.special) throw new Error('Multiple Char Special')
       data.special = result
       data.premod![stat] = input.special
     }

--- a/libs/gi/sheets/src/Characters/dataUtil.tsx
+++ b/libs/gi/sheets/src/Characters/dataUtil.tsx
@@ -327,7 +327,7 @@ export function dataObjForCharacterSheet(
   }
   if (element) {
     data.charEle = constant(element)
-    data.teamBuff = { tally: { [element]: constant(1) } }
+    data.teamBuff!.tally![element] = constant(1)
     data.display!['basic'][`${element}_dmg_`] = input.total[`${element}_dmg_`]
     data.display!['reaction'] = reactions[element]
   }


### PR DESCRIPTION
## Describe your changes

Fix a bug introduced in #2999 that causes the `tally.maxElemas` to be infinity.

It is caused by `data.teamBuff` being overidden in `dataObjectForCharacterSheet`.

## Issue or discord link

- https://discord.com/channels/785153694478893126/819643218446254100/1392749002247901225

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of team buff tracking to ensure all relevant entries are preserved.
  * Enhanced error detection for multiple special stats in character data.
  * Simplified logic for displaying physical damage stats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->