### PR TITLE
feat: auto-focus newly added target in multi-opt (closes #2907)

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
@@ -67,11 +67,13 @@ export default function CustomMultiTargetCard({
     setTargetProp(target)
   }, [onHide, setTargetProp, target])
 
+  const [selectedTarget, setSelectedTarget] = useState(-1)
   const addTarget = useCallback(
     (t: string[], multi?: number) => {
       const target_ = { ...target }
       target_.targets = [...target_.targets, initCustomTarget(t, multi)]
       setTarget(target_)
+      setSelectedTarget(target_.targets.length - 1)
     },
     [target, setTarget]
   )
@@ -99,7 +101,6 @@ export default function CustomMultiTargetCard({
     [target, setTarget, t]
   )
 
-  const [selectedTarget, setSelectedTarget] = useState(-1)
   const setTargetIndex = useCallback(
     (oldInd: number) => (newRank?: number) => {
       if (newRank === undefined || newRank === 0) return


### PR DESCRIPTION
## Describe your changes

Newly added targets in the multi-opt (Custom Multi Target) editor are now auto-selected, so their editor panel opens immediately instead of requiring an extra click. In `addTarget`, `selectedTarget` is set to the new target's index; the `selectedTarget` state declaration was moved above `addTarget` so it's in scope.

## Issue or discord link

- Closes #2907

## Testing/validation

Minimal change — adding a target now opens its editor automatically rather than appending it unselected.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard-to understand areas. (n/a — single-line change)
- [x] I have made corresponding changes to README or wiki. (n/a)
- [x] For front-end changes, I have updated the corresponding English translations. (n/a — no new strings)
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [x] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed (n/a)