### PR TITLE
GO: Add key to character stuff

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/CustomMultiTarget.ts
+++ b/libs/gi/db/src/Database/DataManagers/CustomMultiTarget.ts
@@ -15,9 +15,9 @@ import { allInputPremodKeys } from '../../legacy/keys'
 
 export const MAX_NAME_LENGTH = 200
 export const MAX_DESC_LENGTH = 2000
-export function initCustomMultiTarget() {
+export function initCustomMultiTarget(index: number) {
   return {
-    name: 'New Custom Target',
+    name: `New Custom Target ${index}`,
     targets: [],
   }
 }

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetModal.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetModal.tsx
@@ -47,7 +47,10 @@ export function CustomMultiTargetModal({
     setCustomTargets(teamChar.customMultiTargets)
 
   const addNewCustomMultiTarget = useCallback(() => {
-    setCustomTargets([initCustomMultiTarget(), ...customMultiTargets])
+    setCustomTargets([
+      initCustomMultiTarget(customMultiTargets.length + 1),
+      ...customMultiTargets,
+    ])
   }, [customMultiTargets, setCustomTargets])
   const setCustomMultiTarget = useCallback(
     (ind: number) => (newTarget: CustomMultiTarget) => {

--- a/libs/gi/page-team/src/index.tsx
+++ b/libs/gi/page-team/src/index.tsx
@@ -294,7 +294,11 @@ function InnerContent({ tab }: { tab?: string }) {
             <OptTargetWrapper>
               <Routes>
                 <Route path=":characterKey">
-                  <Route path="*" index element={<Content tab={tab} />} />
+                  <Route
+                    path="*"
+                    index
+                    element={<Content key={characterKey} tab={tab} />}
+                  />
                 </Route>
               </Routes>
             </OptTargetWrapper>


### PR DESCRIPTION
## Describe your changes

Add a key to the main character content in the team page. This seems to force React to not cache certain states, which prevents multiple data corruption issues that have been present.

## Issue or discord link

- Fix #3102 
- https://discord.com/channels/785153694478893126/1418252983430549625
- Fix #3058

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Custom multi-targets now receive sequential numbering in their default names for better organization and distinction.
  * Optimized component remounting behavior for improved performance when navigating between different characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->