### PR TITLE
GO: add progmatic defaults for char/weapons

### DIFF
--- a/libs/gi/consts/src/common.ts
+++ b/libs/gi/consts/src/common.ts
@@ -10,6 +10,12 @@ export type AscensionKey = (typeof allAscensionKeys)[number]
 export const ascensionMaxLevelLow = [20, 40, 50, 60, 70] as const
 export const maxLevelLow = 70
 export const maxLevel = 90
+export const defaultCharacterLevel = maxLevel
+export const defaultCharacterAscension: AscensionKey = 6
+export const defaultTalentLevel = 9
+export const defaultWeaponLevel = maxLevel
+export const defaultWeaponAscension: AscensionKey = 6
+export const defaultOptArtifactLevel = 20
 export const ascensionMaxLevel = [...ascensionMaxLevelLow, 80, 90] as const
 export const milestoneLevelsLow = [
   [70, 4],

--- a/libs/gi/consts/src/weapon.ts
+++ b/libs/gi/consts/src/weapon.ts
@@ -1,3 +1,4 @@
+import { clamp } from '@genshin-optimizer/common/util'
 import { type AscensionKey, type RarityKey, validateLevelAsc } from './common'
 
 export const allWeaponTypeKeys = [
@@ -307,12 +308,14 @@ export const allWeaponSubstatKeys = [
 ] as const
 export type WeaponSubstatKey = (typeof allWeaponSubstatKeys)[number]
 
-// Weapon global max level constant
-const weaponGlobalMaxLevel = 90
-
 export function validateWeaponLevelAsc(
   level: number,
-  ascension: AscensionKey
+  ascension: AscensionKey,
+  rarity: RarityKey
 ): { level: number; ascension: AscensionKey } {
-  return validateLevelAsc(level, ascension, weaponGlobalMaxLevel)
+  const maxLvl = weaponMaxLevel[rarity]
+  const maxAsc = weaponMaxAscension[rarity]
+  const clampedLevel = clamp(level, 1, maxLvl)
+  const clampedAscension = clamp(ascension, 0, maxAsc) as AscensionKey
+  return validateLevelAsc(clampedLevel, clampedAscension, maxLvl)
 }

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.test.ts
@@ -1,0 +1,56 @@
+import { createTestDBStorage } from '@genshin-optimizer/common/database'
+import {
+  defaultCharacterAscension,
+  defaultCharacterLevel,
+  defaultTalentLevel,
+  defaultWeaponAscension,
+  defaultWeaponLevel,
+  weaponMaxAscension,
+  weaponMaxLevel,
+} from '@genshin-optimizer/gi/consts'
+import { allStats } from '@genshin-optimizer/gi/stats'
+import { ArtCharDatabase } from '../ArtCharDatabase'
+import { initCharTC } from './BuildTcDataManager'
+
+describe('BuildTcDataManager', () => {
+  let database: ArtCharDatabase
+  let buildTcs: ArtCharDatabase['buildTcs']
+
+  beforeEach(() => {
+    const dbStorage = createTestDBStorage('go')
+    database = new ArtCharDatabase(1, dbStorage)
+    buildTcs = database.buildTcs
+  })
+
+  it('should clamp Build(TC) weapon level/ascension by rarity', () => {
+    const base = initCharTC('DullBlade')
+    const result = buildTcs['validate']({
+      ...base,
+      weapon: {
+        ...base.weapon,
+        level: defaultWeaponLevel,
+        ascension: defaultWeaponAscension,
+      },
+    })
+
+    const rarity = allStats.weapon.data.DullBlade.rarity
+    expect(result?.weapon.level).toBe(weaponMaxLevel[rarity])
+    expect(result?.weapon.ascension).toBe(weaponMaxAscension[rarity])
+  })
+
+  it('should default Build(TC) character to optimizer-friendly values', () => {
+    const base = initCharTC('DullBlade')
+    const result = buildTcs['validate']({
+      ...base,
+      character: {},
+    })
+
+    expect(result?.character?.level).toBe(defaultCharacterLevel)
+    expect(result?.character?.ascension).toBe(defaultCharacterAscension)
+    expect(result?.character?.talent).toEqual({
+      auto: defaultTalentLevel,
+      skill: defaultTalentLevel,
+      burst: defaultTalentLevel,
+    })
+  })
+})

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -136,16 +136,18 @@ const buildTcWeaponSchema = z.object({
     1
   ) as z.ZodType<RefinementKey>,
 })
-const buildTcWeaponSchemaWithTransform = buildTcWeaponSchema.transform((data) => {
-  const rarity = allStats.weapon.data[data.key]?.rarity
-  if (!rarity) throw new Error('Invalid weapon key')
-  const { level, ascension } = validateWeaponLevelAsc(
-    data.level,
-    data.ascension,
-    rarity
-  )
-  return { ...data, level, ascension }
-})
+const buildTcWeaponSchemaWithTransform = buildTcWeaponSchema.transform(
+  (data) => {
+    const rarity = allStats.weapon.data[data.key]?.rarity
+    if (!rarity) throw new Error('Invalid weapon key')
+    const { level, ascension } = validateWeaponLevelAsc(
+      data.level,
+      data.ascension,
+      rarity
+    )
+    return { ...data, level, ascension }
+  }
+)
 
 const defaultMaxSubstats = () =>
   objKeyMap(

--- a/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/BuildTcDataManager.ts
@@ -26,9 +26,16 @@ import {
   allRefinementKeys,
   allSubstatKeys,
   allWeaponKeys,
+  defaultCharacterAscension,
+  defaultCharacterLevel,
+  defaultTalentLevel,
+  defaultWeaponAscension,
+  defaultWeaponLevel,
   substatTypeKeys,
+  validateWeaponLevelAsc,
 } from '@genshin-optimizer/gi/consts'
 import type { IGOOD } from '@genshin-optimizer/gi/good'
+import { allStats } from '@genshin-optimizer/gi/stats'
 import { z } from 'zod'
 import type { ArtCharDatabase } from '../ArtCharDatabase'
 import { DataManager } from '../DataManager'
@@ -96,38 +103,48 @@ const buildTcArtifactSchema = z.object({
 })
 
 const talentSchema = z.object({
-  auto: zodClampedNumber(1, 15, 1),
-  skill: zodClampedNumber(1, 15, 1),
-  burst: zodClampedNumber(1, 15, 1),
+  auto: zodClampedNumber(1, 15, defaultTalentLevel),
+  skill: zodClampedNumber(1, 15, defaultTalentLevel),
+  burst: zodClampedNumber(1, 15, defaultTalentLevel),
 })
 
 const buildTcCharacterSchema = z
   .object({
-    level: zodClampedNumber(1, 90, 1),
+    level: zodClampedNumber(1, 90, defaultCharacterLevel),
     ascension: zodNumericLiteralWithDefault(
       allAscensionKeys,
-      0
+      defaultCharacterAscension
     ) as z.ZodType<AscensionKey>,
     constellation: zodClampedNumber(0, 6, 0),
     talent: zodObject(talentSchema.shape).catch({
-      auto: 1,
-      skill: 1,
-      burst: 1,
+      auto: defaultTalentLevel,
+      skill: defaultTalentLevel,
+      burst: defaultTalentLevel,
     }),
   })
   .optional()
 
 const buildTcWeaponSchema = z.object({
   key: zodEnum(allWeaponKeys),
-  level: zodClampedNumber(1, 90, 1),
+  level: zodClampedNumber(1, 90, defaultWeaponLevel),
   ascension: zodNumericLiteralWithDefault(
     allAscensionKeys,
-    0
+    defaultWeaponAscension
   ) as z.ZodType<AscensionKey>,
   refinement: zodNumericLiteralWithDefault(
     allRefinementKeys,
     1
   ) as z.ZodType<RefinementKey>,
+})
+const buildTcWeaponSchemaWithTransform = buildTcWeaponSchema.transform((data) => {
+  const rarity = allStats.weapon.data[data.key]?.rarity
+  if (!rarity) throw new Error('Invalid weapon key')
+  const { level, ascension } = validateWeaponLevelAsc(
+    data.level,
+    data.ascension,
+    rarity
+  )
+  return { ...data, level, ascension }
 })
 
 const defaultMaxSubstats = () =>
@@ -145,7 +162,7 @@ const buildTcSchema = z.object({
   name: zodString('Build(TC) Name'),
   description: zodString(),
   character: buildTcCharacterSchema,
-  weapon: buildTcWeaponSchema,
+  weapon: buildTcWeaponSchemaWithTransform,
   artifact: zodObject(buildTcArtifactSchema.shape).catch({
     slots: objKeyMap(allArtifactSlotKeys, defaultSlot),
     substats: {
@@ -242,8 +259,8 @@ export function initCharTC(weaponKey: WeaponKey): BuildTc {
     description: '',
     weapon: {
       key: weaponKey,
-      level: 1,
-      ascension: 0,
+      level: defaultWeaponLevel,
+      ascension: defaultWeaponAscension,
       refinement: 1,
     },
     artifact: {

--- a/libs/gi/db/src/Database/DataManagers/CharacterDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/CharacterDataManager.test.ts
@@ -1,5 +1,13 @@
 import { createTestDBStorage } from '@genshin-optimizer/common/database'
-import { allCharacterKeys, talentLimits } from '@genshin-optimizer/gi/consts'
+import {
+  allCharacterKeys,
+  defaultCharacterAscension,
+  defaultCharacterLevel,
+  talentLimits,
+  weaponMaxAscension,
+  weaponMaxLevel,
+} from '@genshin-optimizer/gi/consts'
+import { allStats } from '@genshin-optimizer/gi/stats'
 import { ArtCharDatabase } from '../ArtCharDatabase'
 
 describe('CharacterDataManager', () => {
@@ -26,5 +34,17 @@ describe('CharacterDataManager', () => {
     expect(result?.talent.auto).toBe(maxTalent)
     expect(result?.talent.skill).toBe(maxTalent)
     expect(result?.talent.burst).toBe(maxTalent)
+  })
+
+  it('getWithInitWeapon should create starter weapon clamped by rarity max', () => {
+    const char = chars.getWithInitWeapon('Amber')
+    expect(char.level).toBe(defaultCharacterLevel)
+    expect(char.ascension).toBe(defaultCharacterAscension)
+
+    const weapon = database.weapons.get(char.equippedWeapon)
+    expect(weapon).toBeDefined()
+    const rarity = allStats.weapon.data[weapon!.key].rarity
+    expect(weapon!.level).toBe(weaponMaxLevel[rarity])
+    expect(weapon!.ascension).toBe(weaponMaxAscension[rarity])
   })
 })

--- a/libs/gi/db/src/Database/DataManagers/CharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/CharacterDataManager.ts
@@ -10,6 +10,9 @@ import {
   allArtifactSlotKeys,
   allTravelerKeys,
   charKeyToLocCharKey,
+  defaultCharacterAscension,
+  defaultCharacterLevel,
+  defaultTalentLevel,
 } from '@genshin-optimizer/gi/consts'
 import type { ICharacter, IGOOD } from '@genshin-optimizer/gi/good'
 import { parseCharacter } from '@genshin-optimizer/gi/good'
@@ -221,14 +224,14 @@ export class CharacterDataManager extends DataManager<
 export function initialCharacter(key: CharacterKey): ICachedCharacter {
   return {
     key,
-    level: 1,
-    ascension: 0,
+    level: defaultCharacterLevel,
+    ascension: defaultCharacterAscension,
     equippedArtifacts: objKeyMap(allArtifactSlotKeys, () => ''),
     equippedWeapon: '',
     talent: {
-      auto: 1,
-      skill: 1,
-      burst: 1,
+      auto: defaultTalentLevel,
+      skill: defaultTalentLevel,
+      burst: defaultTalentLevel,
     },
     constellation: 0,
   }

--- a/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.test.ts
@@ -1,4 +1,5 @@
 import { createTestDBStorage } from '@genshin-optimizer/common/database'
+import { defaultOptArtifactLevel } from '@genshin-optimizer/gi/consts'
 import { ArtCharDatabase } from '../ArtCharDatabase'
 
 describe('OptConfigDataManager', () => {
@@ -19,6 +20,13 @@ describe('OptConfigDataManager', () => {
     }
     const result = optConfigs['validate'](invalid, id)
     expect(result?.generatedBuildListId).toBeUndefined()
+  })
+
+  it('should default optimization level range to max artifacts only', () => {
+    const id = optConfigs.new()
+    const cfg = optConfigs.get(id)
+    expect(cfg?.levelLow).toBe(defaultOptArtifactLevel)
+    expect(cfg?.levelHigh).toBe(defaultOptArtifactLevel)
   })
 
   it('should keep valid generatedBuildListId', () => {

--- a/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/OptConfigDataManager.ts
@@ -10,6 +10,7 @@ import {
   allArtifactSetKeys,
   allLocationCharacterKeys,
   artSlotMainKeys,
+  defaultOptArtifactLevel,
 } from '@genshin-optimizer/gi/consts'
 import { z } from 'zod'
 import type { ArtCharDatabase } from '../ArtCharDatabase'
@@ -108,8 +109,8 @@ const optConfigSchema = z.object({
   ),
   plotBase: z.array(z.string()).optional().catch(undefined),
   compareBuild: zodBoolean(true),
-  levelLow: zodClampedNumber(0, 20, 0),
-  levelHigh: zodClampedNumber(0, 20, 20),
+  levelLow: zodClampedNumber(0, 20, defaultOptArtifactLevel),
+  levelHigh: zodClampedNumber(0, 20, defaultOptArtifactLevel),
   useTeammateBuild: zodBoolean(),
   generatedBuildListId: z.string().optional().catch(undefined),
   upOptLevelLow: zodClampedNumber(0, 20, 0),

--- a/libs/gi/db/src/Database/DataManagers/WeaponDataManager.test.ts
+++ b/libs/gi/db/src/Database/DataManagers/WeaponDataManager.test.ts
@@ -1,6 +1,5 @@
 import { createTestDBStorage } from '@genshin-optimizer/common/database'
-import { allWeaponKeys, weaponMaxLevel } from '@genshin-optimizer/gi/consts'
-import { allStats } from '@genshin-optimizer/gi/stats'
+import type { WeaponKey } from '@genshin-optimizer/gi/consts'
 import { ArtCharDatabase } from '../ArtCharDatabase'
 
 describe('WeaponDataManager', () => {
@@ -13,18 +12,23 @@ describe('WeaponDataManager', () => {
     weapons = database.weapons
   })
 
-  it('should reject level exceeding rarity max', () => {
-    const weaponKey = allWeaponKeys[0]
-    const { rarity } = allStats.weapon.data[weaponKey]
-    const maxLevel = weaponMaxLevel[rarity]
-    const invalid = {
-      key: weaponKey,
-      level: maxLevel + 1,
-      ascension: 3,
-      refinement: 1,
+  it('should clamp 1★ weapons to 70/4 and keep 5★ at 90/6', () => {
+    const weaponInput = (key: WeaponKey) => ({
+      key,
+      level: 90,
+      ascension: 6 as const,
+      refinement: 1 as const,
       location: '',
       lock: false,
-    }
-    expect(weapons['validate'](invalid)).toBeUndefined()
+    })
+
+    expect(weapons['validate'](weaponInput('DullBlade'))).toMatchObject({
+      level: 70,
+      ascension: 4,
+    })
+    expect(weapons['validate'](weaponInput('Deathmatch'))).toMatchObject({
+      level: 90,
+      ascension: 6,
+    })
   })
 })

--- a/libs/gi/db/src/Database/DataManagers/WeaponDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/WeaponDataManager.ts
@@ -4,7 +4,11 @@ import type {
   WeaponKey,
   WeaponTypeKey,
 } from '@genshin-optimizer/gi/consts'
-import { charKeyToLocCharKey } from '@genshin-optimizer/gi/consts'
+import {
+  charKeyToLocCharKey,
+  defaultWeaponAscension,
+  defaultWeaponLevel,
+} from '@genshin-optimizer/gi/consts'
 import type { IGOOD, IWeapon } from '@genshin-optimizer/gi/good'
 import { parseWeapon } from '@genshin-optimizer/gi/good'
 import { allStats } from '@genshin-optimizer/gi/stats'
@@ -295,8 +299,8 @@ export const defaultInitialWeapon = (
 export const initialWeapon = (key: WeaponKey): ICachedWeapon => ({
   id: '',
   key,
-  level: 1,
-  ascension: 0,
+  level: defaultWeaponLevel,
+  ascension: defaultWeaponAscension,
   refinement: 1,
   location: '',
   lock: false,

--- a/libs/gi/db/src/Database/Database.test.ts
+++ b/libs/gi/db/src/Database/Database.test.ts
@@ -311,8 +311,11 @@ describe('Database', () => {
   test('should merge scanner with dups for weapons', () => {
     const a1 = initialWeapon('Akuoumaru')
     const a2old = initialWeapon('BlackTassel')
+    a2old.level = 1
+    a2old.ascension = 0
     const a2new = initialWeapon('BlackTassel')
     a2new.level = 20
+    a2new.ascension = 0
     const a3 = initialWeapon('CalamityQueller') // in db but not in import
     const a4 = initialWeapon('Deathmatch') // in import but not in db
 

--- a/libs/gi/schema/src/weapon/schema.ts
+++ b/libs/gi/schema/src/weapon/schema.ts
@@ -1,6 +1,7 @@
 import {
   zodBoolean,
   zodBoundedNumber,
+  zodClampedNumber,
   zodEnum,
   zodEnumWithDefault,
 } from '@genshin-optimizer/common/database'
@@ -11,7 +12,6 @@ import {
   allLocationCharacterKeys,
   allWeaponKeys,
   validateWeaponLevelAsc,
-  weaponMaxLevel,
 } from '@genshin-optimizer/gi/consts'
 import { allStats } from '@genshin-optimizer/gi/stats'
 import { z } from 'zod'
@@ -19,8 +19,8 @@ import { z } from 'zod'
 const weaponBaseSchema = z
   .object({
     key: zodEnum(allWeaponKeys),
-    level: zodBoundedNumber(1, 90, 1),
-    ascension: zodBoundedNumber(0, 6, 0) as z.ZodType<AscensionKey>,
+    level: zodClampedNumber(1, 90, 1),
+    ascension: zodClampedNumber(0, 6, 0) as z.ZodType<AscensionKey>,
     refinement: zodBoundedNumber(1, 5, 1) as z.ZodType<RefinementKey>,
     location: zodEnumWithDefault(
       [...allLocationCharacterKeys, ''] as const,
@@ -30,27 +30,10 @@ const weaponBaseSchema = z
   })
   .passthrough()
 
-export const weaponSchema = z
-  .preprocess(
-    (obj) => ({
-      ...(typeof obj === 'object' && obj !== null ? obj : {}),
-      _rawLevel: (obj as { level?: unknown })?.level,
-    }),
-    weaponBaseSchema
-  )
+export const weaponSchema = weaponBaseSchema
   .refine((data) => !!allStats.weapon.data[data.key], {
     message: 'Invalid weapon key',
   })
-  .refine(
-    (data) => {
-      const weaponData = allStats.weapon.data[data.key]
-      if (!weaponData) return false
-      const rawLevel = (data as { _rawLevel?: unknown })._rawLevel
-      if (typeof rawLevel !== 'number') return true
-      return rawLevel <= weaponMaxLevel[weaponData.rarity]
-    },
-    { message: 'Level exceeds max for weapon rarity' }
-  )
   .refine(
     (data) => {
       if (!data.location) return true
@@ -63,9 +46,12 @@ export const weaponSchema = z
     { message: 'Weapon type does not match character' }
   )
   .transform((data) => {
+    const rarity = allStats.weapon.data[data.key]?.rarity
+    if (!rarity) throw new Error('Invalid weapon key')
     const { level, ascension } = validateWeaponLevelAsc(
       data.level,
-      data.ascension
+      data.ascension,
+      rarity
     )
 
     return {

--- a/libs/gi/util/src/weapon/randomizeWeapon.ts
+++ b/libs/gi/util/src/weapon/randomizeWeapon.ts
@@ -9,6 +9,7 @@ import {
   validateWeaponLevelAsc,
 } from '@genshin-optimizer/gi/consts'
 import type { IWeapon } from '@genshin-optimizer/gi/schema'
+import { allStats } from '@genshin-optimizer/gi/stats'
 
 const weaponKeys = allWeaponKeys.filter(
   (k) =>
@@ -28,7 +29,11 @@ const weaponKeys = allWeaponKeys.filter(
 export function randomizeWeapon(base: Partial<IWeapon> = {}): IWeapon {
   const key = base.key ?? getRandomElementFromArray(weaponKeys)
   const level = base.level ?? getRandomIntInclusive(1, 90)
-  const { ascension } = validateWeaponLevelAsc(level, base.ascension ?? 0)
+  const { ascension } = validateWeaponLevelAsc(
+    level,
+    base.ascension ?? 0,
+    allStats.weapon.data[key].rarity
+  )
   const refinement =
     base.refinement ?? (getRandomIntInclusive(1, 5) as RefinementKey)
   const lock = base.lock ?? getRandBool()


### PR DESCRIPTION
## Describe your changes

Default to 90/90 T9/9/9 for character and weapons etc

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Weapon level and ascension inputs are now clamped to rarity-specific maximums so invalid levels are auto-corrected.

* **Refactor**
  * Introduced shared default progression values for characters, talents, weapons, and optimization artifacts so new characters/weapons and optimizer configs initialize to consistent, optimizer-friendly defaults.

* **Tests**
  * Added/updated tests to verify clamping and default-initialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frzyc/genshin-optimizer/pull/3221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->