### PR TITLE
Fix Linnea C6 scaling

### DIFF
--- a/libs/gi/sheets/src/Characters/Linnea/index.tsx
+++ b/libs/gi/sheets/src/Characters/Linnea/index.tsx
@@ -168,8 +168,9 @@ const c1TeamStacks_lunarcrystallize_dmgInc = greaterEq(
         input.constellation,
         6,
         percent(
-          dm.constellation6.lunarcrystallize_dmgInc +
-            dm.constellation1.lunarcrystallize_dmgInc
+          dm.constellation6.stacksConsumed *
+            dm.constellation6.lunarcrystallize_dmgInc *
+              dm.constellation1.lunarcrystallize_dmgInc
         ),
         percent(dm.constellation1.lunarcrystallize_dmgInc)
       ),
@@ -196,7 +197,19 @@ const c1LumiStacks = lookup(
 const c1LumiStacks_lunarcrystallize_dmgInc = greaterEq(
   input.constellation,
   1,
-  prod(c1LumiStacks, percent(dm.constellation1.lumi_dmgInc), input.total.def)
+  prod(
+    c1LumiStacks,
+    threshold(
+      input.constellation,
+      6,
+      percent(
+        dm.constellation6.lunarcrystallize_dmgInc *
+          dm.constellation1.lumi_dmgInc
+      ),
+      percent(dm.constellation1.lumi_dmgInc)
+    ),
+    input.total.def
+  )
 )
 
 const [condC2MoondriftPath, condC2Moondrift] = cond(key, 'c2Moondrift')

--- a/libs/gi/sheets/src/Characters/Linnea/index.tsx
+++ b/libs/gi/sheets/src/Characters/Linnea/index.tsx
@@ -170,7 +170,7 @@ const c1TeamStacks_lunarcrystallize_dmgInc = greaterEq(
         percent(
           dm.constellation6.stacksConsumed *
             dm.constellation6.lunarcrystallize_dmgInc *
-              dm.constellation1.lunarcrystallize_dmgInc
+            dm.constellation1.lunarcrystallize_dmgInc
         ),
         percent(dm.constellation1.lunarcrystallize_dmgInc)
       ),


### PR DESCRIPTION
## Describe your changes

<!--- Provide a general summary of your changes -->

## Issue or discord link

- Fix https://github.com/frzyc/genshin-optimizer/issues/3201

## Testing/validation

https://i.imgur.com/AA0GRbw.png

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Adjustments**
  * Updated Linnea’s lunar crystallization damage scaling to better coordinate Const. 1 and Const. 6 stack/threshold behavior, refining the resulting damage increments based on the active constellation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->