### PR TITLE
ZO: Sheer DMG and Res Ignore bonus stat attributes not working, disc +5 upgrades broken

### DIFF
--- a/libs/zzz/consts/src/common.ts
+++ b/libs/zzz/consts/src/common.ts
@@ -21,6 +21,7 @@ export const otherStatKeys = [
   'anom_crit_dmg_', // Anomaly CRIT DMG
   'dazeInc_', // Daze Increase
   'sheerForce',
+  'sheer_dmg_',
 ] as const
 
 export const unCondKeys = [

--- a/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/CharacterOptManager.ts
@@ -317,7 +317,8 @@ export class CharacterOptManager extends DataManager<
 
         let { attribute, damageType1, damageType2 } = tag
 
-        if (q !== 'dmg_') attribute = undefined
+        if (q !== 'dmg_' && q !== 'sheer_dmg_' && q !== 'resIgn_')
+          attribute = undefined
         if (attribute)
           attribute = validateValue(attribute, allAttributeKeys) as
             | AttributeKey

--- a/libs/zzz/formula-ui/src/components/TagDisplay.tsx
+++ b/libs/zzz/formula-ui/src/components/TagDisplay.tsx
@@ -67,6 +67,7 @@ const labelMap = {
   resIgn_: 'Res Ignore',
   dazeInc_: 'Daze Increase',
   buff_: 'Buff Bonus',
+  sheer_dmg_: 'Sheer DMG',
 } as const
 function TagStrDisplay({
   tag,

--- a/libs/zzz/schema/src/disc.ts
+++ b/libs/zzz/schema/src/disc.ts
@@ -24,7 +24,7 @@ import { z } from 'zod'
 
 export const substatSchema = z.object({
   key: zodEnumWithDefault([...allDiscSubStatKeys, ''] as const, ''),
-  upgrades: zodBoundedNumber(0, 5, 0),
+  upgrades: zodBoundedNumber(0, 6, 0),
 })
 
 const substatValidationSchema = z.object({


### PR DESCRIPTION
## Describe your changes

- Fixes Sheer DMG and Res Ignore bonus stat attribute selector not working
- Disc substat +5 upgrades not working

## Issue or discord link

- https://discord.com/channels/785153694478893126/1288975477981057124/1476358082606137384
- https://discord.com/channels/785153694478893126/1252702983561543750/1475845312978354299

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sheer DMG as a new stat type with full system support and UI labeling
  * Expanded attribute validation for additional bonus stat categories
  * Increased maximum substat upgrades from 5 to 6 per disc, enabling greater customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->