### PR TITLE
ZO: Add qt to stat filters

### DIFF
--- a/libs/zzz/db/src/Database/DataManagers/OptConfigDataManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/OptConfigDataManager.ts
@@ -36,6 +36,7 @@ export const statFilterStatKeys = [
   'anomMas',
 ] as const
 export type StatFilterStatKey = (typeof statFilterStatKeys)[number]
+export const statFilterStatQtKeys = ['final', 'combat', 'initial'] as const
 
 export const allAllowLocationsState = [
   'unequippedOnly',
@@ -45,6 +46,7 @@ export const allAllowLocationsState = [
 export type AllowLocationsState = (typeof allAllowLocationsState)[number]
 export type StatFilterTag = {
   q: StatFilterStatKey
+  qt?: (typeof statFilterStatQtKeys)[number]
   attribute?: AttributeKey
 }
 export type StatFilter = {
@@ -120,12 +122,13 @@ export class OptConfigDataManager extends DataManager<
     if (!Array.isArray(statFilters)) statFilters = []
     statFilters = statFilters.map((statFilter) => {
       let {
-        tag: { q, attribute },
+        tag: { q, qt, attribute },
         value,
         isMax,
         disabled,
       } = statFilter as UnArray<StatFilters>
       q = validateValue(q, statFilterStatKeys) ?? statFilterStatKeys[0]
+      qt = validateValue(qt, statFilterStatQtKeys) ?? statFilterStatQtKeys[0]
       if (q !== 'dmg_') attribute = undefined
       if (attribute) attribute = validateValue(attribute, allAttributeKeys)
 
@@ -133,7 +136,7 @@ export class OptConfigDataManager extends DataManager<
       isMax = !!isMax
       disabled = !!disabled
       return {
-        tag: removeUndefinedFields({ q, attribute }) as StatFilterTag,
+        tag: removeUndefinedFields({ q, qt, attribute }) as StatFilterTag,
         value,
         isMax,
         disabled,
@@ -286,6 +289,7 @@ function initialOptConfig(): OptConfig {
 export function newStatFilterTag(q: StatFilterStatKey): StatFilterTag {
   return {
     q,
+    qt: 'final',
   }
 }
 
@@ -293,7 +297,6 @@ export function StatFilterTagToTag(tag: StatFilterTag): Tag {
   return {
     ...tag,
     et: 'own',
-    qt: 'final',
     sheet: 'agg',
   }
 }

--- a/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
+++ b/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
@@ -293,7 +293,6 @@ function QtDropdown({
   qt: Tag['qt']
   setQt: (qt: (typeof statFilterStatQtKeys)[number]) => void
 }) {
-  console.log('QtDropdown', qt)
   return (
     <DropdownButton title={qt && qtMap[qt as keyof typeof qtMap]}>
       {statFilterStatQtKeys.map((q) => (

--- a/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
+++ b/libs/zzz/page-optimize/src/Optimize/StatFilterCard.tsx
@@ -8,6 +8,7 @@ import { type UnArray, isPercentStat } from '@genshin-optimizer/common/util'
 import type { AttributeKey } from '@genshin-optimizer/zzz/consts'
 import { allAttributeKeys } from '@genshin-optimizer/zzz/consts'
 import type { StatFilterTag } from '@genshin-optimizer/zzz/db'
+import { statFilterStatQtKeys } from '@genshin-optimizer/zzz/db'
 import {
   type StatFilterStatKey,
   type StatFilters,
@@ -19,7 +20,7 @@ import {
   useDatabaseContext,
 } from '@genshin-optimizer/zzz/db-ui'
 import type { Tag } from '@genshin-optimizer/zzz/formula'
-import { TagDisplay } from '@genshin-optimizer/zzz/formula-ui'
+import { TagDisplay, qtMap } from '@genshin-optimizer/zzz/formula-ui'
 import { AttributeName, StatDisplay } from '@genshin-optimizer/zzz/ui'
 import {
   CheckBox,
@@ -168,7 +169,7 @@ function InitialStatDropdown({
 }) {
   return (
     <DropdownButton
-      title={(tag && <TagDisplay tag={tag} />) ?? 'Add Final Stat Filter'}
+      title={(tag && <TagDisplay tag={tag} />) ?? 'Add Stat Filter'}
     >
       {statFilterStatKeys.map((statKey) => (
         <MenuItem key={statKey} onClick={() => onSelect(statKey)}>
@@ -213,6 +214,7 @@ function StatFilterItem({
         <Typography>
           <TagDisplay tag={tag} />
         </Typography>
+        <QtDropdown qt={tag.qt} setQt={(qt) => setTarget({ ...tag, qt })} />
         {tag.q === 'dmg_' && (
           <AttributeDropdown
             tag={tag}
@@ -278,6 +280,30 @@ function AttributeDropdown({
           <ColorText color={attr}>
             <AttributeName attribute={attr} />
           </ColorText>
+        </MenuItem>
+      ))}
+    </DropdownButton>
+  )
+}
+
+function QtDropdown({
+  qt,
+  setQt,
+}: {
+  qt: Tag['qt']
+  setQt: (qt: (typeof statFilterStatQtKeys)[number]) => void
+}) {
+  console.log('QtDropdown', qt)
+  return (
+    <DropdownButton title={qt && qtMap[qt as keyof typeof qtMap]}>
+      {statFilterStatQtKeys.map((q) => (
+        <MenuItem
+          key={q}
+          onClick={() => setQt(q)}
+          selected={qt === q}
+          disabled={qt === q}
+        >
+          {qtMap[q]}
         </MenuItem>
       ))}
     </DropdownButton>


### PR DESCRIPTION
## Describe your changes

Added qt dropdown to stat filters

## Testing/validation

<img width="930" height="222" alt="image" src="https://github.com/user-attachments/assets/9d18d7f5-d52f-4121-a3da-122db89bc682" />

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dropdown to select a "qt" (quality/type) property for stat filter tags when configuring stat filters.
  * Stat filter tags now support an additional qualifier, allowing users to specify "final", "combat", or "initial" types.

* **Style**
  * Updated the "Add Final Stat Filter" button label to "Add Stat Filter" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->