### PR TITLE
Add initial support for ZZZ deobf'd DM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,8 @@
 	url = https://github.com/genshin-optimizer/zzz-hakushin-data
 	shallow = true
 	branch = master
+[submodule "libs/zzz/dm/ZenlessDataDeobf"]
+	path = libs/zzz/dm/ZenlessDataDeobf
+	url = https://github.com/genshin-optimizer/ZenlessDataDeobf
+	shallow = true
+	branch = master

--- a/libs/sr/dm-localization/src/executors/gen-locale/lib/util.ts
+++ b/libs/sr/dm-localization/src/executors/gen-locale/lib/util.ts
@@ -1,7 +1,7 @@
 import { h64 } from 'xxhashjs'
 // Convert un-hashed string in datamine to a textmap hash
-// RelicDesc_1012 -> 769181229
-// This can later be used as 769181229 -> (TextMapEN.json) -> "Increases Outgoing Healing by <unbreak>#1[i]%</unbreak>."
+// RelicDesc_1012 -> 12720770977431568614
+// This can later be used as 12720770977431568614 -> (TextMapEN.json) -> "Increases Outgoing Healing by <unbreak>#1[i]%</unbreak>."
 export function convertToHash(str: string) {
   return h64(str, 0).toString()
 }

--- a/libs/zzz/dm/.eslintrc.json
+++ b/libs/zzz/dm/.eslintrc.json
@@ -16,6 +16,13 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["./package.json", "./generators.json", "./executors.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/nx-plugin-checks": "error"
+      }
     }
   ]
 }

--- a/libs/zzz/dm/README.md
+++ b/libs/zzz/dm/README.md
@@ -4,9 +4,19 @@ This library was generated with [Nx](https://nx.dev).
 
 ## Update Datamine
 
-To update the datamine to a new commit, run `yarn run update-dm`. This will update both the Genshin and Star Rail datamines.
+To update the datamine to a new commit, run `yarn run update-dm`. This will update all game datamines.
 
-## Getting data from Hakush.in
+## [DEPRECATED] Getting data from Hakush.in
+
+NOTE: Hakush.in has been taken down, so this no longer works
 
 Download all the English JSONs from `https://api.hakush.in/zzz/`
 `nx get-hakushin zzz-dm`
+
+## Creating deobf DM mappings
+The datamine for ZZZ is obfuscated, so property names are not widely known, and the names change every version update of the DM. We have created a pipeline that will take known reverse mappings of values -> properties and create partially human-readable versions of the datamine configs.
+
+1. Run `nx generate @genshin-optimizer/zzz/dm:generate-all-deobf-template --verbose` to generate missing deobf templates `src/dm/deobf/FileCfg` based on values provided in `src/consts.ts`.
+1. Once the templates have been generated, you can reference between the files themselves, the output of the command, and your own best judgment to figure out what value corresponds to a given property and what you should name it.
+1. Once the mapping has been created, you can re-map the datamine files to readable versions with `nx run zzz-dm:deobf --verbose`
+1. These are also stored in `genshin-optimizer/ZenlessDataDeobf` (private repo, for people without access, you can run the previous steps to recreate the files)

--- a/libs/zzz/dm/executors.json
+++ b/libs/zzz/dm/executors.json
@@ -4,6 +4,11 @@
       "implementation": "./src/executors/gen-hakushin/executor",
       "schema": "./src/executors/gen-hakushin/schema.json",
       "description": "gen-hakushin executor"
+    },
+    "deobf": {
+      "implementation": "./src/executors/deobf/deobf",
+      "schema": "./src/executors/deobf/schema.json",
+      "description": "deobf executor"
     }
   }
 }

--- a/libs/zzz/dm/generators.json
+++ b/libs/zzz/dm/generators.json
@@ -1,0 +1,14 @@
+{
+  "generators": {
+    "generate-all-deobf-template": {
+      "factory": "./src/generators/generate-all-deobf-template",
+      "schema": "./src/generators/all-schema.json",
+      "description": "generate-all-deobf-template generator"
+    },
+    "generate-single-deobf-template": {
+      "factory": "./src/generators/generate-single-deobf-template",
+      "schema": "./src/generators/single-schema.json",
+      "description": "generate-single-deobf-template generator"
+    }
+  }
+}

--- a/libs/zzz/dm/package.json
+++ b/libs/zzz/dm/package.json
@@ -2,5 +2,9 @@
   "name": "@genshin-optimizer/zzz/dm",
   "version": "0.0.1",
   "type": "commonjs",
-  "executors": "./executors.json"
+  "executors": "./executors.json",
+  "dependencies": {
+    "@nx/devkit": "20.5.0"
+  },
+  "generators": "./generators.json"
 }

--- a/libs/zzz/dm/project.json
+++ b/libs/zzz/dm/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/zzz/dm/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "load-dm": {
       "options": {
@@ -17,7 +18,10 @@
     "get-hakushin": {
       "executor": "@genshin-optimizer/zzz/dm:gen-hakushin",
       "outputs": ["{projectRoot}/HakushinData/**/*"]
+    },
+    "deobf": {
+      "executor": "@genshin-optimizer/zzz/dm:deobf",
+      "outputs": ["{projectRoot}/ZenlessDataDeobf/**/*"]
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/zzz/dm/src/consts.ts
+++ b/libs/zzz/dm/src/consts.ts
@@ -2,3 +2,29 @@ export const PROJROOT_PATH = `${process.env['NX_WORKSPACE_ROOT']}/libs/zzz/dm`
 export const DM_PATH = `${PROJROOT_PATH}/ZenlessData` as const
 export const HAKUSHIN_PATH = `${PROJROOT_PATH}/HakushinData` as const
 export const DM2D_PATH = `${PROJROOT_PATH}/assets` as const
+
+export const allCharFileCfgs = [
+  'AvatarBaseTemplateTb',
+  'AvatarBattleTemplateTb',
+  'AvatarPassiveSkillDesTemplateTb',
+  'AvatarPassiveSkillTemplateTb',
+  'AvatarSkillDesTemplateTb',
+  'AvatarSkillTemplateTb',
+  'SkillPropertyTemplateTb',
+] as const
+
+export const allDiscFileCfgs = [
+  'EquipmentTemplateTb',
+  'ItemTemplateTb',
+] as const
+
+export const allWengineFileCfgs = [
+  'WeaponTalentTemplateTb',
+  'WeaponTemplateTb',
+] as const
+
+export const allFileCfgs = [
+  ...allCharFileCfgs,
+  ...allDiscFileCfgs,
+  ...allWengineFileCfgs,
+] as const

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarBaseTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarBaseTemplateTb.ts
@@ -1,0 +1,29 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  1011: 'AvatarId',
+  Avatar_Female_Size02_Anbi_En: 'FullName',
+  Avatar_Female_Size02_Anbi: 'ShortName',
+  Avatar_Female_Size02_Anbi_FullName: 'FullName2',
+  anbi: 'InternalName',
+  'BK_Anbi|BK_CHR_Common|BK_Anbi_VO': 'Unknown1',
+  2: 'Gender',
+  1: 'Camp',
+  Anbi: 'InternalName2',
+  10101: 'UnknownId',
+}
+
+const avatarBaseTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarBaseTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarBaseTemplateTb)[0][0]
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarBattleTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarBattleTemplateTb.ts
@@ -1,0 +1,62 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '0': 'todo', //'todo-KFPDJJGIPMK-DLLEAJCCCPEIdentical-KJAGPAMNACNIdentical-LHDFLMFCJBMIdentical-CPIEPGPJONPIdentical-GKAJKNIOBEHIdentical-JCPDKDBMGEGIdentical-BPHFIFBKGNLIdentical-IDOIIOPCJMIIdentical-BDMDGNGMHBEIdentical-MMGNDHFCKGCIdentical-NNAGNBNJJAHIdentical-NGNMPDPMNBMIdentical-IMENJAPMPGIIdentical-IAEELCIBHFHIdentical-OJJPCDPIIJKIdentical-DEBPMAEMEEI-GMPNLJBJICO-DMLEPEKIICF-NPJNFNINLDM-JHPNMEGHOOK-OIICMIMBHEJ',
+  '1': 'todo-MADHAAEIJAG',
+  '2': 'Specialty',
+  '49': 'Defence',
+  '93': 'AnomalyProficiency',
+  '94': 'AnomalyMastery',
+  '95': 'Attack',
+  '100': 'todo-FGNNAADEBPH',
+  '118': 'Impact',
+  '120': 'todo-CLDCMDBJAKB-CIJOMLFAMJK', // One of these is SPRecovery and one is SPBarPoint
+  '500': 'CritRate',
+  '603': 'HP',
+  '1011': 'AvatarId',
+  '5000': 'CritDamage',
+  '5011': 'AvatarPieceId',
+  '10000': 'RblCorrectionFactor', // Not sure
+  '54230': 'AttackGrowth',
+  '66882': 'DefenceGrowth',
+  '818426': 'HPGrowth',
+  '576912969788645000': 'todo-BKDKAHOLHIJ',
+  '10491841778352947000': 'todo-NGIEBDEJHJL',
+  '10016991024130073000': 'todo-AJILFKOLOID',
+  '["Anbi","Cut","Electric","Female","Camp1","Size2","AidTypeParry","Anbi","EtherEyesSize2"]':
+    'Tags',
+  '[4]': 'todo-HBBEIKMOMBD',
+  '[203]': 'ElementType',
+  '[101]': 'HitType',
+  '["1:1:2","2:203:2"]': 'todo-ABEPBEFBACB',
+  '[]': 'todo-OGFJHJKBFPE-DMGAIFADOEO', // DMGAIFADOEO is potential ID, handled below
+  '"Bip001"': 'todo-PDEHMDDAKDA',
+}
+
+const avatarBattleTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarBattleTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarBattleTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const potentialsKey = Object.entries(
+  Object.values(avatarBattleTemplateTb)[0].find((o) =>
+    Object.values(o).some(
+      (v) => JSON.stringify(v) === '[119100,119101,119102,119103,119104,119105]'
+    )
+  )!
+).find(
+  ([_, v]) =>
+    JSON.stringify(v) === '[119100,119101,119102,119103,119104,119105]'
+)![0]
+mapping[potentialsKey] = 'Potentials'
+const typing = generateTyping(reverseMapping, dmObj)
+typing['Potentials'] = 'object'
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarPassiveSkillDesTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarPassiveSkillDesTemplateTb.ts
@@ -1,0 +1,26 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '1': 'todo-FPHPEALJHCH',
+  '1011': 'AvatarId',
+  '1011501': 'AvatarSkillLevelTemplateId',
+  '[]': 'Potentials',
+  '["Anbi_UniqueSkill_01_Desc","Anbi_MathSkill_Desc"]': 'DescArray',
+  '["Anbi_UniqueSkill_Title","Anbi_MathSkill_Title"]': 'TitleArray',
+}
+
+const avatarPassiveSkillDesTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarPassiveSkillDesTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarPassiveSkillDesTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarPassiveSkillTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarPassiveSkillTemplateTb.ts
@@ -1,0 +1,31 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '1': 'Level',
+  '2': 'todo-HIMAGELFJFI', // 2-7
+  '15': 'MaxLevel',
+  '1011': 'AvatarId',
+  '1011001': 'PassiveSkillId',
+  '"Avatar_PassiveSkill_CoreSkillLevelUp"': 'CoreEnhanceText',
+  '[{"MPIANOLFJMB":12201,"AHDPFMHOLPH":6},{"MPIANOLFJMB":12101,"AHDPFMHOLPH":0}]':
+    'CoreStats', // TODO: This will change every patch since the property obf names will change
+  '["Anbi_UniqueSkill_Title"]': 'Title',
+  '["Anbi_UniqueSkill_02_Desc"]': 'Desc',
+  '[{"BALDAPBGEPK":10,"AHDPFMHOLPH":5000}]': 'Cost', // TODO: This will change every patch since the property obf names will change
+}
+
+const avatarPassiveSkillTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarPassiveSkillTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarPassiveSkillTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarSkillDesTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarSkillDesTemplateTb.ts
@@ -1,0 +1,27 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '0': 'todo-KFDFEMBDLKA-GHCEAHCKJHO-LKFOANPAFEO-ICEDFCOBJNA', // GHCEAHCKJHO is skill type
+  '1011': 'AvatarId',
+  '101100001': 'SkillDesId',
+  '"Anbi_Skill_Normal_Title"': 'Title',
+  '"Anbi_Skill_Normal_Desc"': 'Desc',
+  '""': 'Parameters',
+  '[]': 'Potential',
+}
+
+const avatarSkillDesTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarSkillDesTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarSkillDesTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarSkillTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/AvatarSkillTemplateTb.ts
@@ -1,0 +1,31 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '0': 'todo-GHCEAHCKJHO-DNAEMGCOBHPIdentical-JHEGJGGMHAIIdentical-FACPPINEHAD-IPFKJOHLJFEIdentical-EPACGGDHFALIdentical-FMHHHFOONJIIdentical-CCNCIGHNFFE-JIPLNPMALNH-BGHIODFFBEDIdentical-BOALFCIAFOCIdentical-AGBDJDBGOBJ-EJGJEHCBKAMIdentical-DPGNCMJNHPKIdentical', // JHEGJGGMHAI is probably SpRecoveryGrowth (unused/always 0). TODO: CCNCIGHNFFE is AttributeInfliction
+  '80': 'StunRatioGrowth',
+  '290': 'DamagePercentageGrowth',
+  '1559': 'EtherPurify',
+  '1560': 'StunRatio',
+  '3120': 'DamagePercentage',
+  '5620': 'SpRecovery',
+  '42900': 'FeverRecovery',
+  '1011001': 'SkillId',
+  '""': 'DistanceAttenuation',
+  '[]': 'todo-GLFAPAPGDLA',
+}
+
+const avatarSkillTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/AvatarSkillTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(avatarSkillTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/EquipmentTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/EquipmentTemplateTb.ts
@@ -1,0 +1,33 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '1': 'Slot',
+  '31000': 'EquipmentId',
+  '31021': 'EquipmentPieceId',
+  '"UI/Sprite/A1DynamicLoad/IconSuit/UnPacker/SuitWoodpeckerElectro.png"':
+    'Icon',
+  '"UI/3D/Role/Interface_Prop_Disk_03.prefab"': 'todo-EBJPFNJCHEB',
+  '"UI/Textures/3DSuit/FrontLabel/WoodpeckerElectro/3DSuitWoodpeckerElectroFrontLabel01.tga"':
+    'todo-HHCFFGCBPDO',
+  '"UI/Textures/3DSuit/BackLabel/WoodpeckerElectro/3DSuitWoodpeckerElectroBackLabel01.tga"':
+    'todo-LNMJMJKJBNA',
+  '"UI/Textures/3DSuit/Disk/3DSuitWoodpeckerElectro.tga"': 'todo-EKGGKNNOPHK',
+  '"Play_Music_DiaoLv_Icon_Test"': 'todo-ALMHJKJMLKC',
+  '"Pause_Music_DiaoLv_Icon_Test"': 'todo-IGEIIIEAGGN',
+}
+
+const equipmentTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/EquipmentTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(equipmentTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/ItemTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/ItemTemplateTb.ts
@@ -1,0 +1,44 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '0': 'todo-GMKIIFLFILC-MDDLOBGOLEB-AAJDEBKAJELIdentical-EDPAILDCPLL-FHGOCHDOMFJ',
+  '1': 'todo-LFBMAPBEEPL-PGNDMCIELFA-DDLIFFKIMLB',
+  '2': 'todo-DIAIMJJLKBG',
+  '3': 'todo-KJCANGNFJEI',
+  '10': 'todo-HHPGHOAKJJO-GGGFLBIIKFI',
+  '10001': 'ItemId', // Maybe
+  '"Item_Gold"': 'Name',
+  '"Item_Gold_des"': 'Desc',
+  '"Item_Gold_story"': 'Story',
+  '"Assets/NapResources/UI/Sprite/A1DynamicLoad/ItemIcon/UnPacker/IconCoin.png"':
+    'todo-BIOFJBBKIBE',
+  '"Assets/NapResources/UI/Sprite/A1DynamicLoad/ItemIconSmall/UnPacker/IconCoin.png"':
+    'todo-NAJODJGLLHC',
+  '"Assets/NapResources/UI/Sprite/A1DynamicLoad/ItemIconBig/UnPacker/IconCoin.png"':
+    'todo-KNKPBOCOAHO',
+  '""': 'todo-HMDHLOEHOFK-MEBGDAAMAJH',
+  '"Eff_DropItem_Diny"': 'todo-PPOHKDMFJJA',
+  '"Eff_DropItem_Diny_Loot"': 'todo-PFMBNHKDBPK-NLPMAJDFKLC',
+  '"FirmBox_Diny_Die"': 'todo-AAJBDILEEAF',
+  '"ItemBubble_IconCoin"': 'todo-BBNDAIHCFJK',
+  '"Assets/NapResources/UI/Sprite/A1DynamicLoad/GroceryType/UnPacker/IconGroceryType04.png"':
+    'todo-IJILHCBPIAA',
+  '4951609301349985000': 'todo-NGIEBDEJHJL',
+  '[]': 'todo-HFELAAHPDMH-OOCNNGJJMAK',
+}
+
+const itemTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/ItemTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(itemTemplateTb)[0][4]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/SkillPropertyTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/SkillPropertyTemplateTb.ts
@@ -1,0 +1,25 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '3': 'todo-GJBIMEAALIF', // ALways 3
+  '1001': 'SkillPropertyId',
+  '10000': 'todo-FAJFIBHEPIM', // Always 10000
+  '"SkillDamageRate"': 'SkillPropertyType',
+  '"{0:0.#%}"': 'Format',
+}
+
+const skillPropertyTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/SkillPropertyTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(skillPropertyTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/WeaponTalentTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/WeaponTalentTemplateTb.ts
@@ -1,0 +1,26 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '1': 'WeaponType',
+  '12001': 'WeaponId',
+  '"Weapon_TalentTitle_12001"': 'Title',
+  '"Weapon_TalentDes_81200101"': 'Desc',
+  '[81200101]': 'AbilityConfigIds',
+  '[false]': 'todo-FKLPKKIIGNL',
+}
+
+const weaponTalentTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/WeaponTalentTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(weaponTalentTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/WeaponTemplateTb.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/WeaponTemplateTb.ts
@@ -1,0 +1,37 @@
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = {
+  '0': 'todo-AFOGCPIINNC-KCBNLBGPHJE-CCELPAJBLJH-FBGHPPKLMDM',
+  '1': 'todo-PGAMJGAONFO-IHJMKLJCLFD', // IHJMKLJCLFD is WeaponType
+  '5': 'todo-FPPNLEKNIHO',
+  '300': 'todo-MOAMOCDBKFN',
+  '12001': 'WeaponId',
+  '20301': 'todo-NKFNONEIAEH',
+  '{"MBAPLBKGJGD":12101,"GGGFLBIIKFI":32}': 'MainStat',
+  '{"MBAPLBKGJGD":12102,"GGGFLBIIKFI":800}': 'SubStat',
+  '"Data/ScriptConfig/Character/Weapon_B_Common"': 'todo-NILEMPMJLGE',
+  '"UI/3D/Weapon/Weapon_B_Common_01"': 'todo-KMEPGOJNKDP',
+  '"Weapon/Weapon_B_Common_01"': 'todo-OIJDPMFKPOB',
+  '"10:7200,101010:2|10:16800,101020:7|10:36000,101020:12|10:60000,101030:6|10:120000,101030:12"':
+    'Materials',
+  '"Item_Weapon_B_Common_01_Desc"': 'Desc',
+  '""': 'todo-BHIGMLPMMIA-LNOKHHPBLHB', // LNOKHHPBLHB is extra story
+  '[{"BALDAPBGEPK":10,"AHDPFMHOLPH":1000}]': 'todo-DHGLJOENDHM',
+  '"Play_sfx_Weapon_B_Common_2d"': 'todo-GDBDNPBGOKN',
+}
+
+const weaponTemplateTb = JSON.parse(
+  readDMJSON('FileCfg/WeaponTemplateTb.json')
+) as GenericDmFile
+
+const dmObj = Object.values(weaponTemplateTb)[0][0]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}

--- a/libs/zzz/dm/src/dm/deobf/FileCfg/index.ts
+++ b/libs/zzz/dm/src/dm/deobf/FileCfg/index.ts
@@ -1,0 +1,26 @@
+// WARNING: Generated file, do not modify
+import AvatarBaseTemplateTb from './AvatarBaseTemplateTb'
+import AvatarBattleTemplateTb from './AvatarBattleTemplateTb'
+import AvatarPassiveSkillDesTemplateTb from './AvatarPassiveSkillDesTemplateTb'
+import AvatarPassiveSkillTemplateTb from './AvatarPassiveSkillTemplateTb'
+import AvatarSkillDesTemplateTb from './AvatarSkillDesTemplateTb'
+import AvatarSkillTemplateTb from './AvatarSkillTemplateTb'
+import EquipmentTemplateTb from './EquipmentTemplateTb'
+import ItemTemplateTb from './ItemTemplateTb'
+import SkillPropertyTemplateTb from './SkillPropertyTemplateTb'
+import WeaponTalentTemplateTb from './WeaponTalentTemplateTb'
+import WeaponTemplateTb from './WeaponTemplateTb'
+
+export const deobfMappings = {
+  AvatarBaseTemplateTb,
+  AvatarBattleTemplateTb,
+  AvatarPassiveSkillDesTemplateTb,
+  AvatarPassiveSkillTemplateTb,
+  AvatarSkillDesTemplateTb,
+  AvatarSkillTemplateTb,
+  SkillPropertyTemplateTb,
+  EquipmentTemplateTb,
+  ItemTemplateTb,
+  WeaponTalentTemplateTb,
+  WeaponTemplateTb,
+}

--- a/libs/zzz/dm/src/dm/deobf/index.ts
+++ b/libs/zzz/dm/src/dm/deobf/index.ts
@@ -1,0 +1,2 @@
+export * from './FileCfg'
+export * from './types'

--- a/libs/zzz/dm/src/dm/deobf/types.ts
+++ b/libs/zzz/dm/src/dm/deobf/types.ts
@@ -1,0 +1,4 @@
+export type GenericDmFile = Record<
+  string,
+  Record<string, string | number | object>[]
+>

--- a/libs/zzz/dm/src/dm/deobf/util.ts
+++ b/libs/zzz/dm/src/dm/deobf/util.ts
@@ -1,0 +1,26 @@
+import { objKeyValMap } from '@genshin-optimizer/common/util'
+
+export function generateMapping(
+  reverseMapping: Record<string | number, string>,
+  dmObj: Record<string, string | number | object>
+) {
+  return objKeyValMap(
+    Object.entries(dmObj),
+    ([k, v]) =>
+      [
+        k,
+        reverseMapping[typeof v === 'object' ? JSON.stringify(v) : v],
+      ] as const
+  )
+}
+
+// Need to remove quotes when dumping into TS files so typings are correct instead of literal strings
+export function generateTyping(
+  reverseMapping: Record<string | number, string>,
+  dmObj: Record<string, string | number | object>
+) {
+  return objKeyValMap(Object.values(dmObj), (v) => [
+    reverseMapping[JSON.stringify(v)],
+    typeof v,
+  ])
+}

--- a/libs/zzz/dm/src/executors/deobf/deobf.spec.ts
+++ b/libs/zzz/dm/src/executors/deobf/deobf.spec.ts
@@ -1,0 +1,27 @@
+import { ExecutorContext } from "@nx/devkit";
+
+import { DeobfExecutorSchema } from "./schema";
+import executor from "./deobf";
+
+const options: DeobfExecutorSchema = {};
+const context: ExecutorContext = {
+  root: "",
+  cwd: process.cwd(),
+  isVerbose: false,
+  projectGraph: {
+    nodes: {},
+    dependencies: {},
+  },
+  projectsConfigurations: {
+    projects: {},
+    version: 2,
+  },
+  nxJsonConfiguration: {},
+};
+
+describe("Deobf Executor", () => {
+  it("can run", async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/libs/zzz/dm/src/executors/deobf/deobf.ts
+++ b/libs/zzz/dm/src/executors/deobf/deobf.ts
@@ -1,0 +1,29 @@
+import { writeFileSync } from 'fs'
+import { formatText } from '@genshin-optimizer/common/pipeline'
+import { objKeyValMap } from '@genshin-optimizer/common/util'
+import { type PromiseExecutor, workspaceRoot } from '@nx/devkit'
+import type { GenericDmFile } from '../../dm/deobf'
+import { deobfMappings } from '../../dm/deobf'
+import { readDMJSON } from '../../util'
+import type { DeobfExecutorSchema } from './schema'
+
+const runExecutor: PromiseExecutor<DeobfExecutorSchema> = async (options) => {
+  console.log('Executor ran for Deobf', options)
+  for (const [file, deobfObj] of Object.entries(deobfMappings)) {
+    const outputFile = `${workspaceRoot}/libs/zzz/dm/ZenlessDataDeobf/FileCfg/${file}.json`
+    const dm = JSON.parse(readDMJSON(`FileCfg/${file}.json`)) as GenericDmFile
+    const deobfedDm = Object.values(dm)[0].map((dmObj) =>
+      objKeyValMap(
+        Object.entries(dmObj),
+        ([key, value]) => [deobfObj.mapping[key], value] as const
+      )
+    )
+    const formatted = await formatText(outputFile, JSON.stringify(deobfedDm))
+    writeFileSync(outputFile, formatted)
+  }
+  return {
+    success: true,
+  }
+}
+
+export default runExecutor

--- a/libs/zzz/dm/src/executors/deobf/schema.d.ts
+++ b/libs/zzz/dm/src/executors/deobf/schema.d.ts
@@ -1,0 +1,1 @@
+export interface DeobfExecutorSchema {} // eslint-disable-line

--- a/libs/zzz/dm/src/executors/deobf/schema.json
+++ b/libs/zzz/dm/src/executors/deobf/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Deobf executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/libs/zzz/dm/src/generators/all-schema.json
+++ b/libs/zzz/dm/src/generators/all-schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "GenerateAllDeobfTemplate",
+  "title": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/libs/zzz/dm/src/generators/generate-all-deobf-template.spec.ts
+++ b/libs/zzz/dm/src/generators/generate-all-deobf-template.spec.ts
@@ -1,0 +1,19 @@
+import type { Tree } from '@nx/devkit'
+import { readProjectConfiguration } from '@nx/devkit'
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+
+import { generateAllDeobfTemplateGenerator } from './generate-all-deobf-template'
+
+describe('generate-all-deobf-template generator', () => {
+  let tree: Tree
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace()
+  })
+
+  it('should run successfully', async () => {
+    await generateAllDeobfTemplateGenerator(tree)
+    const config = readProjectConfiguration(tree, 'test')
+    expect(config).toBeDefined()
+  })
+})

--- a/libs/zzz/dm/src/generators/generate-all-deobf-template.ts
+++ b/libs/zzz/dm/src/generators/generate-all-deobf-template.ts
@@ -1,0 +1,14 @@
+import type { Tree } from '@nx/devkit'
+
+import { allFileCfgs } from '../consts'
+import generateIndex from './generate-index-deobf'
+import generateSingleDeobfTemplateGenerator from './generate-single-deobf-template'
+
+export async function generateAllDeobfTemplateGenerator(tree: Tree) {
+  for (const dmFile of allFileCfgs) {
+    await generateSingleDeobfTemplateGenerator(tree, { file: dmFile })
+  }
+  await generateIndex(tree)
+}
+
+export default generateAllDeobfTemplateGenerator

--- a/libs/zzz/dm/src/generators/generate-index-deobf.ts
+++ b/libs/zzz/dm/src/generators/generate-index-deobf.ts
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'fs'
+import * as path from 'path'
+import { formatText } from '@genshin-optimizer/common/pipeline'
+import type { Tree } from '@nx/devkit'
+import { allFileCfgs } from '../consts'
+
+export default async function generateIndex(tree: Tree) {
+  const file_location = `libs/zzz/dm/src/dm/deobf/FileCfg`
+  const dest = path.join(tree.root, file_location, `index.ts`)
+  const contents = `// WARNING: Generated file, do not modify
+${allFileCfgs.map((cfg) => `import ${cfg} from './${cfg}'`).join('\n')}
+
+export const deobfMappings = {
+  ${allFileCfgs.join('\n,  ')}
+}
+`
+  const formatted = await formatText(dest, contents)
+  writeFileSync(dest, formatted)
+}

--- a/libs/zzz/dm/src/generators/generate-single-deobf-template.spec.ts
+++ b/libs/zzz/dm/src/generators/generate-single-deobf-template.spec.ts
@@ -1,0 +1,21 @@
+import type { Tree } from '@nx/devkit'
+import { readProjectConfiguration } from '@nx/devkit'
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+
+import { generateSingleDeobfTemplateGenerator } from './generate-single-deobf-template'
+import type { GenerateSingleDeobfTemplateGeneratorSchema } from './schema'
+
+describe('generate-single-deobf-template generator', () => {
+  let tree: Tree
+  const options: GenerateSingleDeobfTemplateGeneratorSchema = { file: 'test' }
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace()
+  })
+
+  it('should run successfully', async () => {
+    await generateSingleDeobfTemplateGenerator(tree, options)
+    const config = readProjectConfiguration(tree, 'test')
+    expect(config).toBeDefined()
+  })
+})

--- a/libs/zzz/dm/src/generators/generate-single-deobf-template.ts
+++ b/libs/zzz/dm/src/generators/generate-single-deobf-template.ts
@@ -1,0 +1,90 @@
+import { existsSync, writeFileSync } from 'fs'
+import * as path from 'path'
+import { formatText } from '@genshin-optimizer/common/pipeline'
+import type { Tree } from '@nx/devkit'
+import type { GenericDmFile } from '../dm/deobf/types'
+import { readDMJSON } from '../util'
+import type { GenerateSingleDeobfTemplateGeneratorSchema } from './schema'
+
+export async function generateSingleDeobfTemplateGenerator(
+  tree: Tree,
+  { file }: GenerateSingleDeobfTemplateGeneratorSchema,
+  verbose = false
+) {
+  const file_location = `libs/zzz/dm/src/dm/deobf/FileCfg`
+  const dest = path.join(tree.root, file_location, `${file}.ts`)
+  const lowerFile = `${file[0].toLowerCase()}${file.slice(1)}`
+  const dmFile = JSON.parse(
+    readDMJSON(`FileCfg/${file}.json`, tree.root)
+  ) as GenericDmFile
+  const objToUse = getObjToUse(file)
+  const dmObj = Object.values(dmFile)[0][objToUse]
+  const reverseMapping: Record<string | number, string> = {}
+  const keyValueSet: Record<string, Set<string | number>> = {}
+
+  Object.entries(dmObj).forEach(([k, v]) => {
+    const stringified = JSON.stringify(v)
+    keyValueSet[k] = new Set<string | number>()
+    Object.values(dmFile)[0].forEach((o) =>
+      keyValueSet[k].add(JSON.stringify(o[k]))
+    )
+    if (reverseMapping[stringified]) {
+      console.log(
+        `Duplicate reverse mapping key for property ${k} with value ${stringified} in ${file}`
+      )
+      if (
+        Object.values(dmFile)[0].every(
+          (obj) => JSON.stringify(obj[k]) === stringified
+        )
+      ) {
+        console.log(
+          `Note: Property ${k} is the same value ${stringified} across all objects`
+        )
+        reverseMapping[stringified] += `-${k}Identical`
+      } else {
+        reverseMapping[stringified] += `-${k}`
+      }
+    } else {
+      reverseMapping[stringified] = `todo-${k}`
+    }
+  })
+
+  // Debug log to help with identifying if a parameter is actually important or just duplicated nonsense
+  console.log(`PropValue mappings for ${file}`)
+  console.log(keyValueSet)
+  if (existsSync(dest)) {
+    verbose && console.warn(`Template at ${dest} already exists.`)
+    return
+  }
+
+  const contents = `
+import { readDMJSON } from '../../../util'
+import type { GenericDmFile } from '../types'
+import { generateMapping, generateTyping } from '../util'
+
+const reverseMapping = ${JSON.stringify(reverseMapping)}
+
+const ${lowerFile} = JSON.parse(
+  readDMJSON('FileCfg/${file}.json')
+) as GenericDmFile
+
+const dmObj = Object.values(${lowerFile})[0][${objToUse}]
+
+const mapping = generateMapping(reverseMapping, dmObj)
+const typing = generateTyping(reverseMapping, dmObj)
+
+export default {
+  mapping,
+  typing,
+}
+  `
+  const formatted = await formatText(dest, contents)
+  writeFileSync(dest, formatted)
+}
+
+function getObjToUse(file: string) {
+  if (file === 'ItemTemplateTb') return 4
+  else return 0
+}
+
+export default generateSingleDeobfTemplateGenerator

--- a/libs/zzz/dm/src/generators/schema.d.ts
+++ b/libs/zzz/dm/src/generators/schema.d.ts
@@ -1,0 +1,3 @@
+export interface GenerateSingleDeobfTemplateGeneratorSchema {
+  file: string
+}

--- a/libs/zzz/dm/src/generators/single-schema.json
+++ b/libs/zzz/dm/src/generators/single-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "GenerateSingleDeobfTemplate",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "file": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What file should a base deobf template be created for?"
+    }
+  },
+  "required": ["file"]
+}

--- a/libs/zzz/dm/src/util.ts
+++ b/libs/zzz/dm/src/util.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from 'fs'
 import { DM_PATH, HAKUSHIN_PATH } from './consts'
 
-export function readDMJSON(path: string) {
-  const fullPath = `${DM_PATH}/${path}`
+export function readDMJSON(path: string, root?: string) {
+  const fullPath = `${root ? `${root}/libs/zzz/dm/ZenlessData` : DM_PATH}/${path}`
   if (!existsSync(fullPath)) throw `File not found :${fullPath}`
   return readFileSync(fullPath).toString()
 }


### PR DESCRIPTION
## Describe your changes

Add 2 pipelines that help in mapping known DM properties to human-readable names

There is still additional work that needs to be done for proper support in the code, such as:
* Generating typing
* Ensuring all properties we want are available (we are probably missing a lot and need to reverse search to find them and how to connect them)
* other stuff probably

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zenless Zone Zero datamine updates alongside existing games
  * Introduced deobfuscation mapping generation for game data

* **Documentation**
  * Updated datamine process to cover multi-game support
  * Marked deprecated data source as no longer operational; added new deobfuscation workflow guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->