### PR TITLE
GO: FIx Ineffa's A4 EM buff

### DIFF
--- a/libs/gi/sheets/src/Characters/Ineffa/index.tsx
+++ b/libs/gi/sheets/src/Characters/Ineffa/index.tsx
@@ -178,7 +178,6 @@ const dmgFormulas = {
     ),
   },
   passive2: {
-    a4AfterBurst_eleMas,
     a4AfterBurst_eleMasDisp,
   },
   constellation1: {


### PR DESCRIPTION
## Describe your changes

Fixes Ineffa's A4 EM buff applying only to active character, now it applies to the active character and Ineffa herself

## Issue or discord link

- https://discord.com/channels/785153694478893126/1402587981906182164/1402587981906182164

## Testing/validation
<img width="1207" height="603" alt="image" src="https://github.com/user-attachments/assets/0dee518c-3f50-4c0d-8c50-ebd567c5861a" />
<img width="1228" height="629" alt="image" src="https://github.com/user-attachments/assets/e4b29eee-2865-44c3-8015-3881aef663e4" />
<img width="1227" height="598" alt="image" src="https://github.com/user-attachments/assets/850c793c-a44c-4d7d-a68e-92116bc2758e" />


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Elemental Mastery buff now correctly applies when either the active character or the target character qualifies, ensuring the buff triggers in the intended scenarios.

* **UI**
  * The Elemental Mastery buff amount is now shown in the interface when the condition is met, improving transparency of active bonuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->