### PR TITLE
Fix Lunar DMG Bonus constraint

### DIFF
--- a/libs/gi/sheets/src/SheetUtil.tsx
+++ b/libs/gi/sheets/src/SheetUtil.tsx
@@ -90,7 +90,7 @@ export function nonStackBuff(
   buffNode: NumNode | number
 ) {
   return [
-    equal(input.nonStacking[buffName], input.charKey, buffNode),
+    infoMut(equal(input.nonStacking[buffName], input.charKey, buffNode), { path }),
     unequal(input.nonStacking[buffName], input.charKey, buffNode, {
       path,
       isTeamBuff: true,


### PR DESCRIPTION
Adding { path } to the active node in nonStackBuff so that resolveInfo can then look up unit %, thus builds with ≥ X % Lunar DMG Bonus will now pass. Then, wrap the equal result with infoMut (already imported) to directly mutates matchNode.info = { path: 'lunarcharged_dmg_' }. Tested on a local version for every elements (non-moonsign char).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal metadata tracking for improved data handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->