### PR TITLE
Fix Zibai C2

### DIFF
--- a/libs/gi/sheets/src/Characters/Zibai/index.tsx
+++ b/libs/gi/sheets/src/Characters/Zibai/index.tsx
@@ -178,7 +178,7 @@ const c2Moonfall_stride_dmgInc = infoMut(
           'on',
           prod(
             percent(
-              dm.constellation2.stride_dmgInc - dm.passive1.stride_dmgInc
+              dm.constellation2.stride_dmgInc
             ),
             input.total.def
           )
@@ -550,7 +550,6 @@ const sheet: TalentSheet = {
       path: condC2ShiftModePath,
       value: condC2ShiftMode,
       name: ct.ch('c2Cond'),
-      canShow: greaterEq(tally.moonsign, 2, 1),
       teamBuff: true,
       states: {
         on: {

--- a/libs/gi/sheets/src/Characters/Zibai/index.tsx
+++ b/libs/gi/sheets/src/Characters/Zibai/index.tsx
@@ -176,12 +176,7 @@ const c2Moonfall_stride_dmgInc = infoMut(
         equal(
           condA1Moonfall,
           'on',
-          prod(
-            percent(
-              dm.constellation2.stride_dmgInc
-            ),
-            input.total.def
-          )
+          prod(percent(dm.constellation2.stride_dmgInc), input.total.def)
         )
       )
     )


### PR DESCRIPTION
## Describe your changes

- Fix LCR damage bonus from Zibai C2 not applying without Moonsign
- Fix C2 replacing Zibai's A1 scaling instead of adding to it

## Issue or discord link

- Fix https://github.com/frzyc/genshin-optimizer/issues/3245

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected constellation level 2 stride damage increment scaling to use the proper direct value, improving consistency across damage calculations.
  * Adjusted the talent sheet display logic so the constellation 2 section is shown based on the intended constellation criteria, rather than being additionally hidden by an extra moonsign condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->