### PR TITLE
Fix Dori C2 formula

### DIFF
--- a/libs/gi/sheets/src/Characters/Dori/index.tsx
+++ b/libs/gi/sheets/src/Characters/Dori/index.tsx
@@ -161,7 +161,6 @@ const dmgFormulas = {
       2,
       customDmgNode(
         prod(
-          subscript(input.total.skillIndex, dm.skill.shotDmg, { unit: '%' }),
           infoMut(percent(dm.constellation2.toopDmg), {
             name: ct.ch('c2MultiplierKey_'),
           }),


### PR DESCRIPTION
## Describe your changes

- The current formula adds the SKILL multiplier to the C2 effect, which doesn't seem to be correct. I removed that multiplier

## Issue or discord link

- fix #3031 

## Testing/validation

<img width="670" height="211" alt="image" src="https://github.com/user-attachments/assets/fe43f31b-cd97-46d6-9bbc-f53e6e2fa4fc" />


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Dori’s Constellation 2 damage calculation by removing unintended talent-level scaling. Damage now scales only with the constellation multiplier and ATK as intended. Users will see adjusted C2 damage values; elemental typing and activation conditions are unchanged. This delivers more accurate damage estimates for builds and comparisons, with no impact to other talents or constellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->