### PR TITLE
Added unactivated stat to roll eff

### DIFF
--- a/libs/gi/util/src/artifact/artifact.ts
+++ b/libs/gi/util/src/artifact/artifact.ts
@@ -176,7 +176,7 @@ export function getArtifactEfficiency(
   artifact: IArtifact,
   filter: Set<SubstatKey> = new Set(allSubstatKeys)
 ): { currentEfficiency: number; maxEfficiency: number } {
-  const { substats, rarity, level } = artifact
+  const { substats, rarity, level, unactivatedSubstats } = artifact
   const { artifactMeta } = getArtifactMeta(artifact)
   // Relative to max star, so comparison between different * makes sense.
   const currentEfficiency = artifact.substats.reduce(
@@ -189,6 +189,7 @@ export function getArtifactEfficiency(
 
   const rollsRemaining = getRollsRemaining(level, rarity)
   const emptySlotCount = substats.filter((s) => !s.key).length
+
   const matchedSlotCount = substats.filter(
     (s) => s.key && filter.has(s.key)
   ).length
@@ -196,14 +197,18 @@ export function getArtifactEfficiency(
     filter.size -
     matchedSlotCount -
     (filter.has(artifact.mainStatKey as any) ? 1 : 0)
+  const unactivatedSubstatRoll =
+    unactivatedSubstats?.filter((s) => s.key).length ?? 0
 
-  let maxEfficiency = currentEfficiency
+  let maxEfficiency =
+    currentEfficiency + (artifactMeta.unactivatedSubstats[0]?.efficiency ?? 0)
   const maxRollEff = maxSubstatRollEfficiency[rarity]
   // Rolls into good empty slots, assuming max-level artifacts have no empty slots
   maxEfficiency += maxRollEff * Math.min(emptySlotCount, unusedFilterCount)
   // Rolls into an existing good slot
   if (matchedSlotCount || (emptySlotCount && unusedFilterCount))
-    maxEfficiency += maxRollEff * (rollsRemaining - emptySlotCount)
+    maxEfficiency +=
+      maxRollEff * (rollsRemaining - emptySlotCount - unactivatedSubstatRoll)
 
   return { currentEfficiency, maxEfficiency }
 }


### PR DESCRIPTION
## Describe your changes

- This change adds the unactivated stat to the max roll efficiency calculation. It won't count to the current roll eff until it's activated.

## Issue or discord link

- Fix #3060 

## Testing/validation

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Artifact evaluation now accounts for unactivated substats, reflecting their potential rolls and impact on max efficiency.
  - Displays clearer roll details, distinguishing ambiguous vs. unambiguous rolls and showing accurate values when determinable.
  - Scoring explores valid roll combinations to present the highest possible artifact score.
  - Includes unactivated substats in artifact metadata for more complete artifact insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->