### PR TITLE
ZO: Move isStunned to conditional

### DIFF
--- a/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
@@ -174,7 +174,6 @@ export type CharOpt = {
   // Enemy stuff
   enemyLvl: number
   enemyDef: number
-  enemyisStunned: boolean
   enemyStunMultiplier: number
   enemyStats: Array<{
     tag: EnemyStatsTag
@@ -204,7 +203,6 @@ export class CharacterOptManager extends DataManager<
 
       enemyLvl,
       enemyDef,
-      enemyisStunned,
       enemyStunMultiplier,
       enemyStats,
 
@@ -330,7 +328,6 @@ export class CharacterOptManager extends DataManager<
 
     if (typeof enemyLvl !== 'number') enemyLvl = 80
     if (typeof enemyDef !== 'number') enemyDef = 953
-    enemyisStunned = !!enemyisStunned
 
     if (typeof enemyStunMultiplier !== 'number') enemyStunMultiplier = 150
     if (!Array.isArray(enemyStats)) enemyStats = []
@@ -375,7 +372,6 @@ export class CharacterOptManager extends DataManager<
 
       enemyLvl,
       enemyDef,
-      enemyisStunned,
       enemyStunMultiplier,
       enemyStats,
 
@@ -517,7 +513,6 @@ export function initialCharOpt(): CharOpt {
 
     enemyLvl: 80,
     enemyDef: 953,
-    enemyisStunned: false,
     enemyStunMultiplier: 150,
     enemyStats: [],
   }

--- a/libs/zzz/formula-ui/src/char/CharCalcProvider.tsx
+++ b/libs/zzz/formula-ui/src/char/CharCalcProvider.tsx
@@ -55,7 +55,6 @@ export function CharCalcProvider({
         ownBuff.common.critMode.add(charOpt.critMode),
         enemy.common.lvl.add(charOpt.enemyLvl),
         enemy.common.def.add(charOpt.enemyDef),
-        enemy.common.isStunned.add(charOpt.enemyisStunned ? 1 : 0),
         enemy.common.stun_.add(charOpt.enemyStunMultiplier / 100),
         enemy.common.unstun_.add(1),
         ...charOpt.conditionals.flatMap(
@@ -172,7 +171,6 @@ export function CharCalcMockCountProvider({
         ownBuff.common.critMode.add('avg'),
         enemy.common.lvl.add(100),
         enemy.common.def.add(900),
-        enemy.common.isStunned.add(0),
         enemy.common.stun_.add(1.5),
         enemy.common.unstun_.add(1),
         ...conditionals.flatMap(({ sheet, src, dst, condKey, condValue }) =>

--- a/libs/zzz/formula/src/data/char/sheets/Anby.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Anby.ts
@@ -1,9 +1,9 @@
-import { cmpEq, cmpGE, cmpNE, subscript } from '@genshin-optimizer/pando/engine'
+import { cmpGE, subscript } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
-  enemy,
   own,
   ownBuff,
   register,
@@ -34,11 +34,11 @@ const core_after3rdBasic_dazeInc_ = ownBuff.combat.dazeInc_.add(
 
 const m2_stunned_basic_dmg_ = ownBuff.combat.dmg_.addWithDmgType(
   'basic',
-  cmpGE(char.mindscape, 2, cmpEq(enemy.common.isStunned, 1, dm.m2.dmg_))
+  cmpGE(char.mindscape, 2, isStunned.ifOn(dm.m2.dmg_))
 )
 const m2_unstunned_ex_dazeInc_ = ownBuff.combat.dazeInc_.addWithDmgType(
   'exSpecial',
-  cmpGE(char.mindscape, 2, cmpNE(enemy.common.isStunned, 1, dm.m2.daze_))
+  cmpGE(char.mindscape, 2, isStunned.ifOff(dm.m2.daze_))
 )
 
 const sheet = register(

--- a/libs/zzz/formula/src/data/char/sheets/Corin.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Corin.ts
@@ -1,17 +1,11 @@
-import {
-  cmpEq,
-  cmpGE,
-  prod,
-  subscript,
-  sum,
-} from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
   customDmg,
-  enemy,
   enemyDebuff,
   own,
   ownBuff,
@@ -180,7 +174,7 @@ const sheet = register(
           team.common.count.withFaction('VictoriaHousekeepingCo')
         ),
         3,
-        cmpEq(enemy.common.isStunned, 1, percent(dm.ability.common_dmg_))
+        isStunned.ifOn(percent(dm.ability.common_dmg_))
       )
     )
   ),

--- a/libs/zzz/formula/src/data/char/sheets/Harumasa.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Harumasa.ts
@@ -1,11 +1,11 @@
 import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
   customDmg,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -159,7 +159,7 @@ const sheet = register(
         ),
         1,
         cmpGE(
-          sum(enemy.common.isStunned, enemy_anomaly.ifOn(1)),
+          sum(isStunned.ifOn(1), enemy_anomaly.ifOn(1)),
           1,
           percent(dm.ability.common_dmg_)
         )

--- a/libs/zzz/formula/src/data/char/sheets/Hugo.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Hugo.ts
@@ -1,6 +1,5 @@
 import type { NumNode } from '@genshin-optimizer/pando/engine'
 import {
-  cmpEq,
   cmpGE,
   cmpGT,
   min,
@@ -10,10 +9,10 @@ import {
 } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -132,9 +131,7 @@ const sheet = register(
     'core_exSpecial_mv_mult_',
     ownBuff.dmg.mv_mult_.addWithDmgType(
       'exSpecial',
-      cmpEq(
-        enemy.common.isStunned,
-        1,
+      isStunned.ifOn(
         sum(
           percent(subscript(char.core, dm.core.mv_mult_1)),
           prod(
@@ -157,9 +154,7 @@ const sheet = register(
     'core_ult_mv_mult_',
     ownBuff.dmg.mv_mult_.addWithDmgType(
       'ult',
-      cmpEq(
-        enemy.common.isStunned,
-        1,
+      isStunned.ifOn(
         sum(
           percent(subscript(char.core, dm.core.mv_mult_1)),
           prod(
@@ -182,7 +177,7 @@ const sheet = register(
     'core_exSpecial_dazeInc_',
     ownBuff.combat.dazeInc_.addWithDmgType(
       'exSpecial',
-      cmpEq(enemy.common.isStunned, 0, dm.core.dazeInc_)
+      isStunned.ifOff(dm.core.dazeInc_)
     )
   ),
   registerBuff(
@@ -201,14 +196,14 @@ const sheet = register(
     'ability_exSpecial_dmg_',
     ownBuff.combat.dmg_.addWithDmgType(
       'exSpecial',
-      ability_check(cmpEq(enemy.common.isStunned, 1, dm.ability.totalize_dmg_))
+      ability_check(isStunned.ifOn(dm.ability.totalize_dmg_))
     )
   ),
   registerBuff(
     'ability_ult_dmg_',
     ownBuff.combat.dmg_.addWithDmgType(
       'ult',
-      ability_check(cmpEq(enemy.common.isStunned, 1, dm.ability.totalize_dmg_))
+      ability_check(isStunned.ifOn(dm.ability.totalize_dmg_))
     )
   ),
   registerBuff(
@@ -218,7 +213,7 @@ const sheet = register(
       cmpGE(
         char.mindscape,
         1,
-        cmpEq(enemy.common.isStunned, 1, dark_abyss_reverb.ifOn(dm.m1.crit_))
+        isStunned.ifOn(dark_abyss_reverb.ifOn(dm.m1.crit_))
       )
     )
   ),
@@ -229,11 +224,7 @@ const sheet = register(
       cmpGE(
         char.mindscape,
         1,
-        cmpEq(
-          enemy.common.isStunned,
-          1,
-          dark_abyss_reverb.ifOn(dm.m1.crit_dmg_)
-        )
+        isStunned.ifOn(dark_abyss_reverb.ifOn(dm.m1.crit_dmg_))
       )
     )
   ),
@@ -244,7 +235,7 @@ const sheet = register(
       cmpGE(
         char.mindscape,
         1,
-        cmpEq(enemy.common.isStunned, 1, dark_abyss_reverb.ifOn(dm.m1.crit_))
+        isStunned.ifOn(dark_abyss_reverb.ifOn(dm.m1.crit_))
       )
     )
   ),
@@ -255,11 +246,7 @@ const sheet = register(
       cmpGE(
         char.mindscape,
         1,
-        cmpEq(
-          enemy.common.isStunned,
-          1,
-          dark_abyss_reverb.ifOn(dm.m1.crit_dmg_)
-        )
+        isStunned.ifOn(dark_abyss_reverb.ifOn(dm.m1.crit_dmg_))
       )
     )
   ),
@@ -267,14 +254,14 @@ const sheet = register(
     'm2_exSpecial_defIgn_',
     ownBuff.combat.defIgn_.addWithDmgType(
       'exSpecial',
-      cmpGE(char.mindscape, 2, cmpEq(enemy.common.isStunned, 1, dm.m2.defIgn_))
+      cmpGE(char.mindscape, 2, isStunned.ifOn(dm.m2.defIgn_))
     )
   ),
   registerBuff(
     'm2_ult_defIgn_',
     ownBuff.combat.defIgn_.addWithDmgType(
       'ult',
-      cmpGE(char.mindscape, 2, cmpEq(enemy.common.isStunned, 1, dm.m2.defIgn_))
+      cmpGE(char.mindscape, 2, isStunned.ifOn(dm.m2.defIgn_))
     )
   ),
   registerBuff(
@@ -287,29 +274,21 @@ const sheet = register(
     'm6_exSpecial_dmg_',
     ownBuff.combat.dmg_.addWithDmgType(
       'exSpecial',
-      cmpGE(
-        char.mindscape,
-        6,
-        cmpEq(enemy.common.isStunned, 1, dm.m6.totalize_dmg_)
-      )
+      cmpGE(char.mindscape, 6, isStunned.ifOn(dm.m6.totalize_dmg_))
     )
   ),
   registerBuff(
     'm6_ult_dmg_',
     ownBuff.combat.dmg_.addWithDmgType(
       'ult',
-      cmpGE(
-        char.mindscape,
-        6,
-        cmpEq(enemy.common.isStunned, 1, dm.m6.totalize_dmg_)
-      )
+      cmpGE(char.mindscape, 6, isStunned.ifOn(dm.m6.totalize_dmg_))
     )
   ),
   registerBuff(
     'm6_exSpecial_mv_mult_',
     ownBuff.dmg.mv_mult_.addWithDmgType(
       'exSpecial',
-      cmpGE(char.mindscape, 6, cmpEq(enemy.common.isStunned, 0, dm.m6.mv_mult_))
+      cmpGE(char.mindscape, 6, isStunned.ifOff(dm.m6.mv_mult_))
     )
   )
 )

--- a/libs/zzz/formula/src/data/char/sheets/Koleda.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Koleda.ts
@@ -1,17 +1,11 @@
-import {
-  cmpEq,
-  cmpGE,
-  prod,
-  subscript,
-  sum,
-} from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
   customDmg,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -152,11 +146,7 @@ const sheet = register(
           team.common.count.withSpecialty('rupture')
         ),
         3,
-        cmpEq(
-          enemy.common.isStunned,
-          1,
-          prod(exSpecial_debuff, percent(dm.ability.chain_dmg_))
-        )
+        isStunned.ifOn(prod(exSpecial_debuff, percent(dm.ability.chain_dmg_)))
       )
     ),
     undefined,

--- a/libs/zzz/formula/src/data/char/sheets/Soldier11.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Soldier11.ts
@@ -1,16 +1,10 @@
-import {
-  cmpEq,
-  cmpGE,
-  prod,
-  subscript,
-  sum,
-} from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -199,7 +193,7 @@ const sheet = register(
         3,
         sum(
           dm.ability.fire_dmg_,
-          cmpEq(enemy.common.isStunned, 1, dm.ability.fire_dmg_additional)
+          isStunned.ifOn(dm.ability.fire_dmg_additional)
         )
       )
     )

--- a/libs/zzz/formula/src/data/char/sheets/Yixuan.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yixuan.ts
@@ -1,18 +1,12 @@
 import type { NumNode } from '@genshin-optimizer/pando/engine'
-import {
-  cmpEq,
-  cmpGE,
-  prod,
-  subscript,
-  sum,
-} from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
   customSheerDmg,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -51,7 +45,7 @@ const ability_check = (node: NumNode) =>
     node
   )
 const ability_dmg_ = ownBuff.combat.common_dmg_.add(
-  ability_check(cmpEq(enemy.common.isStunned, 1, dm.ability.dmg_))
+  ability_check(isStunned.ifOn(dm.ability.dmg_))
 )
 const m4_dmg_ = ownBuff.combat.common_dmg_.add(
   cmpGE(char.mindscape, 4, prod(tranquility, percent(dm.m4.dmg_)))

--- a/libs/zzz/formula/src/data/char/sheets/ZhuYuan.ts
+++ b/libs/zzz/formula/src/data/char/sheets/ZhuYuan.ts
@@ -1,17 +1,11 @@
-import {
-  cmpEq,
-  cmpGE,
-  prod,
-  subscript,
-  sum,
-} from '@genshin-optimizer/pando/engine'
+import { cmpGE, prod, subscript, sum } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
+import { isStunned } from '../../common/enemy'
 import {
   allBoolConditionals,
   allNumConditionals,
   customDmg,
-  enemy,
   own,
   ownBuff,
   percent,
@@ -39,11 +33,7 @@ const { shotshells_hit } = allNumConditionals(key, true, 0, dm.m2.stacks)
 const core_dmg_ = ownBuff.combat.common_dmg_.add(
   sum(
     percent(subscript(char.core, dm.core.dmg_)),
-    cmpEq(
-      enemy.common.isStunned,
-      1,
-      percent(subscript(char.core, dm.core.add_dmg_))
-    )
+    isStunned.ifOn(percent(subscript(char.core, dm.core.add_dmg_)))
   )
 )
 

--- a/libs/zzz/formula/src/data/common/dmg.ts
+++ b/libs/zzz/formula/src/data/common/dmg.ts
@@ -1,5 +1,4 @@
 import {
-  cmpEq,
   lookup,
   max,
   prod,
@@ -9,6 +8,7 @@ import {
 } from '@genshin-optimizer/pando/engine'
 import type { TagMapNodeEntries } from '../util'
 import { enemy, own, ownBuff, percent } from '../util'
+import { isStunned } from './enemy'
 
 const defLevelFactor = [
   -1, 50, 54, 58, 62, 66, 71, 76, 82, 88, 94, 100, 107, 114, 121, 129, 137, 145,
@@ -70,7 +70,7 @@ const data: TagMapNodeEntries = [
   ),
   // Stunned Multiplier
   ownBuff.dmg.stunned_mult_.add(
-    cmpEq(enemy.common.isStunned, 1, enemy.common.stun_, enemy.common.unstun_)
+    isStunned.ifOn(enemy.common.stun_, enemy.common.unstun_)
   ),
 
   // Standard dmg Crit Multiplier

--- a/libs/zzz/formula/src/data/common/enemy.ts
+++ b/libs/zzz/formula/src/data/common/enemy.ts
@@ -1,0 +1,3 @@
+import { allBoolConditionals } from '../util'
+
+export const { isStunned } = allBoolConditionals('enemy')

--- a/libs/zzz/formula/src/data/disc/disc.test.ts
+++ b/libs/zzz/formula/src/data/disc/disc.test.ts
@@ -62,7 +62,6 @@ function testCharacterData(
     own.common.critMode.add('avg'),
     enemy.common.def.add(953),
     enemy.common.res_.electric.add(0.1),
-    enemy.common.isStunned.add(0),
     enemyDebuff.common.resRed_.electric.add(0.15),
     enemyDebuff.common.dmgInc_.add(0.1),
     enemyDebuff.common.dmgRed_.add(0.15),

--- a/libs/zzz/formula/src/data/util/tag.ts
+++ b/libs/zzz/formula/src/data/util/tag.ts
@@ -217,7 +217,6 @@ export const enemyTag = {
     dazeInc_: agg,
     dazeRed_: agg,
     anomBuildupRes_: agg,
-    isStunned: iso,
   },
 } as const
 

--- a/libs/zzz/formula/src/data/wengine/wengine.test.ts
+++ b/libs/zzz/formula/src/data/wengine/wengine.test.ts
@@ -69,7 +69,6 @@ function testCharacterData(wengineKey: WengineKey) {
     own.common.critMode.add('avg'),
     enemy.common.def.add(953),
     enemy.common.res_.electric.add(0.1),
-    enemy.common.isStunned.add(0),
     enemyDebuff.common.resRed_.electric.add(0.15),
     enemyDebuff.common.dmgInc_.add(0.1),
     enemyDebuff.common.dmgRed_.add(0.15),

--- a/libs/zzz/formula/src/formula.test.ts
+++ b/libs/zzz/formula/src/formula.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@genshin-optimizer/zzz/consts'
 import {
   charTagMapNodeEntries,
+  conditionals,
   discTagMapNodeEntries,
   formulas,
   teamData,
@@ -23,6 +24,7 @@ import { Calculator } from './calculator'
 import { data, keys, values } from './data'
 import {
   type TagMapNodeEntries,
+  conditionalEntries,
   convert,
   enemy,
   enemyDebuff,
@@ -240,7 +242,11 @@ describe('char+wengine test', () => {
         own.common.critMode.add(critMode),
         enemy.common.def.add(635),
         enemy.common.res_.electric.add(0.1),
-        enemy.common.isStunned.add(isStunned ? 1 : 0),
+        conditionalEntries(
+          'enemy',
+          'Anby',
+          null
+        )(conditionals.enemy.isStunned.name, isStunned ? 1 : 0),
         enemyDebuff.common.resRed_.electric.add(0.15),
         enemyDebuff.common.dmgInc_.add(0.1),
         enemyDebuff.common.dmgRed_.add(0.15),
@@ -304,7 +310,7 @@ describe('char+wengine test', () => {
       own.common.critMode.add('avgHit'),
       enemy.common.def.add(635),
       enemy.common.res_.electric.add(0.1),
-      enemy.common.isStunned.add(1),
+      conditionalEntries('enemy', 'Anby', null)('isStunned', 1),
       enemyDebuff.common.resRed_.electric.add(0.15),
       enemyDebuff.common.dmgInc_.add(0.1),
       enemyDebuff.common.dmgRed_.add(0.15),

--- a/libs/zzz/formula/src/meta.ts
+++ b/libs/zzz/formula/src/meta.ts
@@ -1293,6 +1293,7 @@ export const conditionals = {
     },
     frostbite: { sheet: 'anomaly', name: 'frostbite', type: 'bool' },
   },
+  enemy: { isStunned: { sheet: 'enemy', name: 'isStunned', type: 'bool' } },
 } as const
 export const formulas = {
   Alice: {

--- a/libs/zzz/page-optimize/src/EnemyStats.tsx
+++ b/libs/zzz/page-optimize/src/EnemyStats.tsx
@@ -5,6 +5,8 @@ import {
   NumberInputLazy,
 } from '@genshin-optimizer/common/ui'
 import { isIn } from '@genshin-optimizer/common/util'
+import type { Document } from '@genshin-optimizer/game-opt/sheet-ui'
+import { DocumentDisplay } from '@genshin-optimizer/game-opt/sheet-ui'
 import { allAttributeKeys } from '@genshin-optimizer/zzz/consts'
 import type { EnemyStatKey, EnemyStatsTag } from '@genshin-optimizer/zzz/db'
 import { enemyStatKeys, newEnemyStatTag } from '@genshin-optimizer/zzz/db'
@@ -13,13 +15,16 @@ import {
   useCharacterContext,
   useDatabaseContext,
 } from '@genshin-optimizer/zzz/db-ui'
-import type { Attribute, Tag } from '@genshin-optimizer/zzz/formula'
+import {
+  type Attribute,
+  type Tag,
+  conditionals,
+} from '@genshin-optimizer/zzz/formula'
 import { TagDisplay } from '@genshin-optimizer/zzz/formula-ui'
 import { AttributeName } from '@genshin-optimizer/zzz/ui'
 import { DeleteForever } from '@mui/icons-material'
 import {
   Box,
-  Button,
   CardContent,
   IconButton,
   InputAdornment,
@@ -32,13 +37,8 @@ import { useCallback } from 'react'
 export function EnemyStatsSection() {
   const { database } = useDatabaseContext()
   const { key: characterKey } = useCharacterContext()!
-  const {
-    enemyStats,
-    enemyLvl,
-    enemyDef,
-    enemyisStunned,
-    enemyStunMultiplier,
-  } = useCharOpt(characterKey)!
+  const { enemyStats, enemyLvl, enemyDef, enemyStunMultiplier } =
+    useCharOpt(characterKey)!
 
   const setStat = useCallback(
     (tag: EnemyStatsTag, value: number | null, index?: number) =>
@@ -74,17 +74,8 @@ export function EnemyStatsSection() {
             endAdornment: <InputAdornment position="end">%</InputAdornment>,
           }}
         />
-        <Button
-          onClick={() =>
-            database.charOpts.set(characterKey, {
-              enemyisStunned: !enemyisStunned,
-            })
-          }
-          color={enemyisStunned ? 'success' : 'secondary'}
-        >
-          {enemyisStunned ? 'Stunned' : 'Not Stunned'}
-        </Button>
       </Box>
+      <DocumentDisplay document={enemyDoc} />
       {enemyStats.map(({ tag, value }, i) => (
         <EnemyStatDisplay
           key={JSON.stringify(tag) + i}
@@ -223,4 +214,12 @@ function AttributeDropdown({
       ))}
     </DropdownButton>
   )
+}
+
+const enemyDoc: Document = {
+  type: 'conditional',
+  conditional: {
+    label: 'Enemy is Stunned',
+    metadata: conditionals.enemy.isStunned,
+  },
 }


### PR DESCRIPTION
## Describe your changes

Moved `enemy.common.isStunned` to a conditional

## Issue or discord link

- https://github.com/frzyc/genshin-optimizer/issues/3073

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a standardized “Enemy is Stunned” conditional control in Enemy stats via a document-style UI, improving clarity and consistency.
- Refactor
  - Unified stun handling across calculations using a centralized isStunned condition, replacing direct enemy stun flags.
  - Removed legacy enemy stun toggle from settings and deprecated the old enemy stun field from character options.
  - Updated multiple character sheets and damage logic to use the new condition.
- Tests
  - Updated test setups to use conditional-based stun application instead of direct flag manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->