### PR TITLE
Show probability table for different roll allocations

### DIFF
--- a/libs/gi/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/gi/localization/assets/locales/en/page_character_optimize.json
@@ -58,7 +58,16 @@
     "estimatedDist": "Estimated Distribution",
     "currentTarget": "Current Target",
     "currentLine": "Current Target Value",
-    "averageLine": "Average Increase"
+    "averageLine": "Average Increase",
+    "rollAllocations": {
+      "title": "Enhancement roll allocation",
+      "description": "Each row fixes how many enhancement rolls land in each substat, then evaluates every possible roll value and newly activated substat. A dash means the artifact does not have that substat. Allocation chance sums to 100%. Overall contribution sums to the card's Prob. upgrade.",
+      "summary": "Check: Allocation chance {{allocation}} · Prob. upgrade {{probability}} · Average increase {{increase}}",
+      "allocationChance": "Allocation chance",
+      "upgradeWithinAllocation": "Upgrade chance",
+      "overallContribution": "Overall contribution",
+      "averageSuccessfulIncrease": "Avg. successful increase"
+    }
   },
   "excludeArt": {
     "title_exclude": "Excluded Artifacts",

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
@@ -6,6 +6,7 @@ import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
 import { objMap, range } from '@genshin-optimizer/common/util'
 import {
   type ArtifactSlotKey,
+  allSubstatKeys,
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
 import { cachedArtifact } from '@genshin-optimizer/gi/db'
@@ -24,12 +25,22 @@ import {
 import { getSubstatValue } from '@genshin-optimizer/gi/util'
 import { uiInput as input } from '@genshin-optimizer/gi/wr'
 import CheckroomIcon from '@mui/icons-material/Checkroom'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   CircularProgress,
   Divider,
   Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
   Tooltip,
   Typography,
 } from '@mui/material'
@@ -225,6 +236,7 @@ function UpgradeOptChartCardGraph({
   const thr0 = thresholds[0]
   const perc = useCallback((x: number) => (100 * (x - thr0)) / thr0, [thr0])
   const [isExactPending, setIsExactPending] = useState(false)
+  const [showRollAllocations, setShowRollAllocations] = useState(false)
   const dataHist = upOptCalc.histogram(ix, {
     left: objMin,
     right: objMax,
@@ -239,6 +251,29 @@ function UpgradeOptChartCardGraph({
   const reportD = upArt.result!.upAvg
   const chartData = dataHist
   const isExact = upArt.evalMode === 'values'
+  const exactRollAllocations = useMemo(
+    () =>
+      showRollAllocations && isExact
+        ? upOptCalc.exactRollAllocationGroups(ix)
+        : [],
+    [showRollAllocations, isExact, upOptCalc, ix]
+  )
+  const rollAllocationKeys = useMemo(
+    () =>
+      allSubstatKeys.filter((key) =>
+        exactRollAllocations.some((group) =>
+          group.rolls.some((roll) => roll.key === key)
+        )
+      ),
+    [exactRollAllocations]
+  )
+  const formatProbability = (value: number) => {
+    const percent = 100 * value
+    if (percent > 0 && percent < 0.01) return '<0.01%'
+    return `${percent.toFixed(2)}%`
+  }
+  const formatSignedPercent = (value: number, digits: number) =>
+    `${value > 0 ? '+' : ''}${value.toFixed(digits)}%`
 
   useEffect(() => {
     if (isExact) return
@@ -460,6 +495,103 @@ function UpgradeOptChartCardGraph({
           />
         </ComposedChart>
       </ResponsiveContainer>
+      {isExact && upArt.info.type !== 'definition' && (
+        <Accordion
+          expanded={showRollAllocations}
+          onChange={(_, expanded) => setShowRollAllocations(expanded)}
+          disableGutters
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>{t('upOptChart.rollAllocations.title')}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('upOptChart.rollAllocations.description')}
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              {t('upOptChart.rollAllocations.summary', {
+                allocation: formatProbability(
+                  exactRollAllocations.reduce(
+                    (sum, group) => sum + group.probability,
+                    0
+                  )
+                ),
+                probability: formatProbability(
+                  exactRollAllocations.reduce(
+                    (sum, group) => sum + group.overallUpgradeProbability,
+                    0
+                  )
+                ),
+                increase: formatSignedPercent((100 * reportD) / thr0, 2),
+              })}
+            </Typography>
+            <TableContainer sx={{ maxHeight: 440 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    {rollAllocationKeys.map((key) => (
+                      <TableCell key={key} align="right">
+                        {formatReshapeLabel(key)}
+                      </TableCell>
+                    ))}
+                    <TableCell align="right">
+                      {t('upOptChart.rollAllocations.allocationChance')}
+                    </TableCell>
+                    <TableCell align="right">
+                      {t('upOptChart.rollAllocations.upgradeWithinAllocation')}
+                    </TableCell>
+                    <TableCell align="right">
+                      {t('upOptChart.rollAllocations.overallContribution')}
+                    </TableCell>
+                    <TableCell align="right">
+                      {t(
+                        'upOptChart.rollAllocations.averageSuccessfulIncrease'
+                      )}
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {exactRollAllocations.map((group) => (
+                    <TableRow
+                      key={group.rolls
+                        .map(({ key, count }) => `${key}:${count}`)
+                        .join('|')}
+                    >
+                      {rollAllocationKeys.map((key) => {
+                        const roll = group.rolls.find(
+                          (roll) => roll.key === key
+                        )
+                        return (
+                          <TableCell key={key} align="right">
+                            {roll?.count ?? '—'}
+                          </TableCell>
+                        )
+                      })}
+                      <TableCell align="right">
+                        {formatProbability(group.probability)}
+                      </TableCell>
+                      <TableCell align="right">
+                        {formatProbability(group.upgradeProbability)}
+                      </TableCell>
+                      <TableCell align="right">
+                        {formatProbability(group.overallUpgradeProbability)}
+                      </TableCell>
+                      <TableCell align="right">
+                        {group.upgradeProbability > 0
+                          ? formatSignedPercent(
+                              (100 * group.averageIncrease) / thr0,
+                              2
+                            )
+                          : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </AccordionDetails>
+        </Accordion>
+      )}
     </CardThemed>
   )
 }

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
@@ -75,6 +75,13 @@ type DefineInfo = {
   affixes: SubstatKey[]
 }
 export type UpOptInfo = LevelUpInfo | ReshapeInfo | DefineInfo
+type ExactRollAllocationGroup = {
+  rolls: { key: SubstatKey; count: number }[]
+  probability: number
+  upgradeProbability: number
+  overallUpgradeProbability: number
+  averageIncrease: number
+}
 
 function canLevelUp(art: ICachedArtifact) {
   // Restricted to 5* artifacts for now.
@@ -102,6 +109,11 @@ export class UpOptCalculatorV2 {
   obj: Objective
   candidates: EvaluatedMarkovTree[] = []
   fixedIx = 0
+  private artifactsById = new Map<string, ICachedArtifact>()
+  private exactRollAllocationCache = new Map<
+    string,
+    ExactRollAllocationGroup[]
+  >()
 
   /** Serializes exact-calc work so candidates are refined one at a time. */
   private exactQueue: Promise<unknown> = Promise.resolve()
@@ -131,6 +143,7 @@ export class UpOptCalculatorV2 {
     // Create objective function & set up candidates.
     this.obj = makeObjective(nodes, thresholds)
     artifacts.forEach((art) => {
+      this.artifactsById.set(art.id, art)
       this.tryLevelUp(art)
       if (reshapeConfig.enabled) this.tryReshape(art, reshapeConfig.minTotal)
     })
@@ -303,15 +316,105 @@ export class UpOptCalculatorV2 {
     return run
   }
 
-  expandRollsLevel(ix: number) {
-    if (this.candidates[ix].evalMode !== 'rolls') return
-    const newTree = expandNodes(this.candidates[ix].tree)
-    const newEval = this.evaluateNodes(newTree)
-    this.candidates[ix] = {
-      ...this.candidates[ix],
-      ...newEval,
-      evalMode: 'values',
+  exactRollAllocationGroups(ix: number): ExactRollAllocationGroup[] {
+    const candidate = this.candidates[ix]
+    if (
+      !candidate ||
+      candidate.evalMode !== 'values' ||
+      candidate.info.type === 'definition'
+    )
+      return []
+
+    const cacheKey = candidate.id
+    const cached = this.exactRollAllocationCache.get(cacheKey)
+    if (cached) return cached
+
+    const artifact = this.artifactsById.get(candidate.info.artifactId)
+    if (!artifact) return []
+    const initialNodes =
+      candidate.info.type === 'reshape'
+        ? dustReshape(
+            artifact,
+            this.build,
+            [...candidate.info.affixes],
+            candidate.info.mintotal
+          )
+        : levelUpArtifact(artifact, this.build)
+    type MutableAllocation = Pick<
+      ExactRollAllocationGroup,
+      'rolls' | 'probability' | 'overallUpgradeProbability'
+    > & {
+      increaseAccumulator: number
     }
+    const grouped = new Map<string, MutableAllocation>()
+
+    initialNodes.forEach(({ p: initialProbability, n: initialNode }) => {
+      if (initialNode.type !== 'substat') return
+      const baseRolls = new Map(
+        initialNode.subkeys.map(({ key, baseRolls }) => [key, baseRolls])
+      )
+      expandNode(initialNode).forEach(({ p: rollProbability, n: rollNode }) => {
+        if (rollNode.type !== 'rolls') return
+        const allocationProbability = initialProbability * rollProbability
+        const rolls = rollNode.subs.map(({ key, rolls }) => ({
+          key,
+          count: rolls - (baseRolls.get(key) ?? 0),
+        }))
+        const allocationKey = rolls
+          .map(({ key, count }) => `${key}:${count}`)
+          .join('|')
+        let overallUpgradeProbability = 0
+        let increaseAccumulator = 0
+
+        expandNode(rollNode).forEach(({ p: valueProbability, n }) => {
+          const evaluated = evalMarkovNode(this.obj, n)
+          const { prob, upAvg } = evaluated.evaluation
+          overallUpgradeProbability +=
+            allocationProbability * valueProbability * prob
+          increaseAccumulator +=
+            allocationProbability * valueProbability * prob * upAvg
+        })
+
+        const existing = grouped.get(allocationKey)
+        if (existing) {
+          existing.probability += allocationProbability
+          existing.overallUpgradeProbability += overallUpgradeProbability
+          existing.increaseAccumulator += increaseAccumulator
+        } else {
+          grouped.set(allocationKey, {
+            rolls,
+            probability: allocationProbability,
+            overallUpgradeProbability,
+            increaseAccumulator,
+          })
+        }
+      })
+    })
+
+    const allocations = [...grouped.values()].map(
+      ({ increaseAccumulator, ...allocation }) => ({
+        ...allocation,
+        upgradeProbability:
+          allocation.probability > 1e-12
+            ? allocation.overallUpgradeProbability / allocation.probability
+            : 0,
+        averageIncrease:
+          allocation.overallUpgradeProbability > 1e-12
+            ? increaseAccumulator / allocation.overallUpgradeProbability
+            : 0,
+      })
+    )
+
+    allocations.sort((a, b) => {
+      if (b.probability !== a.probability) return b.probability - a.probability
+      for (let i = 0; i < a.rolls.length; i++) {
+        const countDiff = b.rolls[i].count - a.rolls[i].count
+        if (countDiff) return countDiff
+      }
+      return 0
+    })
+    this.exactRollAllocationCache.set(cacheKey, allocations)
+    return allocations
   }
 
   async expandRollsLevelAsync(ix: number, shouldCancel: () => boolean) {
@@ -360,6 +463,8 @@ export class UpOptCalculatorV2 {
 
   reCalc(ix: number, art: ICachedArtifact) {
     const prevId = this.candidates[ix].id
+    this.artifactsById.set(art.id, art)
+    this.exactRollAllocationCache.delete(prevId)
     if (this.candidates[ix].info.type === 'levelUp')
       this.candidates[ix] = this.fromLevelUpInfo(this.candidates[ix].info, art)
     else if (this.candidates[ix].info.type === 'reshape')


### PR DESCRIPTION
## Describe your changes

Adds an accordion table to artifact cards to desk-check the Upgrade Optimizer statistics.

<img width="1516" height="949" alt="image" src="https://github.com/user-attachments/assets/2bfb0dc2-8621-43b8-98de-e67eb6b3c16d" />

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable “Exact Roll Allocations” breakdown to upgrade optimization charts.
  * Displays roll-count combinations with allocation chance, upgrade probability, overall contribution, and average successful increase.
  * Added explanatory labels and descriptions for the new metrics.
* **Enhancements**
  * Allocation results are sorted and presented in a readable, sticky-header table.
  * Results update correctly when evaluating different artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->