### PR TITLE
GO: Fix artifact upgrader charts not updating

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
@@ -2,7 +2,7 @@ import {
   useBoolState,
   useForceUpdate,
 } from '@genshin-optimizer/common/react-util'
-import { CardThemed, SqBadge, usePrev } from '@genshin-optimizer/common/ui'
+import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
 import { linspace, objMap } from '@genshin-optimizer/common/util'
 import {
   type ArtifactSlotKey,
@@ -156,8 +156,12 @@ function UpgradeOptChartCardGraph({
   const [, forceUpdate] = useForceUpdate()
   const equippedArt = useArtifact(upArt.id)
 
-  if (usePrev(equippedArt) !== equippedArt && equippedArt)
-    upOptCalc.reCalc(ix, equippedArt)
+  useEffect(() => {
+    if (equippedArt) {
+      upOptCalc.reCalc(ix, equippedArt)
+      forceUpdate()
+    }
+  }, [equippedArt, upOptCalc, ix, forceUpdate])
 
   const constrained = thresholds.length > 1
 


### PR DESCRIPTION
Closes #3136. I high key don't know anything about React, so this might not be the right approach. Please feel free to push changes to my fork/branch.

The issue was that in development, [React `<StrictMode>`](https://react.dev/reference/react/StrictMode) renders every component twice (to check for impurity issues). The first render doesn't pick up on the updated artifact from `upOptCalc.reCalc` because it's not in an effect and so doesn't trigger reactivity, but the second one gets the fresh artifact.

However, `<StrictMode>` does nothing in prod, so in the live version of the website requires a *real* second render to pick up on the previous artifact state. You can verify this by pressing the edit button on an artifact in the upgrader, which triggers a rerender and causes the graph to update (this was not obvious to me when I was reporting because there's never any reason to press the edit button and then immediately cancel LOL).

So, the solution: just move the `upOptCalc.reCalc` into a `useEffect`. Which also means I have to remove the `usePrev` call, and, I'm gonna be honest, I don't really understand what it's doing. Hope it doesn't break things. Let me know, I guess.

To test this change you'll have to remove the `<React.StrictMode>` in `main.tsx` on `master` and see that chart updating stops working, but that even with strict mode disabled it still works in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the efficiency of upgrade optimization calculations when equipment changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->