### PR TITLE
ZO: Migrate old charOpt to team key

### DIFF
--- a/libs/game-opt/sheet-ui/src/components/FieldDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/FieldDisplay.tsx
@@ -156,7 +156,7 @@ export function TagFieldDisplay({
   if (!showZero && !calcValue && !compareCalcValue) return null
 
   let fieldVal = false as ReactNode
-  const unit = getUnitStr(fieldRead.tag['name'] || fieldRead.tag['q'] || '')
+  const unit = getUnitStr(fieldRead.tag['q'] || fieldRead.tag['name'] || '')
 
   const diff = calcValue - compareCalcValue
   const pctDiff =

--- a/libs/zzz/db/src/Database/migrate.ts
+++ b/libs/zzz/db/src/Database/migrate.ts
@@ -14,7 +14,7 @@ import type {
   IZenlessObjectDescription,
 } from '../Interfaces'
 
-export const currentDBVersion = 2
+export const currentDBVersion = 3
 
 export function migrateZOOD(
   zood: IZenlessObjectDescription & IZZZDatabase
@@ -69,6 +69,53 @@ export function migrateZOOD(
     }
     migrateData('Astra', 'AstraYao')
     migrateData('QingYi', 'Qingyi')
+  })
+
+  migrateVersion(3, () => {
+    function migrateCharOpt() {
+      const charOpts = zood['charOpts'] as any[] | undefined
+
+      if (charOpts) {
+        zood['teams'] = charOpts.map((charOpt) => {
+          const charKey = charOpt.id as string
+          const {
+            critMode,
+            bonusStats,
+            conditionals,
+            enemyStats,
+            optConfigId,
+            teammates: oldTeammates,
+            target,
+            ...rest
+          } = charOpt
+
+          return {
+            id: charKey,
+            teammates: [
+              { characterKey: charKey, optConfigId },
+              ...(oldTeammates ?? []).map((ck: any) => ({
+                characterKey: ck,
+              })),
+            ],
+            frames: [
+              {
+                multiplier: 1,
+                critMode,
+                bonusStats,
+                conditionals,
+                enemyStats,
+                tag: target,
+              },
+            ],
+            ...rest,
+          }
+        })
+
+        delete zood['charOpts']
+      }
+    }
+
+    migrateCharOpt()
   })
 
   zood.dbVersion = currentDBVersion
@@ -149,53 +196,60 @@ export function migrateStorage(storage: DBStorage) {
     migrateData('QingYi', 'Qingyi')
   })
 
-  function migrateCharOpt() {
-    const keys = storage.keys
-    for (const key of keys) {
-      if (key.startsWith('zzz_charOpt_')) {
-        const charKey = key.slice('zzz_charOpt_'.length)
-        const oldTeam = storage.get(`zzz_team_${charKey}`)
-        const charOpt = storage.get(key)
-        const charMeta = storage.get(`zzz_charMeta_${charKey}`)
+  migrateVersion(3, () => {
+    function migrateCharOpt() {
+      const keys = storage.keys
+      for (const key of keys) {
+        if (key.startsWith('zzz_charOpt_')) {
+          const charKey = key.slice('zzz_charOpt_'.length)
+          const oldTeam = storage.get(`zzz_team_${charKey}`)
+          const charOpt = storage.get(key)
+          const charMeta = storage.get(`zzz_charMeta_${charKey}`)
 
-        const {
-          critMode,
-          bonusStats,
-          conditionals,
-          enemyStats,
-          optConfigId,
-          teammates: oldTeammates,
-          ...rest
-        } = charOpt
-        const frame = {
-          multiplier: 1,
-          critMode,
-          bonusStats,
-          conditionals,
-          enemyStats,
+          const {
+            critMode,
+            bonusStats,
+            conditionals,
+            enemyStats,
+            optConfigId,
+            teammates: oldTeammates,
+            target,
+            ...rest
+          } = charOpt
+          const frame = {
+            multiplier: 1,
+            critMode,
+            bonusStats,
+            conditionals,
+            enemyStats,
+            tag: target,
+          }
+          const teammates = [
+            { characterKey: charKey, optConfigId },
+            ...oldTeammates.map((ck: any) => ({
+              characterKey: ck,
+            })),
+          ]
+
+          const team = {
+            teammates,
+            frames: [frame],
+            ...rest,
+          }
+
+          storage.set(`zzz_team_${charKey}`, team)
+          if (oldTeam) {
+            storage.set(`zzz_charMeta_${charKey}`, {
+              description: `${charMeta?.description ?? ''}\n\n${JSON.stringify(oldTeam)}`,
+            })
+          }
+          storage.remove(key)
         }
-        const teammates = [
-          { characterKey: charKey, optConfigId },
-          ...oldTeammates.map((ck: any) => ({
-            characterKey: ck,
-          })),
-        ]
-
-        const team = {
-          teammates,
-          frames: [frame],
-          ...rest,
-        }
-
-        storage.set(`zzz_team_${charKey}`, team)
-        storage.set(`zzz_charMeta_${charKey}`, {
-          description: `${charMeta?.description ?? ''}\n\n${JSON.stringify(oldTeam)}`,
-        })
-        storage.remove(key)
       }
     }
-  }
-  migrateCharOpt()
+
+    migrateCharOpt()
+  })
 
   storage.setDBVersion(currentDBVersion)
   if (version > currentDBVersion)

--- a/libs/zzz/db/src/Database/migrate.ts
+++ b/libs/zzz/db/src/Database/migrate.ts
@@ -226,7 +226,7 @@ export function migrateStorage(storage: DBStorage) {
           }
           const teammates = [
             { characterKey: charKey, optConfigId },
-            ...oldTeammates.map((ck: any) => ({
+            ...(oldTeammates ?? []).map((ck: any) => ({
               characterKey: ck,
             })),
           ]

--- a/libs/zzz/db/src/Database/migrate.ts
+++ b/libs/zzz/db/src/Database/migrate.ts
@@ -149,6 +149,54 @@ export function migrateStorage(storage: DBStorage) {
     migrateData('QingYi', 'Qingyi')
   })
 
+  function migrateCharOpt() {
+    const keys = storage.keys
+    for (const key of keys) {
+      if (key.startsWith('zzz_charOpt_')) {
+        const charKey = key.slice('zzz_charOpt_'.length)
+        const oldTeam = storage.get(`zzz_team_${charKey}`)
+        const charOpt = storage.get(key)
+        const charMeta = storage.get(`zzz_charMeta_${charKey}`)
+
+        const {
+          critMode,
+          bonusStats,
+          conditionals,
+          enemyStats,
+          optConfigId,
+          teammates: oldTeammates,
+          ...rest
+        } = charOpt
+        const frame = {
+          multiplier: 1,
+          critMode,
+          bonusStats,
+          conditionals,
+          enemyStats,
+        }
+        const teammates = [
+          { characterKey: charKey, optConfigId },
+          ...oldTeammates.map((ck: any) => ({
+            characterKey: ck,
+          })),
+        ]
+
+        const team = {
+          teammates,
+          frames: [frame],
+          ...rest,
+        }
+
+        storage.set(`zzz_team_${charKey}`, team)
+        storage.set(`zzz_charMeta_${charKey}`, {
+          description: `${charMeta?.description ?? ''}\n\n${JSON.stringify(oldTeam)}`,
+        })
+        storage.remove(key)
+      }
+    }
+  }
+  migrateCharOpt()
+
   storage.setDBVersion(currentDBVersion)
   if (version > currentDBVersion)
     throw new Error(`Database version ${version} is not supported`)

--- a/libs/zzz/dm-localization/assets/locales/en/char_Jane_gen.json
+++ b/libs/zzz/dm-localization/assets/locales/en/char_Jane_gen.json
@@ -2,6 +2,21 @@
   "name": "Jane",
   "fullName": "Jane Doe",
   "basic": {
+    "BasicAttackDancingBlades": {
+      "name": "Basic Attack: Dancing Blades",
+      "desc": {
+        "0": "Press <IconNormal /> to activate:",
+        "1": "Unleashes up to 6 attacks in front, dealing <ct color=#F0D12B>Physical DMG</ct>."
+      },
+      "params": [
+        "1st-Hit ",
+        "2nd-Hit ",
+        "3rd-Hit ",
+        "4th-Hit ",
+        "5th-Hit ",
+        "6th-Hit "
+      ]
+    },
     "Passion": {
       "name": "Passion",
       "desc": {
@@ -10,6 +25,21 @@
         "2": "In the <ct color=#FFFFFF>Passion</ct> state, Jane's skills that deal damage consume <ct color=#FFFFFF>Passion Stream</ct>. Activating a <ct color=#FFFFFF>Perfect Dodge</ct> or <ct color=#FFFFFF>Defensive Assist</ct> regenerates <ct color=#FFFFFF>Passion Stream</ct>. Jane exits the <ct color=#FFFFFF>Passion</ct> state when all of her <ct color=#FFFFFF>Passion Stream</ct> is consumed."
       },
       "params": []
+    },
+    "BasicAttackSalchowJump": {
+      "name": "Basic Attack: Salchow Jump",
+      "desc": {
+        "0": "Entering the <ct color=#FFFFFF>Passion</ct> state grants Jane one use of <ct color=#FFFFFF>Basic Attack: Salchow Jump</ct>.",
+        "1": "When available, hold <IconNormal /> to activate:",
+        "2": "Launch rapid consecutive attacks forward, followed by a Finishing Move, dealing <ct color=#F0D12B>Physical DMG</ct>.",
+        "3": "Hold the button during the consecutive attacks to extend the skill duration. Release <IconNormal /> to trigger the Finishing Move early.",
+        "4": "Anti-Interrupt level is increased during the consecutive attacks, and Jane takes 40% reduced DMG. Jane is invulnerable during the Finishing Move.",
+        "5": "Using and damaging an enemy with <ct color=#FFFFFF>Basic Attack: Salchow Jump</ct> while in the <ct color=#FFFFFF>Passion</ct> state generates <ct color=#FFFFFF>Passion Stream</ct>."
+      },
+      "params": [
+        "Consecutive Attack ",
+        "Finishing Move "
+      ]
     }
   },
   "dodge": {
@@ -80,6 +110,18 @@
       },
       "params": [
         " "
+      ]
+    },
+    "EXSpecialAttackAerialSweepClearout": {
+      "name": "EX Special Attack: Aerial Sweep - Clearout",
+      "desc": {
+        "0": "With enough Energy, press <IconSpecialReady /> to activate:",
+        "1": "Leaps into the air to launch multiple consecutive kicks forward, then sweeps across, dealing massive <ct color=#F0D12B>Physical DMG</ct>.",
+        "2": "Character is invulnerable while using this skill."
+      },
+      "params": [
+        " ",
+        "Energy Cost "
       ]
     }
   },

--- a/libs/zzz/stats/Data/Characters/Jane.json
+++ b/libs/zzz/stats/Data/Characters/Jane.json
@@ -34,7 +34,6 @@
   ],
   "skillParams": {
     "basic": {
-      "Passion": [],
       "BasicAttackDancingBlades": [
         {
           "DamagePercentage": 0.361,
@@ -103,6 +102,7 @@
           "AttributeInfliction": 226.62
         }
       ],
+      "Passion": [],
       "BasicAttackSalchowJump": [
         {
           "DamagePercentage": 3.008,

--- a/libs/zzz/stats/src/allStat_gen.json
+++ b/libs/zzz/stats/src/allStat_gen.json
@@ -11221,7 +11221,6 @@
       ],
       "skillParams": {
         "basic": {
-          "Passion": [],
           "BasicAttackDancingBlades": [
             {
               "DamagePercentage": 0.361,
@@ -11290,6 +11289,7 @@
               "AttributeInfliction": 226.62
             }
           ],
+          "Passion": [],
           "BasicAttackSalchowJump": [
             {
               "DamagePercentage": 3.008,


### PR DESCRIPTION
## Describe your changes

- Adds migration for `charOpt` to `teams` key
- Fixes Jane's text
- Fixes `TagFieldDisplay` to show units correctly on hover

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved saved character team compatibility by migrating stored character options into the latest team format, including frame and tag/metadata handling.
* **Bug Fixes**
  * Updated unit label selection in field display to prioritize the more specific tag when multiple tag fields are present.
* **Chores**
  * Updated an external referenced data source to a newer revision.
* **Documentation**
  * Reorganized a character’s skill parameter entry structure without changing its values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->