### PR TITLE
Fix debug display using the wrong tag

### DIFF
--- a/libs/game-opt/formula-ui/src/DebugDisplay.tsx
+++ b/libs/game-opt/formula-ui/src/DebugDisplay.tsx
@@ -130,10 +130,9 @@ export function DebugListingsDisplay({
 }
 
 export function DebugReadModal() {
-  const tag = useContext(TagContext)
-  const calculator = useContext(CalcContext)?.withTag(tag)
+  const { read, setRead, tag, setTag } = useContext(DebugReadContext)
+  const calculator = useContext(CalcContext)?.withTag(tag ?? {})
   const debugCalc = calculator?.toDebug()
-  const { read, setRead } = useContext(DebugReadContext)
   const computed = read && calculator?.compute(read)
   const debug = read && debugCalc?.compute(read)
   const name = read?.tag['name'] || read?.tag['q']
@@ -141,12 +140,23 @@ export function DebugReadModal() {
   const jsonStr = meta && prettify(meta)
 
   return (
-    <ModalWrapper open={!!read} onClose={() => setRead(undefined)}>
+    <ModalWrapper
+      open={!!read && !!tag}
+      onClose={() => {
+        setRead(undefined)
+        setTag(undefined)
+      }}
+    >
       <CardThemed bgt="dark">
         <CardHeader
           title={`Debug formula for ${name}`}
           action={
-            <IconButton onClick={() => setRead(undefined)}>
+            <IconButton
+              onClick={() => {
+                setRead(undefined)
+                setTag(undefined)
+              }}
+            >
               <CloseIcon />
             </IconButton>
           }

--- a/libs/game-opt/formula-ui/src/context/DebugReadContext.tsx
+++ b/libs/game-opt/formula-ui/src/context/DebugReadContext.tsx
@@ -1,9 +1,12 @@
-import type { BaseRead } from '@genshin-optimizer/pando/engine'
+import type { BaseRead, Tag } from '@genshin-optimizer/pando/engine'
 import { createContext } from 'react'
 
 export type DebugReadContextObj = {
   read: BaseRead | undefined
   setRead: (read: BaseRead | undefined) => void
+  // Tag from TagContext is not accurate, as the TagContext can be changed at a lower layer than where the DebugDisplay will sit
+  tag: Tag | undefined
+  setTag: (tag: Tag | undefined) => void
 }
 export const DebugReadContext = createContext<DebugReadContextObj>(
   {} as DebugReadContextObj

--- a/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
@@ -10,6 +10,7 @@ import { evalIfFunc } from '@genshin-optimizer/common/util'
 import type {
   IListConditionalData,
   INumConditionalData,
+  Tag,
 } from '@genshin-optimizer/game-opt/engine'
 import { CalcContext, TagContext } from '@genshin-optimizer/game-opt/formula-ui'
 import type { BaseRead } from '@genshin-optimizer/pando/engine'
@@ -46,7 +47,7 @@ export function ConditionalsDisplay({
 }: {
   bgt?: CardBackgroundColor
   conditional: Conditional
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   const { srcDisplay, dstDisplay } = useContext(SrcDstDisplayContext)
   const setConditional = useContext(SetConditionalContext)
@@ -131,7 +132,7 @@ const ConditionalDisplay = memo(function ConditionalDisplay({
   setValue: (value: number) => void
   bgt?: CardBackgroundColor
   disabled?: boolean
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   const { header, fields, targeted } = conditional
   const { srcDisplay, dstDisplay } = useContext(SrcDstDisplayContext)

--- a/libs/game-opt/sheet-ui/src/components/DocumentDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/DocumentDisplay.tsx
@@ -1,6 +1,7 @@
 import type { CardBackgroundColor } from '@genshin-optimizer/common/ui'
 import { CardThemed } from '@genshin-optimizer/common/ui'
 import { evalIfFunc } from '@genshin-optimizer/common/util'
+import type { Tag } from '@genshin-optimizer/game-opt/engine'
 import { CalcContext, TagContext } from '@genshin-optimizer/game-opt/formula-ui'
 import type { BaseRead } from '@genshin-optimizer/pando/engine'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
@@ -57,7 +58,7 @@ export function DocumentContent({
   bgt?: CardBackgroundColor
   collapse?: boolean
   typoVariant?: TypographyOwnProps['variant']
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   switch (document.type) {
     case 'fields':
@@ -125,7 +126,7 @@ function FieldsSectionContent({
 }: {
   fieldsDocument: FieldsDocument
   bgt?: CardBackgroundColor
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   return (
     <>

--- a/libs/game-opt/sheet-ui/src/components/DocumentDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/DocumentDisplay.tsx
@@ -102,7 +102,7 @@ export function DocumentDisplay({
   bgt?: CardBackgroundColor
   collapse?: boolean
   typoVariant?: TypographyOwnProps['variant']
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   const content = (
     <DocumentContent

--- a/libs/game-opt/sheet-ui/src/components/FieldDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/FieldDisplay.tsx
@@ -92,7 +92,7 @@ export function FieldsDisplay({
 }: {
   fields: Field[]
   bgt?: CardBackgroundColor
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
   return (
     <FieldDisplayList sx={{ m: 0 }} bgt={bgt}>
@@ -110,8 +110,9 @@ function FieldDisplay({
 }: {
   field: Field
   component?: ElementType
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
 }) {
+  const tag = useContext(TagContext)
   if ('fieldValue' in field)
     return <TextFieldDisplay field={field} component={component} />
   if (isMultiTagField(field)) {
@@ -130,7 +131,7 @@ function FieldDisplay({
         field={field}
         component={component}
         onClickFormula={
-          onClickFormula ? () => onClickFormula(fieldRead) : undefined
+          onClickFormula ? () => onClickFormula(fieldRead, tag) : undefined
         }
       />
     )
@@ -186,7 +187,7 @@ export function MultiTagFieldDisplay({
   component?: ElementType
   showZero?: boolean
   rowSx?: SxProps<Theme>
-  onClickFormula?: (read: BaseRead) => void
+  onClickFormula?: (read: BaseRead, tag: Tag) => void
   onMouseEnter?: () => void
   onMouseLeave?: () => void
 }) {
@@ -289,7 +290,7 @@ export function MultiTagFieldDisplay({
             const tag = fieldRead.tag
             const unit = getUnitStr(tag['name'] || tag['q'] || '')
             const onClick = onClickFormula
-              ? () => onClickFormula(fieldRead)
+              ? () => onClickFormula(fieldRead, contextTag)
               : undefined
             return (
               <Box

--- a/libs/sr/page-optimize/src/index.tsx
+++ b/libs/sr/page-optimize/src/index.tsx
@@ -106,12 +106,15 @@ export default function PageOptimize() {
   )
 
   const [debugRead, setDebugRead] = useState<BaseRead>()
+  const [debugTag, setDebugTag] = useState<Tag>()
   const debugObj = useMemo<DebugReadContextObj>(
     () => ({
       read: debugRead,
       setRead: setDebugRead,
+      tag: debugTag,
+      setTag: setDebugTag,
     }),
-    [debugRead]
+    [debugRead, debugTag]
   )
   return (
     <Box>

--- a/libs/sr/page-team/src/index.tsx
+++ b/libs/sr/page-team/src/index.tsx
@@ -195,12 +195,15 @@ function Page({ teamId }: { teamId: string }) {
   )
 
   const [debugRead, setDebugRead] = useState<BaseRead>()
+  const [debugTag, setDebugTag] = useState<Tag>()
   const debugObj = useMemo<DebugReadContextObj>(
     () => ({
       read: debugRead,
       setRead: setDebugRead,
+      tag: debugTag,
+      setTag: setDebugTag,
     }),
-    [debugRead]
+    [debugRead, debugTag]
   )
 
   const { height, ref } = useRefSize()

--- a/libs/zzz/formula-ui/src/char/CharStatsDisplay.tsx
+++ b/libs/zzz/formula-ui/src/char/CharStatsDisplay.tsx
@@ -168,7 +168,7 @@ const CharStatRow = memo(function CharStatRow({
   optTarget: ReturnType<typeof getTeamFrame0>['tag']
   resolvedOptTag: Tag | undefined
 }) {
-  const { setRead } = useContext(DebugReadContext)
+  const { setRead, setTag } = useContext(DebugReadContext)
   const calc = useZzzCalcContext()
   const baseTag = tagIn ?? read!.tag
 
@@ -225,8 +225,14 @@ const CharStatRow = memo(function CharStatRow({
   )
 
   const onClickFormula = useMemo(
-    () => (shouldShowDevComponents ? () => setRead(calcRead) : undefined),
-    [setRead, calcRead]
+    () =>
+      shouldShowDevComponents
+        ? () => {
+            setRead(calcRead)
+            setTag(mergedTag)
+          }
+        : undefined,
+    [setRead, calcRead, setTag, mergedTag]
   )
 
   return (

--- a/libs/zzz/formula-ui/src/hooks/useDebugFormulaClick.ts
+++ b/libs/zzz/formula-ui/src/hooks/useDebugFormulaClick.ts
@@ -1,13 +1,19 @@
 import { shouldShowDevComponents } from '@genshin-optimizer/common/util'
+import type { Tag } from '@genshin-optimizer/game-opt/engine'
 import { DebugReadContext } from '@genshin-optimizer/game-opt/formula-ui'
 import type { BaseRead } from '@genshin-optimizer/pando/engine'
 import { useContext, useMemo } from 'react'
 
 /** Opens `DebugReadModal` for a sheet field read when dev components are enabled. */
-export function useDebugFormulaClick(): ((read: BaseRead) => void) | undefined {
-  const { setRead } = useContext(DebugReadContext)
+export function useDebugFormulaClick():
+  | ((read: BaseRead, tag: Tag) => void)
+  | undefined {
+  const { setRead, setTag } = useContext(DebugReadContext)
   return useMemo(() => {
     if (!shouldShowDevComponents) return undefined
-    return (read: BaseRead) => setRead(read)
-  }, [setRead])
+    return (read: BaseRead, tag: Tag) => {
+      setRead(read)
+      setTag(tag)
+    }
+  }, [setRead, setTag])
 }

--- a/libs/zzz/page-optimize/src/index.tsx
+++ b/libs/zzz/page-optimize/src/index.tsx
@@ -150,12 +150,15 @@ export default function PageOptimize() {
   )
 
   const [debugRead, setDebugRead] = useState<BaseRead>()
+  const [debugTag, setDebugTag] = useState<Tag>()
   const debugObj = useMemo<DebugReadContextObj>(
     () => ({
       read: debugRead,
       setRead: setDebugRead,
+      tag: debugTag,
+      setTag: setDebugTag,
     }),
-    [debugRead]
+    [debugRead, debugTag]
   )
   return (
     <Box>


### PR DESCRIPTION
## Describe your changes

DebugDisplay was using Tag from TagContext, but we placed DebugDisplay at a very high level on the component stack. Further down the component stack, we will end up adding another TagContext layer, but the DebugDisplay would be unaware of that. To resolve that, we can just store the Tag into the DebugContext along with the Read

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Formula debugging now also tracks and preserves the active tag when selecting a formula/field.
  - The debug modal opens only when both the selected read and tag are available.
- **Bug Fixes**
  - Closing the debug view now clears both the selected read and tag (not just the read).
  - Improved consistency so clicks in conditional, document, and field displays keep tag and formula details in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->