### PR TITLE
Improve performance of the optimize page UI

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BuildAlert.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/Components/BuildAlert.tsx
@@ -1,6 +1,6 @@
 import { timeStringMs } from '@genshin-optimizer/common/util'
 import { Alert, Grid, LinearProgress, Typography, styled } from '@mui/material'
-import type { ReactNode } from 'react'
+import { type ReactNode, useSyncExternalStore } from 'react'
 
 export const warningBuildNumber = 10000000
 export type BuildStatus = {
@@ -13,6 +13,8 @@ export type BuildStatus = {
   skippedPerSecond: number // number of configs skipped in the last second (none are tested)
   startTime?: number
   finishTime?: number
+  changed: boolean
+  cb?: () => void
 }
 
 const Monospace = styled('strong')({
@@ -23,23 +25,42 @@ const BorderLinearProgress = styled(LinearProgress)(() => ({
   height: 10,
   borderRadius: 5,
 }))
+
+function useBuildStatus(buildStatus: BuildStatus): BuildStatus {
+  let last = { ...buildStatus }
+  return useSyncExternalStore(
+    (cb) => {
+      buildStatus.cb = cb
+      return () => {}
+    },
+    () => {
+      if (buildStatus.changed) {
+        buildStatus.changed = false
+        last = { ...buildStatus }
+      }
+      return last
+    }
+  )
+}
+
 export default function BuildAlert({
-  status: {
+  buildStatus,
+  characterName,
+}: {
+  buildStatus: BuildStatus
+  characterName: ReactNode
+}) {
+  const status = useBuildStatus(buildStatus)
+  const {
     type,
     tested,
-    failed: _,
     skipped,
     total,
     testedPerSecond,
     skippedPerSecond,
     startTime,
     finishTime,
-  },
-  characterName,
-}: {
-  status: BuildStatus
-  characterName: ReactNode
-}) {
+  } = status
   const hasTotal = isFinite(total)
 
   const generatingBuilds = type !== 'inactive'

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -132,6 +132,7 @@ function initBuildStatus(): BuildStatus {
     total: 0,
     testedPerSecond: 0,
     skippedPerSecond: 0,
+    changed: false,
   }
 }
 const audio = new Audio('assets/notification.mp3')
@@ -368,7 +369,8 @@ export default function TabBuild() {
       topN: maxBuildsToShow,
       plotBase: plotBaseNode,
     }
-    const status = {
+    const status: BuildStatus = {
+      type: 'active',
       tested: 0,
       failed: 0,
       skipped: 0,
@@ -376,12 +378,12 @@ export default function TabBuild() {
       testedPerSecond: 0,
       skippedPerSecond: 0,
       startTime: performance.now(),
-      needUpdate: false,
+      changed: false,
     }
+    setBuildStatus(status)
     const statusUpdateTimer = setInterval(() => {
-      if (status.needUpdate) {
-        status.needUpdate = false
-        setBuildStatus({ type: 'active', ...status })
+      if (status.changed) {
+        status.cb?.()
       }
     }, 100)
 
@@ -476,8 +478,8 @@ export default function TabBuild() {
     } finally {
       clearInterval(statusUpdateTimer)
       setBuildStatus({
-        type: 'inactive',
         ...status,
+        type: 'inactive',
         finishTime: performance.now(),
       })
     }
@@ -764,7 +766,7 @@ export default function TabBuild() {
       </ButtonGroup>
       <ScalesWith />
       {!!characterKey && (
-        <BuildAlert {...{ status: buildStatus, characterName }} />
+        <BuildAlert buildStatus={buildStatus} characterName={characterName} />
       )}
       {optimizationTarget && (
         <Box>

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabOptimize/index.tsx
@@ -206,7 +206,7 @@ export default function TabBuild() {
         return false
       if (art.level < levelLow) return false
       if (art.level > levelHigh) return false
-      const mainStats = mainStatKeys[art.slotKey]
+      const mainStats = mainStatKeys[art.slotKey as keyof typeof mainStatKeys]
       if (mainStats?.length && !mainStats.includes(art.mainStatKey))
         return false
 
@@ -368,7 +368,7 @@ export default function TabBuild() {
       topN: maxBuildsToShow,
       plotBase: plotBaseNode,
     }
-    const status: Omit<BuildStatus, 'type'> = {
+    const status = {
       tested: 0,
       failed: 0,
       skipped: 0,
@@ -376,11 +376,14 @@ export default function TabBuild() {
       testedPerSecond: 0,
       skippedPerSecond: 0,
       startTime: performance.now(),
+      needUpdate: false,
     }
-    const statusUpdateTimer = setInterval(
-      () => setBuildStatus({ type: 'active', ...status }),
-      100
-    )
+    const statusUpdateTimer = setInterval(() => {
+      if (status.needUpdate) {
+        status.needUpdate = false
+        setBuildStatus({ type: 'active', ...status })
+      }
+    }, 100)
 
     const cancellationError = new Error()
     try {
@@ -761,9 +764,7 @@ export default function TabBuild() {
       </ButtonGroup>
       <ScalesWith />
       {!!characterKey && (
-        <BuildAlert
-          {...{ status: buildStatus, characterName, maxBuildsToShow }}
-        />
+        <BuildAlert {...{ status: buildStatus, characterName }} />
       )}
       {optimizationTarget && (
         <Box>

--- a/libs/gi/solver/src/GOSolver/GOSolver.ts
+++ b/libs/gi/solver/src/GOSolver/GOSolver.ts
@@ -21,7 +21,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
     | 'testedPerSecond'
     | 'skippedPerSecond',
     number
-  >
+  > & { needUpdate: boolean }
   private exclusion: Count['exclusion']
   private topN: number
   private buildValues: { w: Worker; val: number }[]
@@ -151,6 +151,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
         lastTime = currentTime
         lastTested = this.status.tested
         lastSkipped = this.status.skipped
+        this.status.needUpdate = true
       }, 1000)
     } catch (e) {
       cleanup()
@@ -166,6 +167,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
     this.status.tested += r.tested
     this.status.failed += r.failed
     this.status.skipped += r.skipped
+    this.status.needUpdate = true
 
     if (r.buildValues) {
       const { topN } = this,

--- a/libs/gi/solver/src/GOSolver/GOSolver.ts
+++ b/libs/gi/solver/src/GOSolver/GOSolver.ts
@@ -21,7 +21,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
     | 'testedPerSecond'
     | 'skippedPerSecond',
     number
-  > & { needUpdate: boolean }
+  > & { changed: boolean }
   private exclusion: Count['exclusion']
   private topN: number
   private buildValues: { w: Worker; val: number }[]
@@ -74,9 +74,11 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
 
     // Cleanup function from the BPS tracker
     const stopTracking = this.trackBuildsPerSecond()
-
-    await this.execute([{ command: 'count', exclusion, maxIterateSize }])
-    stopTracking()
+    try {
+      await this.execute([{ command: 'count', exclusion, maxIterateSize }])
+    } finally {
+      stopTracking()
+    }
     this.notifiedBroadcast({ command: 'finalize' })
     await this.execute([])
     return this.finalizedResults
@@ -151,7 +153,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
         lastTime = currentTime
         lastTested = this.status.tested
         lastSkipped = this.status.skipped
-        this.status.needUpdate = true
+        this.status.changed = true
       }, 1000)
     } catch (e) {
       cleanup()
@@ -167,7 +169,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
     this.status.tested += r.tested
     this.status.failed += r.failed
     this.status.skipped += r.skipped
-    this.status.needUpdate = true
+    this.status.changed = true
 
     if (r.buildValues) {
       const { topN } = this,


### PR DESCRIPTION
## Describe your changes

Previously, workers would occasionally be forced to wait of the main thread to finish rendering an update.

<img width="122" height="69" alt="image" src="https://github.com/user-attachments/assets/26b968db-f977-4db1-b6ba-696d1efac955" />
(Bottom bumps are a worker doing work, and the top is main thread)

Now updates are targeted to only rerender the `BuildAlert` and only update when the `status` has changed.
<img width="152" height="58" alt="image" src="https://github.com/user-attachments/assets/e090e972-9437-4f39-919d-06e34699cb91" />


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Build status tracking mechanism optimized for improved efficiency.
  * Exception safety enhanced in build tracking cleanup operations.

* **Bug Fixes**
  * Type safety improvements in artifact filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->