### PR TITLE
GO: Silently revise GOODv3 to be properly backcompat

### DIFF
--- a/libs/gi/good/src/IArtifact.ts
+++ b/libs/gi/good/src/IArtifact.ts
@@ -10,10 +10,13 @@ import type {
 // GOOD 3 and above
 export interface IArtifact extends IBaseArtifact {
   totalRolls?: number // 3-9 for valid 5* artifacts; includes starting rolls
-  startingRolls?: number // 3-4 for valid 5* artifacts; If a 4th substat is in substats array, and this value is 3, the 4th substat is a revealed stat, but should not be factored into calculation
   astralMark?: boolean // Favorite star in-game
-  discard?: boolean // Trash icon in-game
-  elixirCrafted?: boolean // Flag for if the artifact was created using Sanctifying Elixir. This guarantees the main stat + 2 additional rolls on the first 2 substats
+  elixirCrafted?: boolean // Flag for if the artifact was created using Sanctifying Elixir. This guarantees the main stat + at least 2 rolls on the first 2 substats
+  unactivatedSubstats?: ISubstat[] // Unactivated substat(s). Once a substat is activated, it should be moved to `substats` instead
+}
+
+export interface ISubstat extends IBaseSubstat {
+  initialValue?: number // Initial roll of the artifact, if it is known. This includes the first roll of this stat, even if it was not revealed initially e.g. from `unactivatedSubstats`
 }
 
 // GOOD 2 and below
@@ -28,7 +31,7 @@ export interface IBaseArtifact {
   substats: ISubstat[]
 }
 
-export interface ISubstat {
+export interface IBaseSubstat {
   key: SubstatKey | ''
   value: number
 }

--- a/libs/gi/page-doc/src/index.tsx
+++ b/libs/gi/page-doc/src/index.tsx
@@ -162,15 +162,16 @@ const artifactCode = `interface IArtifact {
   substats: ISubstat[]
   // Below are new to GOOD 3
   totalRolls?: number // 3-9 for valid 5* artifacts; includes starting rolls
-  startingRolls?: number // 3-4 for valid 5* artifacts; If a 4th substat is in substats array, and this value is 3, the 4th substat is a revealed stat, but should not be factored into calculation
   astralMark?: boolean // Favorite star in-game
-  discard?: boolean // Trash icon in-game
   elixirCrafted?: boolean // Flag for if the artifact was created using Sanctifying Elixir. This guarantees the main stat + 2 additional rolls on the first 2 substats
+  unactivatedSubstats?: ISubstat[] // Unactivated substat(s). Once a substat is activated, it should be moved to \`substats\` instead
 }
 
 interface ISubstat {
   key: StatKey //e.g. "critDMG_"
   value: number //e.g. 19.4
+  // Below is new to GOOD 3
+  initialValue?: number // Initial roll of the artifact, if it is known. This includes the first roll of this stat, even if it was not revealed initially e.g. from \`unactivatedSubstats\`
 }
 
 type SlotKey = "flower" | "plume" | "sands" | "goblet" | "circlet"`
@@ -427,14 +428,16 @@ function VersionHistoryPane() {
         <CardContent>
           <Typography>
             Adds new fields to <code>IArtifact</code> to represent new in-game
-            properties, and help differentiate between 3 and 4-line starts for
-            5* artifacts. All other fields remain the same. V3 is backwards
-            compatible with V2.
+            properties, store initial rolls for reroll information, and help
+            differentiate between 3 and 4-line starts for 5* artifacts. All
+            other fields remain the same. V3 is backwards compatible with V2.
             <br />
-            New fields:{' '}
+            New fields for <code>IArtifact</code>:{' '}
             <code>
-              totalRolls, startingRolls, astralMark, discard, elixirCrafted
+              totalRolls, astralMark, elixirCrafted, unactivatedSubstats
             </code>
+            <br />
+            New field for <code>ISubstat</code>: <code>initialValue</code>
           </Typography>
         </CardContent>
       </CardThemed>


### PR DESCRIPTION
## Describe your changes

* Remove `discard` because it doesn't actually exist in-game
* Adjust IArtifact and ISubstat to be truly backwards-compat with v2 format and to better represent initial rolls and total rolls

## Issue or discord link

-  Address #3043

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support for unactivated substats on artifacts.
  * Tracking of initial substat roll values for better reroll insights.

* Documentation
  * Updated version history and field list to reflect new artifact and substat fields.
  * Clarified ElixirCrafted description to indicate “at least 2 rolls” on first two substats.

* Refactor
  * Streamlined substat structure for improved consistency.
  * Removed obsolete artifact fields to reduce redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->