### PR TITLE
Add elemental dmginc and cdmg to lunar damage

### DIFF
--- a/libs/gi/wr/src/reaction.ts
+++ b/libs/gi/wr/src/reaction.ts
@@ -364,13 +364,17 @@ export function lunarDmg(
     }
   )
 
-  const critDMG_ =
-    variant === 'lunarcharged'
-      ? input.total.critDMG_
-      : infoMut(sum(input.total.critDMG_, input.total.lunarbloom_critDMG_), {
-          ...input.total.critDMG_.info,
-          pivot: true,
-        })
+  const critDMG_ = infoMut(
+    sum(
+      input.total.critDMG_,
+      ...(variant === 'lunarbloom' ? [input.total.lunarbloom_critDMG_] : []),
+      input.total[`${transformativeReactions[variant].resist}_critDMG_`]
+    ),
+    {
+      ...input.total.critDMG_.info,
+      pivot: true,
+    }
+  )
 
   return data(
     prod(
@@ -383,7 +387,8 @@ export function lunarDmg(
             path: `${variant}_baseDmg_`,
           })
         ),
-        input.total[`${variant}_dmgInc`]
+        input.total[`${variant}_dmgInc`],
+        input.total[`${transformativeReactions[variant].resist}_dmgInc`]
       ),
       lookup(
         input.hit.hitMode,


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- https://discord.com/channels/785153694478893126/819643218446254100/1425136746177499176

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected critical damage aggregation for lunar reactions across variants, ensuring all relevant sources are included.
  * Fixed damage increment composition by accounting for resistance-based increments in lunar damage calculations.
  * Results in more accurate crit and average hit values, and more consistent final lunar damage outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->