### PR TITLE
updating JSON import syntax

### DIFF
--- a/apps/zzz-frontend/src/app/App.tsx
+++ b/apps/zzz-frontend/src/app/App.tsx
@@ -2,6 +2,8 @@ import {
   AdBanner,
   AdBlockContextWrapper,
   AdRailSticky,
+
+
 } from '@genshin-optimizer/common/ad'
 import { ScrollTop, useRefSize } from '@genshin-optimizer/common/ui'
 import { isDev } from '@genshin-optimizer/common/util'

--- a/apps/zzz-frontend/vite.config.mts
+++ b/apps/zzz-frontend/vite.config.mts
@@ -6,7 +6,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import react from '@vitejs/plugin-react'
 import { defineConfig, normalizePath } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig(() => ({
   base: '',


### PR DESCRIPTION
Summary

Replaces the deprecated JSON import assertion syntax with the newer import attributes syntax.

Changes

Updated:
import pkg from './package.json' assert { type: 'json' }
to:
import pkg from './package.json' with { type: 'json' }

Reason

The assert { type: 'json' } syntax is being replaced by the newer with { type: 'json' } syntax as part of the JavaScript import attributes specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated JSON module import syntax in configuration.
  * Reformatted import spacing in the application file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->