### PR TITLE
Remove default TC Build description

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -49,7 +49,7 @@ export class BuildTcDataManager extends DataManager<
     const { character, weapon, artifact, optimization } = obj as BuildTc
     const _character = validateBuildTCChar(character)
     if (typeof name !== 'string') name = 'Build(TC) Name'
-    if (typeof description !== 'string') description = 'Build(TC) Description'
+    if (typeof description !== 'string') description = ''
     const _weapon = validateBuildTCWeapon(weapon)
     if (!_weapon) return undefined
 
@@ -121,7 +121,7 @@ export class BuildTcDataManager extends DataManager<
 export function initCharTC(weaponKey: WeaponKey): BuildTc {
   return {
     name: 'Build(TC) Name',
-    description: 'Build(TC) Description',
+    description: '',
     weapon: {
       key: weaponKey,
       level: 1,


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- Fix #2332

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build TC descriptions now default to an empty value instead of showing a placeholder. This prevents misleading “Build(TC) Description” text from appearing when no description is provided.
  * Applies when descriptions are missing or invalid, ensuring cleaner displays across views, exports, and reports.
  * No changes to user workflows; only visible text behavior is affected when descriptions are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->