### PR TITLE
GO: Use non-stacking for bloom crit damage

### DIFF
--- a/libs/gi/sheets/src/Characters/Lauma/index.tsx
+++ b/libs/gi/sheets/src/Characters/Lauma/index.tsx
@@ -4,7 +4,9 @@ import { allStats } from '@genshin-optimizer/gi/stats'
 import {
   constant,
   equal,
+  equalStr,
   greaterEq,
+  greaterEqStr,
   infoMut,
   input,
   lookup,
@@ -17,7 +19,7 @@ import {
   sum,
   tally,
 } from '@genshin-optimizer/gi/wr'
-import { cond, st, stg } from '../../SheetUtil'
+import { cond, nonStackBuff, st, stg } from '../../SheetUtil'
 import { CharacterSheet } from '../CharacterSheet'
 import type { TalentSheet } from '../ICharacterSheet'
 import { charTemplates } from '../charTemplates'
@@ -172,6 +174,28 @@ const a1AfterSkill_bloom_critRate_ = greaterEq(
 )
 const a1AfterSkill_hyperbloom_critRate_ = { ...a1AfterSkill_bloom_critRate_ }
 const a1AfterSkill_burgeon_critRate_ = { ...a1AfterSkill_bloom_critRate_ }
+
+const bloomRelatedCdNonstackWrite = greaterEqStr(
+  input.asc,
+  1,
+  equalStr(tally.moonsign, 1, equalStr(condA1AfterSkill, 'on', key))
+)
+const [a1AfterSkill_bloom_critDMG_, a1AfterSkill_bloom_critDMG_inactive] =
+  nonStackBuff('bloomcd', 'bloom_critDMG_', percent(dm.passive1.bloom_critDMG_))
+const [
+  a1AfterSkill_hyperbloom_critDMG_,
+  a1AfterSkill_hyperbloom_critDMG_inactive,
+] = nonStackBuff(
+  'bloomcd',
+  'hyperbloom_critDMG_',
+  percent(dm.passive1.bloom_critDMG_)
+)
+const [a1AfterSkill_burgeon_critDMG_, a1AfterSkill_burgeon_critDMG_inactive] =
+  nonStackBuff(
+    'bloomcd',
+    'burgeon_critDMG_',
+    percent(dm.passive1.bloom_critDMG_)
+  )
 
 const a1AfterSkill_lunarBloom_critRate_ = greaterEq(
   input.asc,
@@ -340,8 +364,11 @@ export const data = dataObjForCharacterSheet(key, dmgFormulas, {
         c2PaleHymn_lunarbloom_dmgInc
       ),
       bloom_critRate_: a1AfterSkill_bloom_critRate_,
+      bloom_critDMG_: a1AfterSkill_bloom_critDMG_,
       hyperbloom_critRate_: a1AfterSkill_hyperbloom_critRate_,
+      hyperbloom_critDMG_: a1AfterSkill_hyperbloom_critDMG_,
       burgeon_critRate_: a1AfterSkill_burgeon_critRate_,
+      burgeon_critDMG_: a1AfterSkill_burgeon_critDMG_,
       lunarbloom_critRate_: a1AfterSkill_lunarBloom_critRate_,
       lunarbloom_critDMG_: a1AfterSkill_lunarBloom_critDMG_,
       lunarbloom_baseDmg_: a0_lunarbloom_baseDmg_,
@@ -350,6 +377,9 @@ export const data = dataObjForCharacterSheet(key, dmgFormulas, {
     },
     tally: {
       moonsign: constant(1),
+    },
+    nonStacking: {
+      bloomcd: bloomRelatedCdNonstackWrite,
     },
   },
 })
@@ -578,10 +608,28 @@ const sheet: TalentSheet = {
               node: a1AfterSkill_bloom_critRate_,
             },
             {
+              node: a1AfterSkill_bloom_critDMG_,
+            },
+            {
+              node: a1AfterSkill_bloom_critDMG_inactive,
+            },
+            {
               node: a1AfterSkill_hyperbloom_critRate_,
             },
             {
+              node: a1AfterSkill_hyperbloom_critDMG_,
+            },
+            {
+              node: a1AfterSkill_hyperbloom_critDMG_inactive,
+            },
+            {
               node: a1AfterSkill_burgeon_critRate_,
+            },
+            {
+              node: a1AfterSkill_burgeon_critDMG_,
+            },
+            {
+              node: a1AfterSkill_burgeon_critDMG_inactive,
             },
             {
               node: a1AfterSkill_lunarBloom_critRate_,

--- a/libs/gi/sheets/src/Characters/Nahida/index.tsx
+++ b/libs/gi/sheets/src/Characters/Nahida/index.tsx
@@ -5,7 +5,9 @@ import {
   compareEq,
   constant,
   equal,
+  equalStr,
   greaterEq,
+  greaterEqStr,
   infoMut,
   input,
   lookup,
@@ -20,7 +22,7 @@ import {
   target,
   unequal,
 } from '@genshin-optimizer/gi/wr'
-import { cond, st, stg } from '../../SheetUtil'
+import { cond, nonStackBuff, st, stg } from '../../SheetUtil'
 import { CharacterSheet } from '../CharacterSheet'
 import type { TalentSheet } from '../ICharacterSheet.d'
 import { charTemplates } from '../charTemplates'
@@ -242,6 +244,26 @@ const c2Burning_critDMG_ = greaterEq(
   2,
   equal(condC2Bloom, 'on', percent(dm.constellation2.critDMG_))
 )
+const bloomRelatedCdNonstackWrite = greaterEqStr(
+  input.constellation,
+  2,
+  equalStr(condC2Bloom, 'on', key)
+)
+const [c2Bloom_critDMG_, c2Bloom_critDMG_inactive] = nonStackBuff(
+  'bloomcd',
+  'bloom_critDMG_',
+  percent(dm.constellation2.critDMG_)
+)
+const [c2Hyperbloom_critDMG_, c2Hyperbloom_critDMG_inactive] = nonStackBuff(
+  'bloomcd',
+  'hyperbloom_critDMG_',
+  percent(dm.constellation2.critDMG_)
+)
+const [c2Burgeon_critDMG_, c2Burgeon_critDMG_inactive] = nonStackBuff(
+  'bloomcd',
+  'burgeon_critDMG_',
+  percent(dm.constellation2.critDMG_)
+)
 const c2Lunarbloom_critRate_ = greaterEq(
   input.constellation,
   2,
@@ -328,6 +350,9 @@ const data = dataObjForCharacterSheet(key, dmgFormulas, {
       bloom_critRate_: c2Bloom_critRate_,
       hyperbloom_critRate_: c2Hyperbloom_critRate_,
       burgeon_critRate_: c2Burgeon_critRate_,
+      bloom_critDMG_: c2Bloom_critDMG_,
+      hyperbloom_critDMG_: c2Hyperbloom_critDMG_,
+      burgeon_critDMG_: c2Burgeon_critDMG_,
       burning_critDMG_: c2Burning_critDMG_,
       lunarbloom_critRate_: c2Lunarbloom_critRate_,
       lunarbloom_critDMG_: c2Lunarbloom_critDMG_,
@@ -335,6 +360,9 @@ const data = dataObjForCharacterSheet(key, dmgFormulas, {
     },
     total: {
       eleMas: a1InBurst_eleMas,
+    },
+    nonStacking: {
+      bloomcd: bloomRelatedCdNonstackWrite,
     },
   },
 })
@@ -488,10 +516,28 @@ const sheet: TalentSheet = {
               node: c2Bloom_critRate_,
             },
             {
+              node: c2Bloom_critDMG_,
+            },
+            {
+              node: c2Bloom_critDMG_inactive,
+            },
+            {
               node: c2Hyperbloom_critRate_,
             },
             {
+              node: c2Hyperbloom_critDMG_,
+            },
+            {
+              node: c2Hyperbloom_critDMG_inactive,
+            },
+            {
               node: c2Burgeon_critRate_,
+            },
+            {
+              node: c2Burgeon_critDMG_,
+            },
+            {
+              node: c2Burgeon_critDMG_inactive,
             },
             {
               node: c2Lunarbloom_critRate_,

--- a/libs/gi/sheets/src/Characters/dataUtil.tsx
+++ b/libs/gi/sheets/src/Characters/dataUtil.tsx
@@ -428,10 +428,6 @@ export function dataObjForCharacterSheet(
         data.premod![stat] = result
       }
     }
-    // Workaround for bloom-related crit DMG
-    data.premod!.bloom_critDMG_ = one
-    data.premod!.hyperbloom_critDMG_ = one
-    data.premod!.burgeon_critDMG_ = one
   }
 
   return mergeData([data, inferInfoMut(additional)])

--- a/libs/gi/wr/src/formula.ts
+++ b/libs/gi/wr/src/formula.ts
@@ -91,6 +91,7 @@ const allNonstackBuffs = [
   'gleamingmoonintent',
   'gleamingmoondevotion',
   'nightweaver',
+  'bloomcd',
 ] as const
 export type NonStackBuff = (typeof allNonstackBuffs)[number]
 const allMoves = [


### PR DESCRIPTION
## Describe your changes
Use non-stacking mechanism to only allow 1 instance of 100% bloom-related crit damage, as per the description. Previous method accidentally made all blooms crit in crit-mode

## Issue or discord link

- https://discord.com/channels/785153694478893126/1416712491781849159

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added non-stacking Bloom/Hyperbloom/Burgeon Crit DMG buffs for Lauma (after Skill) and Nahida (Constellation 2), with active/inactive states shown in character and team buff panels.
- Bug Fixes
  - Corrected stacking behavior for Bloom-related Crit DMG to prevent double counting; removed temporary initialization that could inflate values.
- UI
  - Updated talent/constellation displays to include Bloom/Hyperbloom/Burgeon Crit DMG entries with clear active/inactive indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->