### PR TITLE
GO: consider multiple equippable builds in upOpt

### DIFF
--- a/libs/gi/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/gi/localization/assets/locales/en/page_character_optimize.json
@@ -27,7 +27,7 @@
   "upOptLevelFilter": "Artifact Upgrader Level Filter",
   "upOptLevelFilterTooltip": "This level filter is not synced with Optimize config.",
   "upOptNoResults": "It looks like there aren't any artifacts available for upgrading that could enhance your setup. Your artifact filters might be too restrictive. Alternatively, try the main artifact optimizer to find a better build.",
-  "upOptInfo": "The Artifact Upgrader identifies artifacts with high potential to boost the Optimization Target's value, guiding you to artifacts worth leveling up.<br/>As it only swaps one artifact at a time, for the best overall build across all artifacts, use the main artifact optimizer.",
+  "upOptInfo": "The Artifact Upgrader identifies artifacts with high potential to boost the Optimization Target's value, guiding you to artifacts worth leveling up.<br/>Each candidate is evaluated with its best equippable build.",
   "upOptEmptyBuild": "You're using a partially empty build. Since the Artifact Upgrader only swaps artifacts individually, completing a set is unlikely. It's recommended to begin with a base build, preferably generated from the main Optimizer.",
   "upOptShowingNum": "Showing {{count}} out of {{value}} Artifacts",
   "upOptReshape": {
@@ -38,7 +38,7 @@
   },
   "upOptDefine": {
     "label": "Define",
-    "tooltip": "Evaluate hypothetical artifacts created by defining (Sanctifying Elixirs). Candidates are generated for the selected sets, slots, main stats, and every pair of the selected substats below.",
+    "tooltip": "Evaluate hypothetical artifacts created by defining (Sanctifying Elixirs). Candidates are generated for every set enabled in Artifact Set Configuration, the selected slots and main stats, and every pair of the selected substats below.",
     "substats": "Substats to consider for defining:"
   },
   "upOptChart": {
@@ -46,7 +46,7 @@
     "prob": "Prob. upgrade{{est}}: ",
     "average": "Average increase{{est}}: ",
     "equipped": "Equipped",
-    "current": "Current on Build",
+    "current": "Recommended Build",
     "reshape": "Reshape",
     "reshapeStats": "Guaranteed: {{count}} rolls into {{stats}}",
     "define": "Define",

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/UpgradeOptChartCard.tsx
@@ -6,9 +6,10 @@ import { CardThemed, SqBadge } from '@genshin-optimizer/common/ui'
 import { objMap, range } from '@genshin-optimizer/common/util'
 import {
   type ArtifactSlotKey,
+  allArtifactSlotKeys,
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
-import { cachedArtifact } from '@genshin-optimizer/gi/db'
+import { type ICachedArtifact, cachedArtifact } from '@genshin-optimizer/gi/db'
 import {
   TeamCharacterContext,
   useArtifact,
@@ -33,7 +34,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Area,
@@ -46,7 +47,11 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { type UpOptCalculatorV2, type UpOptInfo } from './upOpt'
+import {
+  type UpOptBuild,
+  type UpOptCalculatorV2,
+  type UpOptInfo,
+} from './upOpt'
 
 type DefineInfo = Extract<UpOptInfo, { type: 'definition' }>
 
@@ -119,7 +124,21 @@ export default function UpgradeOptChartCard(props: Props) {
               artifactId={artifactId!}
               onEdit={() => props.setArtifactIdToEdit(artifactId)}
               extraButtons={
-                <EquipButton newArtId={artifactId!} disabled={isEquipped} />
+                <EquipButton
+                  recommendedArtifactIds={objMap(
+                    upOptArt.build,
+                    (artifact) => artifact?.id
+                  )}
+                  disabled={
+                    isEquipped &&
+                    Object.entries(upOptArt.build).every(
+                      ([slotKey, artifact]) =>
+                        !artifact ||
+                        data.get(input.art[slotKey as ArtifactSlotKey].id)
+                          .value === artifact.id
+                    )
+                  }
+                />
               }
             />
           )}
@@ -132,10 +151,10 @@ export default function UpgradeOptChartCard(props: Props) {
   )
 }
 function EquipButton({
-  newArtId,
+  recommendedArtifactIds,
   disabled,
 }: {
-  newArtId: string
+  recommendedArtifactIds: Record<ArtifactSlotKey, string | undefined>
   disabled: boolean
 }) {
   const database = useDatabase()
@@ -150,9 +169,6 @@ function EquipButton({
     database.teams.getLoadoutArtifacts(loadoutDatum),
     (art) => art?.id
   )
-  const newArt = database.arts.get(newArtId)
-  if (!newArt) return
-
   return (
     <>
       <EquipBuildModal
@@ -162,18 +178,20 @@ function EquipButton({
         currentWeaponId={weapon?.id}
         currentArtifactIds={artifactids}
         newWeaponId={weapon?.id}
-        newArtifactIds={objMap(artifactids, (art, slotKey) =>
-          slotKey === newArt.slotKey ? newArtId : art
-        )}
+        newArtifactIds={recommendedArtifactIds}
         show={show}
         onEquip={() => {
           if (buildType === 'equipped')
-            database.arts.set(newArtId, {
-              location: charKeyToLocCharKey(characterKey),
-            })
+            Object.values(recommendedArtifactIds).forEach(
+              (artifactId) =>
+                artifactId &&
+                database.arts.set(artifactId, {
+                  location: charKeyToLocCharKey(characterKey),
+                })
+            )
           else if (buildType === 'real')
             database.builds.set(buildId, (build) => {
-              build.artifactIds[newArt.slotKey] = newArtId
+              build.artifactIds = recommendedArtifactIds
             })
         }}
         onHide={onHide}
@@ -301,11 +319,14 @@ function UpgradeOptChartCardGraph({
   return (
     <CardThemed bgt="light" sx={{ height: '100%', minHeight: 350 }}>
       <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-        <Box sx={{ height: 50, width: 50 }}>
-          {!!comparisonSlotKey && (
-            <EquippedArtifact slotKey={comparisonSlotKey} />
-          )}
-        </Box>
+        <RecommendedBuild
+          build={upArt.build}
+          definedArtifact={
+            upArt.info.type === 'definition'
+              ? defineDisplayArtifact(upArt.info)
+              : undefined
+          }
+        />
         <Box
           sx={{
             flexGrow: 1,
@@ -464,12 +485,26 @@ function UpgradeOptChartCardGraph({
   )
 }
 
-function EquippedArtifact({ slotKey }: { slotKey: ArtifactSlotKey }) {
-  const database = useDatabase()
-  const { data } = useContext(DataContext)
-  const artifact = useMemo(
-    () => database.arts.get(data.get(input.art[slotKey].id).value),
-    [slotKey, data, database]
+function RecommendedBuild({
+  build,
+  definedArtifact,
+}: {
+  build: UpOptBuild
+  definedArtifact?: ICachedArtifact
+}) {
+  return (
+    <Box sx={{ display: 'flex', flexShrink: 0 }}>
+      {allArtifactSlotKeys.map((slotKey) => {
+        const artifact =
+          definedArtifact?.slotKey === slotKey
+            ? definedArtifact
+            : build[slotKey]
+        return (
+          <Box key={slotKey} sx={{ height: 50, width: 50 }}>
+            <ArtifactCardPico slotKey={slotKey} artifactObj={artifact} />
+          </Box>
+        )
+      })}
+    </Box>
   )
-  return <ArtifactCardPico slotKey={slotKey} artifactObj={artifact} />
 }

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -1,5 +1,11 @@
 import { useForceUpdate } from '@genshin-optimizer/common/react-util'
-import { CardThemed, InfoTooltip, SqBadge } from '@genshin-optimizer/common/ui'
+import {
+  BootstrapTooltip,
+  CardThemed,
+  DropdownButton,
+  InfoTooltip,
+  SqBadge,
+} from '@genshin-optimizer/common/ui'
 import {
   bulkCatTotal,
   clamp,
@@ -9,11 +15,7 @@ import {
   objPathValue,
   range,
 } from '@genshin-optimizer/common/util'
-import type {
-  ArtifactSetKey,
-  CharacterKey,
-  MainStatKey,
-} from '@genshin-optimizer/gi/consts'
+import type { CharacterKey, MainStatKey } from '@genshin-optimizer/gi/consts'
 import {
   allArtifactSetKeys,
   allArtifactSlotKeys,
@@ -22,7 +24,6 @@ import {
   charKeyToLocCharKey,
 } from '@genshin-optimizer/gi/consts'
 import type { ArtSetExclusionKey } from '@genshin-optimizer/gi/db'
-import { type ICachedArtifact } from '@genshin-optimizer/gi/db'
 import {
   TeamCharacterContext,
   useDBMeta,
@@ -34,6 +35,9 @@ import {
   type FilterOption,
   initialFilterOption,
 } from '@genshin-optimizer/gi/schema'
+import type { OptProblemInput, SolverBuild } from '@genshin-optimizer/gi/solver'
+import { GOSolver } from '@genshin-optimizer/gi/solver'
+import { compactArtifacts } from '@genshin-optimizer/gi/solver-tc'
 import { StatIcon } from '@genshin-optimizer/gi/svgicons'
 import type { dataContextObj } from '@genshin-optimizer/gi/ui'
 import {
@@ -41,19 +45,27 @@ import {
   ArtifactEditor,
   ArtifactSetMultiAutocomplete,
   ArtifactSlotToggle,
+  CharacterName,
   DataContext,
   HitModeToggle,
   NoArtWarning,
   ReactionToggle,
   getTeamData,
   resolveInfo,
+  useGlobalError,
+  useNumWorkers,
   useTeamData,
 } from '@genshin-optimizer/gi/ui'
 import { uiDataForTeam } from '@genshin-optimizer/gi/uidata'
-import { artifactFilterConfigs } from '@genshin-optimizer/gi/util'
+import {
+  artifactFilterConfigs,
+  setKeysByRarities,
+} from '@genshin-optimizer/gi/util'
 import type { NumNode } from '@genshin-optimizer/gi/wr'
 import { dynamicData, mergeData, optimize } from '@genshin-optimizer/gi/wr'
 import AddIcon from '@mui/icons-material/Add'
+import CloseIcon from '@mui/icons-material/Close'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import {
   Alert,
   Box,
@@ -63,6 +75,7 @@ import {
   FormControlLabel,
   Grid,
   Link,
+  MenuItem,
   Pagination,
   Skeleton,
   Typography,
@@ -77,12 +90,16 @@ import {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
   useState,
 } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { CustomMultiTargetButton } from '../../CustomMultiTarget/CustomMultiTargetButton'
 import ArtifactSetConfig from '../TabOptimize/Components/ArtifactSetConfig'
 import BonusStatsCard from '../TabOptimize/Components/BonusStatsCard'
+import BuildAlert, {
+  type BuildStatus,
+} from '../TabOptimize/Components/BuildAlert'
 import MainStatSelectionCard from '../TabOptimize/Components/MainStatSelectionCard'
 import { OptCharacterCard } from '../TabOptimize/Components/OptCharacterCard'
 import OptimizationTargetSelector from '../TabOptimize/Components/OptimizationTargetSelector'
@@ -109,6 +126,17 @@ const filterOptionReducer = (
   state: Partial<FilterOption>,
   action: Partial<FilterOption>
 ) => ({ ...state, ...action })
+function initBuildStatus(): BuildStatus {
+  return {
+    type: 'inactive',
+    tested: 0,
+    failed: 0,
+    skipped: 0,
+    total: 0,
+    testedPerSecond: 0,
+    skippedPerSecond: 0,
+  }
+}
 export default function TabUpopt() {
   const { t } = useTranslation('page_character_optimize')
   const { t: tk } = useTranslation('statKey_gen')
@@ -149,16 +177,11 @@ export default function TabUpopt() {
 
   const [artsDirty, setArtsDirty] = useForceUpdate()
   /**
-   * Only register new/removal for artifact, so that changes to artifact will not cause upopt recalc.
-   * Artifact updates are captured in UpgradeOptChartCard.
-   * This makes updating an calculated artifact will not update the calculator list.(and will not change place in the list)
+   * Any artifact change can alter an artifact's best complementary build, so
+   * invalidate both the build search and the candidate calculations.
    */
   useEffect(
-    () =>
-      database.arts.followAny(
-        (_, reason) =>
-          (reason === 'new' || reason === 'remove') && setArtsDirty()
-      ),
+    () => database.arts.followAny(() => setArtsDirty()),
     [setArtsDirty, database]
   )
   const filteredArts = useMemo(() => {
@@ -252,9 +275,14 @@ export default function TabUpopt() {
     )
   }, [database, optConfig, filteredArtIdMap])
 
+  const [maxWorkers, nativeThreads, setMaxWorkers] = useNumWorkers()
   const equippedArts = useLoadoutArtifacts(loadoutDatum)
+  const [upOptCalc, setUpOptCalc] = useState<UpOptCalculatorV2>()
+  const [hasGenerated, setHasGenerated] = useState(false)
+  const [buildStatus, setBuildStatus] = useState(initBuildStatus)
+  const throwGlobalError = useGlobalError()
 
-  const upOptCalc = useMemo(() => {
+  const upOptInput = useMemo(() => {
     const {
       statFilters,
       optimizationTarget,
@@ -266,6 +294,10 @@ export default function TabUpopt() {
       upOptDefine,
       upOptDefineSubstats,
       artSetExclusion,
+      allowPartial,
+      useExcludedArts,
+      artExclusion,
+      excludedLocations,
     } = optConfig
 
     if (!optimizationTarget) return
@@ -303,61 +335,11 @@ export default function TabUpopt() {
         })
     )
 
-    const curEquipSetKeys = objKeyMap(
-      allArtifactSlotKeys,
-      (slotKey) => equippedArts[slotKey]?.setKey
-    )
-    function respectSexExclusion(art: ICachedArtifact) {
-      const newSK = { ...curEquipSetKeys }
-      newSK[art.slotKey] = art.setKey
-      const skc: Partial<Record<ArtifactSetKey, number>> = {}
-      allArtifactSlotKeys.forEach((slotKey) => {
-        const setKey = newSK[slotKey]
-        if (!setKey) return
-        if (setKey.startsWith('Prayers')) return
-        skc[setKey] = (skc[setKey] ?? 0) + 1
-      })
-      const pass = Object.entries(skc).every(([setKey, num]) => {
-        const ex = artSetExclusion[setKey as ArtSetExclusionKey]
-        if (!ex) return true
-        switch (num) {
-          case 0:
-          case 1:
-            return true
-          case 2:
-          case 3:
-            return !ex.includes(2)
-          case 4:
-          case 5:
-            return !ex.includes(4)
-          default:
-            throw Error('error in respectSetExclude: num > 5')
-        }
-      })
-      if (!pass) return false
-
-      if (!artSetExclusion['rainbow']) return true
-      const nRainbow = Object.values(skc).reduce((a, b) => a + (b % 2), 0)
-      switch (nRainbow) {
-        case 0:
-        case 1:
-          return true
-        case 2:
-        case 3:
-          return !artSetExclusion['rainbow'].includes(2)
-        case 4:
-        case 5:
-          return !artSetExclusion['rainbow'].includes(4)
-        default:
-          throw Error('error in respectSex: nRainbow > 5')
-      }
-    }
     const artifactsToConsider = filteredArts
       // retrieve the artifacts again, just incase there is an update that is not captured by UpgradeOptChartCard
       .map((art) => database.arts.get(art.id))
       .filter(notEmpty)
       .filter((art) => art.rarity === 5)
-      .filter(respectSexExclusion)
       .filter(
         (art) =>
           art.slotKey === 'flower' ||
@@ -379,9 +361,10 @@ export default function TabUpopt() {
     })
     const defineConfig = {
       enabled: upOptDefine && upOptDefineSubstats.length >= 2,
-      setKeys: (artSetKeys.length
-        ? artSetKeys
-        : [...allArtifactSetKeys]) as ArtifactSetKey[],
+      setKeys: setKeysByRarities[5].filter((setKey) => {
+        const excluded = artSetExclusion[setKey as ArtSetExclusionKey] ?? []
+        return !excluded.includes(2) || !excluded.includes(4)
+      }),
       slotKeys: slotKeys.length ? slotKeys : [...allArtifactSlotKeys],
       mainStats: [...new Set<MainStatKey>(mainStatsForDefine)],
       substats: upOptDefineSubstats,
@@ -394,14 +377,46 @@ export default function TabUpopt() {
       ({ path: [p] }) => p !== 'dyn'
     )
 
-    return new UpOptCalculatorV2(
+    const locKey = charKeyToLocCharKey(characterKey)
+    const equippableArts = database.arts.values.filter((art) => {
+      if (art.rarity !== 5) return false
+      if (!useExcludedArts && artExclusion.includes(art.id)) return false
+      if (
+        art.location &&
+        art.location !== locKey &&
+        excludedLocations.includes(art.location)
+      )
+        return false
+      return (
+        art.slotKey === 'flower' ||
+        art.slotKey === 'plume' ||
+        !mainStatKeys[art.slotKey]?.length ||
+        mainStatKeys[art.slotKey]?.includes(art.mainStatKey)
+      )
+    })
+    const problem: OptProblemInput = {
+      arts: compactArtifacts(equippableArts, 0, allowPartial),
+      optimizationTarget: nodes[0],
+      constraints: nodes.slice(1).map((value, i) => ({
+        value,
+        min: valueFilter[i].minimum,
+      })),
+      exclusion: artSetExclusion,
+      topN: 1,
+      keepBestPerArtifact: true,
+    }
+
+    return {
       nodes,
-      [-Infinity, ...valueFilter.map((x) => x.minimum)],
-      equippedArts,
+      thresholds: [-Infinity, ...valueFilter.map((x) => x.minimum)],
       artifactsToConsider,
-      { enabled: upOptReshape, minTotal: upOptReshapeRolls as 2 | 3 | 4 },
-      defineConfig
-    )
+      reshapeConfig: {
+        enabled: upOptReshape,
+        minTotal: upOptReshapeRolls as 2 | 3 | 4,
+      },
+      defineConfig,
+      problem,
+    }
     /**
      * WARNING:
      * Due to the violatile nature of the calculations above,
@@ -418,10 +433,119 @@ export default function TabUpopt() {
     activeCharKey,
     characterKey,
     filteredArts,
-    artSetKeys,
     slotKeys,
-    equippedArts,
   ])
+
+  const solveId = useRef(0)
+  const cancelToken = useRef(() => {})
+  const generateBuilds = useCallback(() => {
+    const id = ++solveId.current
+    setUpOptCalc(undefined)
+    setHasGenerated(false)
+    if (!upOptInput) return
+    const { problem } = upOptInput
+    if (Object.values(problem.arts.values).some((arts) => !arts.length)) {
+      setHasGenerated(true)
+      return
+    }
+
+    const status: Omit<BuildStatus, 'type'> = {
+      tested: 0,
+      failed: 0,
+      skipped: 0,
+      total: 0,
+      testedPerSecond: 0,
+      skippedPerSecond: 0,
+      startTime: performance.now(),
+    }
+    setBuildStatus({ type: 'active', ...status })
+    const timer = setInterval(
+      () => setBuildStatus({ type: 'active', ...status }),
+      100
+    )
+    const solver = new GOSolver(problem, status, maxWorkers)
+    let cancelled = false
+    cancelToken.current = () => {
+      if (cancelled) return
+      cancelled = true
+      ++solveId.current
+      clearInterval(timer)
+      solver.cancel(new Error('Artifact Upgrader search cancelled'))
+      setBuildStatus({
+        type: 'inactive',
+        ...status,
+        finishTime: performance.now(),
+      })
+    }
+
+    solver
+      .solve()
+      .then((results) => {
+        if (id !== solveId.current) return
+        const bestByArtifact = new Map<string, SolverBuild>()
+        for (const build of results.flatMap((result) => result.builds))
+          for (const artifactId of build.artifactIds) {
+            const old = bestByArtifact.get(artifactId)
+            if (!old || old.value < build.value)
+              bestByArtifact.set(artifactId, build)
+          }
+        const best = results
+          .map(({ bestBuild }) => bestBuild)
+          .filter(notEmpty)
+          .reduce<SolverBuild | undefined>(
+            (old, build) => (!old || old.value < build.value ? build : old),
+            undefined
+          )
+        if (!best) return
+        const toBuild = (build: SolverBuild) =>
+          objKeyMap(allArtifactSlotKeys, (slotKey) =>
+            build.artifactIds
+              .map((artifactId) => database.arts.get(artifactId))
+              .find((art) => art?.slotKey === slotKey)
+          )
+        const builds = new Map(
+          [...bestByArtifact].map(([artifactId, build]) => [
+            artifactId,
+            toBuild(build),
+          ])
+        )
+        setUpOptCalc(
+          new UpOptCalculatorV2(
+            upOptInput.nodes,
+            upOptInput.thresholds,
+            toBuild(best),
+            equippedArts,
+            builds,
+            upOptInput.artifactsToConsider,
+            upOptInput.reshapeConfig,
+            upOptInput.defineConfig
+          )
+        )
+        setHasGenerated(true)
+      })
+      .catch((error) => {
+        if (!cancelled && id === solveId.current) throwGlobalError(error)
+      })
+      .finally(() => {
+        if (id !== solveId.current) return
+        clearInterval(timer)
+        setHasGenerated(true)
+        setBuildStatus({
+          type: 'inactive',
+          ...status,
+          finishTime: performance.now(),
+        })
+        cancelToken.current = () => {}
+      })
+  }, [upOptInput, maxWorkers, database, throwGlobalError, equippedArts])
+
+  useEffect(() => {
+    cancelToken.current()
+    setUpOptCalc(undefined)
+    setHasGenerated(false)
+    setBuildStatus(initBuildStatus())
+  }, [upOptInput])
+  useEffect(() => () => cancelToken.current(), [])
 
   // Paging logic
   const [pageIdex, setpageIdex] = useState(0)
@@ -721,11 +845,65 @@ export default function TabUpopt() {
                     optimizationTarget: target,
                   })
                 }
-                disabled={false}
+                disabled={buildStatus.type === 'active'}
                 targetSelectorModalProps={{
                   excludeSections: ['character', 'bonusStats', 'teamBuff'],
                 }}
               />
+              <DropdownButton
+                disabled={buildStatus.type === 'active'}
+                title={
+                  <Trans t={t} i18nKey="thread" count={maxWorkers}>
+                    {{ count: maxWorkers }} Threads
+                  </Trans>
+                }
+              >
+                <MenuItem>
+                  <Typography variant="caption" color="info.main">
+                    {t('threadDropdownDesc')}
+                  </Typography>
+                </MenuItem>
+                {range(1, nativeThreads)
+                  .reverse()
+                  .map((workerCount) => (
+                    <MenuItem
+                      key={workerCount}
+                      onClick={() => setMaxWorkers(workerCount)}
+                    >
+                      <Trans t={t} i18nKey="thread" count={workerCount}>
+                        {{ count: workerCount }} Threads
+                      </Trans>
+                    </MenuItem>
+                  ))}
+              </DropdownButton>
+              <BootstrapTooltip
+                placement="top"
+                title={!optimizationTarget ? t('selectTargetFirst') : ''}
+              >
+                <span>
+                  <Button
+                    disabled={buildStatus.type === 'inactive' && !upOptInput}
+                    color={buildStatus.type === 'active' ? 'error' : 'success'}
+                    onClick={
+                      buildStatus.type === 'active'
+                        ? () => cancelToken.current()
+                        : generateBuilds
+                    }
+                    startIcon={
+                      buildStatus.type === 'active' ? (
+                        <CloseIcon />
+                      ) : (
+                        <TrendingUpIcon />
+                      )
+                    }
+                    sx={{ borderRadius: '0px 4px 4px 0px' }}
+                  >
+                    {buildStatus.type === 'active'
+                      ? t('generateButton.cancel')
+                      : t('generateButton.generateBuilds')}
+                  </Button>
+                </span>
+              </BootstrapTooltip>
             </ButtonGroup>
             <Alert severity="info">
               <Trans t={t} i18nKey={'upOptInfo'}>
@@ -733,20 +911,15 @@ export default function TabUpopt() {
                 to boost the Optimization Target's value, guiding you to
                 artifacts worth leveling up.
                 <br />
-                As it only swaps one artifact at a time, for the best overall
-                build across all artifacts, use the main artifact optimizer.
+                Each candidate is evaluated with its best equippable build.
               </Trans>
             </Alert>
-            {Object.values(equippedArts).some((a) => !a) && (
-              <Alert severity="warning">
-                <Trans t={t} i18nKey={'upOptEmptyBuild'}>
-                  You're using a partially empty build. Since the Artifact
-                  Upgrader only swaps artifacts individually, completing a set
-                  is unlikely. It's recommended to begin with a base build,
-                  preferably generated from the main Optimizer.
-                </Trans>
-              </Alert>
-            )}
+            <BuildAlert
+              status={buildStatus}
+              characterName={
+                <CharacterName characterKey={characterKey} gender={gender} />
+              }
+            />
             <CardThemed bgt="light">
               <CardContent>
                 <Grid container spacing={1}>
@@ -769,9 +942,11 @@ export default function TabUpopt() {
                 allowUpload
               />
             </Suspense>
-            {!upOptCalc?.candidates.length && (
-              <Alert severity="warning">{t('upOptNoResults')}</Alert>
-            )}
+            {hasGenerated &&
+              buildStatus.type === 'inactive' &&
+              !upOptCalc?.candidates.length && (
+                <Alert severity="warning">{t('upOptNoResults')}</Alert>
+              )}
             <Suspense
               fallback={
                 <Skeleton

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
@@ -4,6 +4,7 @@ import {
   type ArtifactSlotKey,
   type MainStatKey,
   type SubstatKey,
+  allArtifactSlotKeys,
   allSubstatKeys,
   artSlotMainKeys,
 } from '@genshin-optimizer/gi/consts'
@@ -26,10 +27,9 @@ import type {
   Objective,
 } from '@genshin-optimizer/gi/upopt'
 import { type OptNode, optimize, precompute } from '@genshin-optimizer/gi/wr'
-import { removeSetKeys } from './formulaUtils'
 import { erf } from './mathUtil'
 
-type Build = Record<ArtifactSlotKey, ICachedArtifact | undefined>
+export type UpOptBuild = Record<ArtifactSlotKey, ICachedArtifact | undefined>
 type MarkovTree = { p: number; n: MarkovNode }[]
 type EvaluatedMarkovTree = {
   result: { p: number; upAvg: number; lower: number; upper: number }
@@ -37,6 +37,7 @@ type EvaluatedMarkovTree = {
   info: UpOptInfo
   evalMode: MarkovNode['type']
   id: string
+  build: UpOptBuild
   chartData?: {
     left: number
     right: number
@@ -98,29 +99,38 @@ function shouldYieldToUi(lastYield: number) {
 }
 
 export class UpOptCalculatorV2 {
-  build: Build
+  build: UpOptBuild
+  thresholdBuild: UpOptBuild
+  builds: Map<string, UpOptBuild>
   obj: Objective
   candidates: EvaluatedMarkovTree[] = []
   fixedIx = 0
 
   /** Serializes exact-calc work so candidates are refined one at a time. */
   private exactQueue: Promise<unknown> = Promise.resolve()
+  private definitionBuildCache = new Map<string, UpOptBuild[]>()
 
   constructor(
     nodes: OptNode[],
     thresholds: number[],
-    build: Build,
+    build: UpOptBuild,
+    thresholdBuild: UpOptBuild,
+    builds: Map<string, UpOptBuild>,
     artifacts: ICachedArtifact[],
     reshapeConfig: ReshapeConfig,
     defineConfig: DefineConfig
   ) {
     this.build = build
-    // Remove setKey thresholds that are always active/inactive, then optimize the formula tree.
-    nodes = removeSetKeys(nodes, build)
+    this.thresholdBuild = thresholdBuild
+    this.builds = builds
+    // Set thresholds cannot be folded because candidates may use different
+    // complementary builds.
     nodes = optimize(nodes, {})
 
     // Populate threshold[0] with current value. It's a bit convoluted :/
-    const buildAsList = Object.values(build).filter((v) => v !== undefined)
+    const buildAsList = Object.values(thresholdBuild).filter(
+      (v) => v !== undefined
+    )
     const artsBySlot = compactArtifacts(buildAsList, 0, false)
     const evalFn = precompute(nodes, artsBySlot.base, (f) => f.path[1], 5)
     const baseBuild = Object.values(artsBySlot.values).map((v) =>
@@ -131,6 +141,7 @@ export class UpOptCalculatorV2 {
     // Create objective function & set up candidates.
     this.obj = makeObjective(nodes, thresholds)
     artifacts.forEach((art) => {
+      if (!builds.has(art.id)) return
       this.tryLevelUp(art)
       if (reshapeConfig.enabled) this.tryReshape(art, reshapeConfig.minTotal)
     })
@@ -148,9 +159,14 @@ export class UpOptCalculatorV2 {
   }
 
   fromLevelUpInfo(info: LevelUpInfo, art: ICachedArtifact) {
+    const { build, evaluation } = this.bestBuildEvaluation(
+      (build) => this.evaluateNodes(levelUpArtifact(art, build)),
+      art.id
+    )
     return {
-      ...this.evaluateNodes(levelUpArtifact(art, this.build)),
+      ...evaluation,
       info,
+      build,
       evalMode: 'substat' as const,
       id: `${this.candidates.length}`,
     }
@@ -178,24 +194,85 @@ export class UpOptCalculatorV2 {
   }
 
   fromReshapeInfo(info: ReshapeInfo, art: ICachedArtifact) {
+    const { build, evaluation } = this.bestBuildEvaluation(
+      (build) =>
+        this.evaluateNodes(
+          dustReshape(art, build, info.affixes, info.mintotal)
+        ),
+      art.id
+    )
     return {
-      ...this.evaluateNodes(
-        dustReshape(art, this.build, info.affixes, info.mintotal)
-      ),
+      ...evaluation,
       info,
+      build,
       evalMode: 'substat' as const,
       id: `${this.candidates.length}`,
     }
   }
 
-  tryDefine({ setKeys, slotKeys, mainStats, substats }: DefineConfig) {
-    setKeys = setKeys.filter((setKey) => this.obj.allReadKeys.includes(setKey))
-    if (!setKeys.length) {
-      console.warn(
-        'No useful set keys available for definition; picking Glad as default'
+  private bestBuildEvaluation(
+    evaluate: (
+      build: UpOptBuild
+    ) => Pick<EvaluatedMarkovTree, 'tree' | 'result'>,
+    artifactId: string
+  ) {
+    const recommended = this.builds.get(artifactId) ?? this.build
+    const options = [recommended]
+    if (
+      Object.values(this.thresholdBuild).some(
+        (artifact) => artifact?.id === artifactId
+      ) &&
+      this.thresholdBuild !== recommended
+    )
+      options.push(this.thresholdBuild)
+
+    return options
+      .map((build) => ({ build, evaluation: evaluate(build) }))
+      .reduce((best, candidate) =>
+        compare(candidate.evaluation, best.evaluation) < 0 ? candidate : best
       )
-      setKeys = ['GladiatorsFinale'] // Default to something so user sees some results
+  }
+
+  private bestDefinitionEvaluation(info: DefineInfo) {
+    const cacheKey = `${info.setKey}|${info.slotKey}|${info.mainStatKey}`
+    let options = this.definitionBuildCache.get(cacheKey)
+    if (!options) {
+      const seen = new Set<string>()
+      options = [
+        this.build,
+        this.thresholdBuild,
+        ...[...this.builds.values()].filter((build) => {
+          const artifact = build[info.slotKey]
+          return (
+            artifact?.setKey === info.setKey &&
+            artifact.mainStatKey === info.mainStatKey
+          )
+        }),
+      ].filter((build) => {
+        const key = allArtifactSlotKeys
+          .map((slotKey) => build[slotKey]?.id ?? '')
+          .join('|')
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+      this.definitionBuildCache.set(cacheKey, options)
     }
+
+    return options
+      .map((build) => ({
+        build,
+        evaluation: this.evaluateNodes(
+          elixirDefinition({ ...info, prob_4line: 0.34 }, build)
+        ),
+      }))
+      .reduce((best, candidate) =>
+        compare(candidate.evaluation, best.evaluation) < 0 ? candidate : best
+      )
+  }
+
+  tryDefine({ setKeys, slotKeys, mainStats, substats }: DefineConfig) {
+    if (!setKeys.length) return
     setKeys.forEach((setKey) => {
       slotKeys.forEach((slotKey) => {
         artSlotMainKeys[slotKey]
@@ -223,11 +300,11 @@ export class UpOptCalculatorV2 {
   }
 
   fromDefineInfo(info: DefineInfo) {
+    const { build, evaluation } = this.bestDefinitionEvaluation(info)
     return {
-      ...this.evaluateNodes(
-        elixirDefinition({ ...info, prob_4line: 0.34 }, this.build)
-      ),
+      ...evaluation,
       info,
+      build,
       evalMode: 'substat' as const,
       id: `${this.candidates.length}`,
     }
@@ -354,6 +431,7 @@ export class UpOptCalculatorV2 {
       result: accumulateEvaluations(evaluated),
       evalMode: 'values',
       info: this.candidates[ix].info,
+      build: this.candidates[ix].build,
     }
     return true
   }
@@ -429,7 +507,10 @@ export class UpOptCalculatorV2 {
   }
 }
 
-function compare(a: EvaluatedMarkovTree, b: EvaluatedMarkovTree) {
+function compare(
+  a: Pick<EvaluatedMarkovTree, 'tree' | 'result'>,
+  b: Pick<EvaluatedMarkovTree, 'tree' | 'result'>
+) {
   const scoreA = a.result.p * a.result.upAvg
   const scoreB = b.result.p * b.result.upAvg
   if (scoreA > 1e-5 || scoreB > 1e-5) return scoreB - scoreA

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.ts
@@ -56,11 +56,14 @@ export class BNBSplitWorker implements SplitWorker {
   callback: (interim: Interim) => void
 
   constructor(
-    { arts, optTarget, constraints, topN }: Setup,
+    { arts, optTarget, constraints, topN, keepBestPerArtifact }: Setup,
     callback: (interim: Interim) => void
   ) {
     this.arts = arts
-    this.min = [-Infinity, ...constraints.map((x) => x.min)]
+    this.min = [
+      -Infinity,
+      ...constraints.map((x) => (keepBestPerArtifact ? -Infinity : x.min)),
+    ]
     this.nodes = [optTarget, ...constraints.map((x) => x.value)]
     this.callback = callback
     this.topN = topN

--- a/libs/gi/solver/src/GOSolver/BackgroundWorker.ts
+++ b/libs/gi/solver/src/GOSolver/BackgroundWorker.ts
@@ -44,8 +44,8 @@ async function handleEvent(e: MessageEvent<WorkerCommand>): Promise<void> {
     }
     case 'finalize': {
       computeWorker.refresh(true)
-      const { builds, plotData } = computeWorker
-      postMessage({ resultType: 'finalize', builds, plotData })
+      const { builds, bestBuild, plotData } = computeWorker
+      postMessage({ resultType: 'finalize', builds, bestBuild, plotData })
       break
     }
     case 'count': {

--- a/libs/gi/solver/src/GOSolver/ComputeWorker.test.ts
+++ b/libs/gi/solver/src/GOSolver/ComputeWorker.test.ts
@@ -1,0 +1,58 @@
+import { allArtifactSlotKeys } from '@genshin-optimizer/gi/consts'
+import { customRead } from '@genshin-optimizer/gi/wr'
+import type { ArtifactsBySlot, RequestFilter } from '../common'
+import { ComputeWorker } from './ComputeWorker'
+
+describe('ComputeWorker keepBestPerArtifact', () => {
+  test('retains the best valid build containing every artifact', () => {
+    const arts: ArtifactsBySlot = {
+      base: { x: 0, y: 0 },
+      values: {
+        flower: [
+          { id: 'flower-low', values: { x: 0 } },
+          { id: 'flower-high', values: { x: 1, y: 1 } },
+        ],
+        plume: [
+          { id: 'plume-low', values: { x: 0 } },
+          { id: 'plume-high', values: { x: 1 } },
+        ],
+        sands: [{ id: 'sands', values: { x: 1 } }],
+        goblet: [{ id: 'goblet', values: { x: 1 } }],
+        circlet: [{ id: 'circlet', values: { x: 1 } }],
+      },
+    }
+    const worker = new ComputeWorker(
+      {
+        arts,
+        optTarget: customRead(['dyn', 'x']),
+        constraints: [{ value: customRead(['dyn', 'y']), min: 1 }],
+        plotBase: undefined,
+        topN: 1,
+        keepBestPerArtifact: true,
+        command: 'setup',
+      },
+      () => {}
+    )
+    const filter = Object.fromEntries(
+      allArtifactSlotKeys.map((slotKey) => [
+        slotKey,
+        { kind: 'id', ids: new Set(arts.values[slotKey].map(({ id }) => id)) },
+      ])
+    ) as RequestFilter
+
+    worker.compute(filter)
+    worker.refresh(true)
+
+    const best = Object.fromEntries(
+      worker.builds.flatMap((build) =>
+        build.artifactIds.map((artifactId) => [artifactId, build.value])
+      )
+    )
+    expect(best['flower-low']).toBe(4)
+    expect(best['flower-high']).toBe(5)
+    expect(best['plume-low']).toBe(4)
+    expect(best['plume-high']).toBe(5)
+    expect(best['circlet']).toBe(5)
+    expect(worker.bestBuild?.value).toBe(5)
+  })
+})

--- a/libs/gi/solver/src/GOSolver/ComputeWorker.ts
+++ b/libs/gi/solver/src/GOSolver/ComputeWorker.ts
@@ -12,6 +12,8 @@ import type { Interim, Setup } from '../type'
 
 export class ComputeWorker {
   builds: SolverBuild[] = []
+  bestBuildByArtifact: Record<string, SolverBuild> | undefined
+  bestBuild: SolverBuild | undefined
   buildValues: number[] | undefined = undefined
   plotData: PlotData | undefined
   threshold = -Infinity
@@ -24,12 +26,20 @@ export class ComputeWorker {
   callback: (interim: Interim) => void
 
   constructor(
-    { arts, optTarget, constraints, plotBase, topN }: Setup,
+    {
+      arts,
+      optTarget,
+      constraints,
+      plotBase,
+      topN,
+      keepBestPerArtifact,
+    }: Setup,
     callback: (interim: Interim) => void
   ) {
     this.arts = arts
     this.min = constraints.map((x) => x.min)
     this.topN = topN
+    if (keepBestPerArtifact) this.bestBuildByArtifact = {}
     this.callback = callback
     this.nodes = constraints.map((x) => x.value)
     this.nodes.push(optTarget)
@@ -52,7 +62,7 @@ export class ComputeWorker {
     let nodes = this.nodes
     ;({ nodes, arts: preArts } = pruneAll(
       nodes,
-      min,
+      this.bestBuildByArtifact ? min.map(() => -Infinity) : min,
       preArts,
       this.topN,
       {},
@@ -81,9 +91,25 @@ export class ComputeWorker {
     const permute = (i: number) => {
       if (i < 0) {
         const result = compute(buffer)
-        if (min.every((m, i) => m <= result[i])) {
-          const value = result[min.length],
-            { builds, plotData } = this
+        const meetsConstraints = min.every((m, i) => m <= result[i])
+        const value = result[min.length],
+          { builds, plotData } = this
+        if (this.bestBuildByArtifact) {
+          const build: SolverBuild = {
+            value,
+            artifactIds: buffer.map((x) => x.id).filter((id) => id),
+          }
+          for (const id of build.artifactIds) {
+            const old = this.bestBuildByArtifact[id]
+            if (!old || old.value < value) this.bestBuildByArtifact[id] = build
+          }
+          if (
+            meetsConstraints &&
+            (!this.bestBuild || this.bestBuild.value < value)
+          )
+            this.bestBuild = build
+          if (!meetsConstraints) count.failed += 1
+        } else if (meetsConstraints) {
           let build: SolverBuild | undefined
           if (value >= this.threshold) {
             build = {
@@ -122,6 +148,10 @@ export class ComputeWorker {
   }
 
   refresh(force: boolean): void {
+    if (this.bestBuildByArtifact) {
+      if (force) this.builds = Object.values(this.bestBuildByArtifact)
+      return
+    }
     const { topN } = this
     if (Object.keys(this.plotData ?? {}).length >= 100000)
       this.plotData = mergePlot([this.plotData!])

--- a/libs/gi/solver/src/GOSolver/GOSolver.ts
+++ b/libs/gi/solver/src/GOSolver/GOSolver.ts
@@ -89,6 +89,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
     topN,
     exclusion,
     constraints,
+    keepBestPerArtifact,
   }: OptProblemInput): Setup {
     constraints = constraints.filter((x) => x.min > -Infinity)
 
@@ -105,7 +106,9 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
       reaffine: true,
       pruneArtRange: true,
       pruneNodeRange: true,
-      pruneOrder: true,
+      // Dominated artifacts can still be part of the best build containing
+      // that artifact, so they must be retained for Artifact Upgrader.
+      pruneOrder: !keepBestPerArtifact,
     }))
     nodes = optimize(nodes, {}, (_) => false)
 
@@ -118,6 +121,7 @@ export class GOSolver extends WorkerCoordinator<WorkerCommand, WorkerResult> {
       optTarget,
       plotBase,
       topN,
+      keepBestPerArtifact,
       constraints: nodes.map((value, i) => ({ value, min: minimums[i] })),
     }
   }

--- a/libs/gi/solver/src/type.d.ts
+++ b/libs/gi/solver/src/type.d.ts
@@ -15,6 +15,8 @@ export type OptProblemInput = {
 
   topN: number
   plotBase?: OptNode
+  /** Keep the best build containing every artifact instead of only the global top N. */
+  keepBestPerArtifact?: boolean
 }
 
 export type WorkerCommand =
@@ -35,6 +37,7 @@ export interface Setup {
   constraints: { value: OptNode; min: number }[]
   plotBase: OptNode | undefined
   topN: number
+  keepBestPerArtifact?: boolean
 }
 export interface Split {
   command: 'split'
@@ -71,6 +74,7 @@ export interface CountResult {
 export interface FinalizeResult {
   resultType: 'finalize'
   builds: SolverBuild[]
+  bestBuild?: SolverBuild
   plotData?: PlotData | undefined
 }
 export interface Interim {


### PR DESCRIPTION
## Describe your changes
Expands upOpt to consider more than just the currently equipped build.

The optimizer runs first on the player's inventory and keeps a small set of promising builds (essentially running the optimizer). Then upOpt generates one level-up, reshape, or Define artifact at a time and substitutes it into those builds for evaluation.

<img width="1518" height="1263" alt="image" src="https://github.com/user-attachments/assets/f6fb0e2b-e431-4fc3-b101-dcdfec01581c" />

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Artifact Upgrader now evaluates each candidate using its best equippable build.
  - Recommendations display a complete artifact build across all slots.
  - Applying a recommendation equips or saves the full recommended build at once.
  - Added support for generating and cancelling optimization results.
  - Candidate generation now includes every enabled artifact set and respects configured slots, stats, and substat pairs.

- **Bug Fixes**
  - Artifact changes, including follow-status updates, now trigger recalculation.
  - Updated chart labeling to distinguish the recommended build from the current build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->