### PR TITLE
GO: Add support for GOOD v3

### DIFF
--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -150,7 +150,7 @@ export class ArtCharDatabase extends Database {
       format: 'GOOD',
       dbVersion: currentDBVersion,
       source: GOSource,
-      version: 1,
+      version: 3,
     }
     this.dataManagers.map((dm) => dm.exportGOOD(good))
     this.dataEntries.map((de) => de.exportGOOD(good))

--- a/libs/gi/good/src/IArtifact.ts
+++ b/libs/gi/good/src/IArtifact.ts
@@ -7,7 +7,17 @@ import type {
   SubstatKey,
 } from '@genshin-optimizer/gi/consts'
 
-export interface IArtifact {
+// GOOD 3 and above
+export interface IArtifact extends IBaseArtifact {
+  totalRolls?: number // 3-9 for valid 5* artifacts; includes starting rolls
+  startingRolls?: number // 3-4 for valid 5* artifacts; If a 4th substat is in substats array, and this value is 3, the 4th substat is a revealed stat, but should not be factored into calculation
+  astralMark?: boolean // Favorite star in-game
+  discard?: boolean // Trash icon in-game
+  elixirCrafted?: boolean // Flag for if the artifact was created using Sanctifying Elixir. This guarantees the main stat + 2 additional rolls on the first 2 substats
+}
+
+// GOOD 2 and below
+export interface IBaseArtifact {
   setKey: ArtifactSetKey
   slotKey: ArtifactSlotKey
   level: number

--- a/libs/gi/good/src/IGOOD.ts
+++ b/libs/gi/good/src/IGOOD.ts
@@ -4,7 +4,7 @@ import type { IWeapon } from './IWeapon'
 export type IGOOD = {
   format: 'GOOD'
   source: string
-  version: 1
+  version: 1 | 2 | 3
   characters?: ICharacter[]
   artifacts?: IArtifact[]
   weapons?: IWeapon[]

--- a/libs/gi/page-doc/src/index.tsx
+++ b/libs/gi/page-doc/src/index.tsx
@@ -428,11 +428,11 @@ function VersionHistoryPane() {
           <Typography>
             Adds new fields to <code>IArtifact</code> to represent new in-game
             properties, and help differentiate between 3 and 4-line starts for
-            5* artfiacts. All other fields remain the same. V3 is backwards
+            5* artifacts. All other fields remain the same. V3 is backwards
             compatible with V2.
             <br />
             New fields:{' '}
-            <code>totalRolls, startingRolls, astralMark, elixirCrafted</code>
+            <code>totalRolls, startingRolls, astralMark, discard, elixirCrafted</code>
           </Typography>
         </CardContent>
       </CardThemed>

--- a/libs/gi/page-doc/src/index.tsx
+++ b/libs/gi/page-doc/src/index.tsx
@@ -41,7 +41,7 @@ export default function PageDocumentation() {
         </Grid>
         <Grid item>
           <Typography variant="h6">
-            <SqBadge color="info">Version. 3</SqBadge>
+            <SqBadge color="info">Version 3</SqBadge>
           </Typography>
         </Grid>
       </Grid>

--- a/libs/gi/page-doc/src/index.tsx
+++ b/libs/gi/page-doc/src/index.tsx
@@ -41,7 +41,7 @@ export default function PageDocumentation() {
         </Grid>
         <Grid item>
           <Typography variant="h6">
-            <SqBadge color="info">Version. 2</SqBadge>
+            <SqBadge color="info">Version. 3</SqBadge>
           </Typography>
         </Grid>
       </Grid>
@@ -160,6 +160,12 @@ const artifactCode = `interface IArtifact {
   location: CharacterKey|"" //where "" means not equipped.
   lock: boolean //Whether the artifact is locked in game.
   substats: ISubstat[]
+  // Below are new to GOOD 3
+  totalRolls?: number // 3-9 for valid 5* artifacts; includes starting rolls
+  startingRolls?: number // 3-4 for valid 5* artifacts; If a 4th substat is in substats array, and this value is 3, the 4th substat is a revealed stat, but should not be factored into calculation
+  astralMark?: boolean // Favorite star in-game
+  discard?: boolean // Trash icon in-game
+  elixirCrafted?: boolean // Flag for if the artifact was created using Sanctifying Elixir. This guarantees the main stat + 2 additional rolls on the first 2 substats
 }
 
 interface ISubstat {
@@ -410,6 +416,23 @@ function VersionHistoryPane() {
           <Typography>
             Adds <code>materials</code> field to <code>IGOOD</code>. All other
             fields remain the same. V2 is backwards compatible with V1.
+          </Typography>
+        </CardContent>
+      </CardThemed>
+      <CardThemed>
+        <CardContent>
+          <Typography>Version 3</Typography>
+        </CardContent>
+        <Divider />
+        <CardContent>
+          <Typography>
+            Adds new fields to <code>IArtifact</code> to represent new in-game
+            properties, and help differentiate between 3 and 4-line starts for
+            5* artfiacts. All other fields remain the same. V3 is backwards
+            compatible with V2.
+            <br />
+            New fields:{' '}
+            <code>totalRolls, startingRolls, astralMark, elixirCrafted</code>
           </Typography>
         </CardContent>
       </CardThemed>

--- a/libs/gi/page-doc/src/index.tsx
+++ b/libs/gi/page-doc/src/index.tsx
@@ -432,7 +432,9 @@ function VersionHistoryPane() {
             compatible with V2.
             <br />
             New fields:{' '}
-            <code>totalRolls, startingRolls, astralMark, discard, elixirCrafted</code>
+            <code>
+              totalRolls, startingRolls, astralMark, discard, elixirCrafted
+            </code>
           </Typography>
         </CardContent>
       </CardThemed>


### PR DESCRIPTION
## Describe your changes

Add support for new optional fields on IArtifact. These fields help us determine 3 vs 4 line starts for compatible scanners, supports the new revealed-but-not-active 4th line, and other new properties on artifacts since the last update.
No actual code support is added yet

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for GOOD v3 artifact data with optional metadata: total rolls, starting rolls, favorite/star, discard, and elixir-crafted flags; maintains backward compatibility.

- Documentation
  - Updated docs and examples to Version 3, added Version 3 entry to version history, and updated header badge.

- Chores
  - Bumped exported GOOD version to v3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->