### PR TITLE
ZO: Fix Manato's and Yidhari's hp scalings

### DIFF
--- a/libs/zzz/formula/src/data/char/sheets/Manato.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Manato.ts
@@ -1,4 +1,4 @@
-import { cmpGE } from '@genshin-optimizer/pando/engine'
+import { cmpGE, constant, prod } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
 import {
@@ -34,6 +34,11 @@ const sheet = register(
   ...registerAllDmgDazeAndAnom(key, dm),
 
   // Buffs
+  registerBuff(
+    'core_hpSheerForce',
+    // TODO: use dm
+    ownBuff.initial.sheerForce.add(prod(own.final.hp, constant(0.1)))
+  ),
   registerBuff(
     'm6_dmg_',
     ownBuff.combat.common_dmg_.add(

--- a/libs/zzz/formula/src/data/char/sheets/Yidhari.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yidhari.ts
@@ -1,4 +1,4 @@
-import { cmpGE } from '@genshin-optimizer/pando/engine'
+import { cmpGE, constant, prod } from '@genshin-optimizer/pando/engine'
 import { type CharacterKey } from '@genshin-optimizer/zzz/consts'
 import { allStats, mappedStats } from '@genshin-optimizer/zzz/stats'
 import {
@@ -34,6 +34,11 @@ const sheet = register(
   ...registerAllDmgDazeAndAnom(key, dm),
 
   // Buffs
+  registerBuff(
+    'core_hpSheerForce',
+    // TODO: use dm
+    ownBuff.initial.sheerForce.add(prod(own.final.hp, constant(0.1)))
+  ),
   registerBuff(
     'm6_dmg_',
     ownBuff.combat.common_dmg_.add(

--- a/libs/zzz/formula/src/meta/char/Manato/buffs.ts
+++ b/libs/zzz/formula/src/meta/char/Manato/buffs.ts
@@ -1,5 +1,16 @@
 // WARNING: Generated file, do not modify
 export const buffs = {
+  core_hpSheerForce: {
+    sheet: 'Manato',
+    name: 'core_hpSheerForce',
+    tag: {
+      et: 'display',
+      qt: 'initial',
+      q: 'sheerForce',
+      sheet: 'Manato',
+      name: 'core_hpSheerForce',
+    },
+  },
   m6_dmg_: {
     sheet: 'Manato',
     name: 'm6_dmg_',

--- a/libs/zzz/formula/src/meta/char/Yidhari/buffs.ts
+++ b/libs/zzz/formula/src/meta/char/Yidhari/buffs.ts
@@ -1,5 +1,16 @@
 // WARNING: Generated file, do not modify
 export const buffs = {
+  core_hpSheerForce: {
+    sheet: 'Yidhari',
+    name: 'core_hpSheerForce',
+    tag: {
+      et: 'display',
+      qt: 'initial',
+      q: 'sheerForce',
+      sheet: 'Yidhari',
+      name: 'core_hpSheerForce',
+    },
+  },
   m6_dmg_: {
     sheet: 'Yidhari',
     name: 'm6_dmg_',

--- a/libs/zzz/page-optimize/src/CharSheetsDisplay.tsx
+++ b/libs/zzz/page-optimize/src/CharSheetsDisplay.tsx
@@ -2,7 +2,12 @@ import { shouldShowDevComponents } from '@genshin-optimizer/common/util'
 import type { Document } from '@genshin-optimizer/game-opt/sheet-ui'
 import { DocumentDisplay } from '@genshin-optimizer/game-opt/sheet-ui'
 import { useCharacterContext } from '@genshin-optimizer/zzz/db-ui'
-import { Soldier0Anby, Yixuan } from '@genshin-optimizer/zzz/formula'
+import {
+  Manato,
+  Soldier0Anby,
+  Yidhari,
+  Yixuan,
+} from '@genshin-optimizer/zzz/formula'
 import { TagDisplay, charSheets } from '@genshin-optimizer/zzz/formula-ui'
 import { Box } from '@mui/material'
 
@@ -12,6 +17,8 @@ export function CharSheetSection() {
     <Box>
       {characterKey === 'Yixuan' && <MinimalYixuanSheet />}
       {characterKey === 'Soldier0Anby' && <MinimalS0AnbySheet />}
+      {characterKey === 'Manato' && <MinimalManatoSheet />}
+      {characterKey === 'Yidhari' && <MinimalYidhariSheet />}
       {shouldShowDevComponents &&
         Object.values(charSheets[characterKey]).flatMap((sheet, index1) =>
           sheet.documents.map((doc, index2) => (
@@ -78,6 +85,56 @@ function MinimalS0AnbySheet() {
   return (
     <>
       {s0AnbyDocs.map((doc, index) => (
+        <DocumentDisplay key={index} document={doc} />
+      ))}
+    </>
+  )
+}
+
+const manatoDocs: Document[] = [
+  {
+    type: 'text',
+    text: "We automatically convert Manato's HP to Sheer Force at a ratio of 1:0.1. Everything else in his kit is not factored",
+  },
+  {
+    type: 'fields',
+    fields: [
+      {
+        title: <TagDisplay tag={Manato.buffs.core_hpSheerForce.tag} />,
+        fieldRef: Manato.buffs.core_hpSheerForce.tag,
+      },
+    ],
+  },
+]
+function MinimalManatoSheet() {
+  return (
+    <>
+      {manatoDocs.map((doc, index) => (
+        <DocumentDisplay key={index} document={doc} />
+      ))}
+    </>
+  )
+}
+
+const yidhariDocs: Document[] = [
+  {
+    type: 'text',
+    text: "We automatically convert Yidhari's HP to Sheer Force at a ratio of 1:0.1. Everything else in her kit is not factored",
+  },
+  {
+    type: 'fields',
+    fields: [
+      {
+        title: <TagDisplay tag={Yidhari.buffs.core_hpSheerForce.tag} />,
+        fieldRef: Yidhari.buffs.core_hpSheerForce.tag,
+      },
+    ],
+  },
+]
+function MinimalYidhariSheet() {
+  return (
+    <>
+      {yidhariDocs.map((doc, index) => (
         <DocumentDisplay key={index} document={doc} />
       ))}
     </>


### PR DESCRIPTION
## Describe your changes

Added buffs and UI for Manato's and Yidhari's core passive hp scalings

## Issue or discord link

- https://discord.com/channels/785153694478893126/1252702983561543750/1430281839850815659
## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HP-scaling buff to Manato and Yidhari that grants bonus benefits based on 10% of final HP value.
  * Updated character displays to showcase the new buff mechanics in optimization views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->