### PR TITLE
Add the ZO version number to the footer

### DIFF
--- a/apps/zzz-frontend/src/app/Footer.tsx
+++ b/apps/zzz-frontend/src/app/Footer.tsx
@@ -1,6 +1,8 @@
 import { AppBar, Box, Skeleton, Typography } from '@mui/material'
 import { Suspense } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 
+declare const __VERSION__: string
 export default function Footer() {
   return (
     <Suspense fallback={<Skeleton variant="rectangular" height={64} />}>
@@ -9,6 +11,7 @@ export default function Footer() {
   )
 }
 function FooterContent() {
+  const { t } = useTranslation('ui')
   return (
     <AppBar
       component="footer"
@@ -23,21 +26,32 @@ function FooterContent() {
         gap={2}
       >
         <Typography variant="caption" sx={{ color: 'neutral400.main' }}>
-          Build:
-          <a
-            href={
-              process.env.NX_URL_GITHUB_GO_CURRENT_VERSION ||
-              `${process.env.NX_URL_GITHUB_GO}/releases`
-            }
-            target="_blank"
-            rel="noreferrer"
-            style={{ color: 'inherit' }}
+          <Trans t={t} i18nKey="ui:rightsDisclaimer">
+            Zenless Optimizer is not affiliated with or endorsed by HoYoverse.
+          </Trans>
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{ color: 'neutral400.main', textAlign: 'right' }}
+        >
+          <Trans
+            t={t}
+            i18nKey="ui:appVersion"
+            values={{ version: __VERSION__ }}
           >
-            {process.env.NX_URL_GITHUB_GO_CURRENT_VERSION?.replace(
-              /.*commit\//,
-              ''
-            ).substring(0, 7)}
-          </a>
+            Zenless Optimizer Version:
+            <a
+              href={
+                process.env.NX_URL_GITHUB_GO_CURRENT_VERSION ||
+                `${process.env.NX_URL_GITHUB_GO}/releases`
+              }
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: 'inherit', marginLeft: 2 }}
+            >
+              {{ version: __VERSION__ } as any}
+            </a>
+          </Trans>
         </Typography>
       </Box>
     </AppBar>

--- a/apps/zzz-frontend/vite.config.mts
+++ b/apps/zzz-frontend/vite.config.mts
@@ -6,7 +6,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import react from '@vitejs/plugin-react'
 import { defineConfig, normalizePath } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import pkg from '../../package.json' assert { type: 'json' }
+import pkg from './package.json' assert { type: 'json' }
 
 export default defineConfig(() => ({
   base: '',

--- a/libs/zzz/localization/assets/locales/en/ui.json
+++ b/libs/zzz/localization/assets/locales/en/ui.json
@@ -10,5 +10,7 @@
     "rarity": "Rarity"
   },
   "phase": "Phase {{value}}",
-  "selectlevel": "Select Level"
+  "selectlevel": "Select Level",
+  "rightsDisclaimer": "Zenless Optimizer is not affiliated with or endorsed by HoYoverse.",
+  "appVersion": "Zenless Optimizer Version: <1>{{version}}</1>"
 }


### PR DESCRIPTION
## Describe your changes

- Add the ZO version number to the footer

## Issue or discord link

- fix #2938 

## Testing/validation

<img width="1900" height="66" alt="image" src="https://github.com/user-attachments/assets/9c7ebf82-29ae-42f9-bf3e-5d52511227e6" />


## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Footer now uses localization for text.
  - Added a rights disclaimer in the footer.
  - Version display is localized and includes a link to the corresponding release, opening in a new tab.
- Style
  - Adjusted footer layout: right-aligned caption and added spacing to the version link.
- Chores
  - Updated build configuration to source the app version from the app’s package metadata.
- Localization
  - Added new translation keys for the rights disclaimer and app version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->