### PR TITLE
Add default target for all stats

### DIFF
--- a/libs/gi/uidata/src/uiData.ts
+++ b/libs/gi/uidata/src/uiData.ts
@@ -89,7 +89,7 @@ export class UIData {
     }
   }
 
-  childUIData(data: Data): UIData {
+  child(data: Data): UIData {
     let child = this.children.get(data)
     if (!child) {
       child = new UIData(data, this)
@@ -342,7 +342,7 @@ export class UIData {
     node: DataNode<NumNode | StrNode>
   ): CalcResult<number | string | undefined> {
     const parent = node.reset ? this.origin : this
-    return parent.childUIData(node.data).computeNode(node.operands[0])
+    return parent.child(node.data).computeNode(node.operands[0])
   }
   private _compute(node: ComputeNode): CalcResult<number> {
     const { operation, operands } = node
@@ -564,7 +564,7 @@ export function uiDataForTeam(
 
   const origin = new UIData(undefined as any, undefined)
   return Object.fromEntries(
-    keys.map((key, i) => [key, { target: origin.childUIData(own[i]) }])
+    keys.map((k, i) => [k, { target: origin.child(target[i]).child(own[i]) }])
   )
 }
 


### PR DESCRIPTION
## Describe your changes

#2999 removes the `target` (default to itself) when computing character's stat, esp. for target-dependent display stats. The affected display stats will calculate as "empty" as target check fails. This PR reintroduce the default `target` to be the same as `own` for all stats (including display nodes). This matches the previous behavior.

## Issue or discord link

https://discord.com/channels/785153694478893126/819643218446254100/1402434144197152879

## Testing/validation

n/a

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed
