### PR TITLE
Re-add `teamBuffDisplay` for `UIData.getTeamBuff`

### DIFF
--- a/libs/gi/uidata/src/uiData.ts
+++ b/libs/gi/uidata/src/uiData.ts
@@ -106,7 +106,7 @@ export class UIData {
   }
   getTeamBuff(): UIInput<CalcResult, CalcResult<string>> {
     if (!this.teamBuff) {
-      const calculated = this.getAll(['teamBuff']),
+      const calculated = this.getAll(['teamBuffDisplay']),
         result = {} as any
       // Convert `input` to `uiInput`
       crawlObject(
@@ -353,7 +353,7 @@ export class UIData {
   }
   private _subscript(node: SubscriptNode<number>): CalcResult<number> {
     const operand = this.computeNode(node.operands[0])
-    const value = node.list[operand.value] ?? NaN
+    const value = node.list[operand.value] ?? Number.NaN
     return this._constant(value)
   }
   private _constant<V>(value: V): CalcResult<V> {
@@ -449,7 +449,7 @@ function mergeInfo(base: Info, override: Info): Info {
 }
 
 const illformed: CalcResult<number> = {
-  value: NaN,
+  value: Number.NaN,
   meta: {
     op: 'const',
     ops: [],
@@ -556,7 +556,9 @@ export function uiDataForTeam(
     })
   )
   Object.values(teamData).forEach((data, i) =>
-    Object.assign(own[i], mergeData([...data, totalBuff[i], commonData]))
+    Object.assign(own[i], mergeData([...data, totalBuff[i], commonData]), {
+      teamBuffDisplay: totalBuff[i],
+    })
   )
 
   const origin = new UIData(undefined as any, undefined)


### PR DESCRIPTION
## Describe your changes

The previous PR (#2999) changes the semantic of `[teamBuff, ...]` path in UIData from "buffs from all members to the current character" to "buffs from current character to all members" to simplify `uiDataForTeam` implementation.

This introduces a bug that items relied on the old definition of [teamBuff] to get an invalid list of items. This PR moves those usage to [teamBuffDisplay].

## Issue or discord link

- https://discord.com/channels/785153694478893126/819643218446254100/1393788235456708659

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the use of the key for team buff data to ensure consistency in data display.
  * Standardized the handling of missing or invalid numeric values for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->