### PR TITLE
Prevent multiple opt configs from having the same build list

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
@@ -197,6 +197,16 @@ export class OptConfigDataManager extends DataManager<
       !this.database.generatedBuildList.get(generatedBuildListId)
     )
       generatedBuildListId = undefined
+    // Don't allow 2 opt configs to have the same build list
+    if (
+      generatedBuildListId &&
+      this.database.optConfigs.entries.some(
+        ([otherKey, otherConfig]) =>
+          key !== otherKey &&
+          otherConfig.generatedBuildListId === generatedBuildListId
+      )
+    )
+      generatedBuildListId = undefined
     if (typeof useTeammateBuild !== 'boolean') useTeammateBuild = false
 
     return {


### PR DESCRIPTION
## Describe your changes

Prior to #3104, opt configs were getting criss-crossed in strange ways. One of those ways would accidentally cause 2 optconfigs to have the same generatedBuildListId. Thus, anytime the build list for 1 opt config was changed, it was changed for the other one. This could happen across characters as well, carrying builds across characters incorrectly.
This change adds a check that will remove these accidentally linked optconfigs.

## Issue or discord link

- Fix #3058 again

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a validation issue where multiple configurations could incorrectly share the same build list identifier, ensuring proper data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->