### PR TITLE
Replace maintain-one-comment with find-comment and create-or-update-comment

### DIFF
--- a/.github/workflows/clean-pr.yml
+++ b/.github/workflows/clean-pr.yml
@@ -58,9 +58,11 @@ jobs:
         with:
           issue-number: ${{ steps.build-info.outputs.deploy_path }}
           comment-author: 'github-actions[bot]'
+          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.build-info.outputs.deploy_path }}
           body: |
             [${{ steps.output-date.outputs.date }}] - Deleted deployment

--- a/.github/workflows/clean-pr.yml
+++ b/.github/workflows/clean-pr.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           issue-number: ${{ steps.build-info.outputs.deploy_path }}
           comment-author: 'github-actions[bot]'
-          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         with:

--- a/.github/workflows/clean-pr.yml
+++ b/.github/workflows/clean-pr.yml
@@ -52,11 +52,16 @@ jobs:
       - name: Output date
         id: output-date
         run: echo "date=$(date -u)" >> $GITHUB_OUTPUT
-      # - name: Maintain comment
-      #   uses: actions-cool/maintain-one-comment@v3
-      #   if: github.event_name != 'workflow_dispatch'
-      #   with:
-      #     body: |
-      #       [${{ steps.output-date.outputs.date }}] - Deleted deployment
-      #     body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
-      #     update-mode: 'append'
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ steps.build-info.outputs.deploy_path }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Deployed
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ steps.build-info.outputs.deploy_path }}
+          body: |
+            [${{ steps.output-date.outputs.date }}] - Deleted deployment

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -98,10 +98,12 @@ jobs:
         with:
           issue-number: ${{ steps.vars.outputs.deployment_name }}
           comment-author: 'github-actions[bot]'
+          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         if: ${{ steps.vars.outputs.deployment_name != 'beta' }}
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.vars.outputs.deployment_name }}
           body: |
             [${{ steps.vars.outputs.frontend_name }}] [${{ steps.output-date2.outputs.date }}] - ${{ steps.export-url.outputs.url }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -91,13 +91,18 @@ jobs:
         run: echo "date=$(date -u)" >> $GITHUB_OUTPUT
       - name: Log Info
         run: echo "[${{ steps.vars.outputs.frontend_name }}] [${{ steps.output-date2.outputs.date }}] - ${{ steps.export-url.outputs.url }}"
-      # - name: Maintain comment
-      #   uses: actions-cool/maintain-one-comment@v3
-      #   if: ${{ steps.vars.outputs.deployment_name != 'beta' }}
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     number: ${{ steps.vars.outputs.deployment_name }}
-      #     body: |
-      #       [${{ steps.vars.outputs.frontend_name }}] [${{ steps.output-date2.outputs.date }}] - ${{ steps.export-url.outputs.url }}
-      #     body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
-      #     update-mode: 'append'
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        if: ${{ steps.vars.outputs.deployment_name != 'beta' }}
+        with:
+          issue-number: ${{ steps.vars.outputs.deployment_name }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Deployed
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        if: ${{ steps.vars.outputs.deployment_name != 'beta' }}
+        with:
+          issue-number: ${{ steps.vars.outputs.deployment_name }}
+          body: |
+            [${{ steps.vars.outputs.frontend_name }}] [${{ steps.output-date2.outputs.date }}] - ${{ steps.export-url.outputs.url }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -98,7 +98,6 @@ jobs:
         with:
           issue-number: ${{ steps.vars.outputs.deployment_name }}
           comment-author: 'github-actions[bot]'
-          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         if: ${{ steps.vars.outputs.deployment_name != 'beta' }}

--- a/.github/workflows/deploy-somnia.yml
+++ b/.github/workflows/deploy-somnia.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           issue-number: ${{ needs.set-env.outputs.prNumber }}
           comment-author: 'github-actions[bot]'
-          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         if: ${{ needs.set-env.outputs.prNumber != '' }}

--- a/.github/workflows/deploy-somnia.yml
+++ b/.github/workflows/deploy-somnia.yml
@@ -73,13 +73,18 @@ jobs:
       - name: Output date
         id: output-date
         run: echo "date=$(date -u)" >> $GITHUB_OUTPUT
-      # - name: Maintain comment
-      #   uses: actions-cool/maintain-one-comment@v3
-      #   if: ${{ needs.set-env.outputs.prNumber != '' }}
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     number: ${{ needs.set-env.outputs.prNumber }}
-      #     body: |
-      #       [${{ needs.set-env.outputs.env }}] [${{ steps.output-date.outputs.date }}] - Deployed ${{ needs.set-env.outputs.ref }} to ${{ needs.set-env.outputs.env }}" >> $GITHUB_OUTPUT
-      #     body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
-      #     update-mode: 'append'
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        if: ${{ needs.set-env.outputs.prNumber != '' }}
+        with:
+          issue-number: ${{ needs.set-env.outputs.prNumber }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Deployed
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        if: ${{ needs.set-env.outputs.prNumber != '' }}
+        with:
+          issue-number: ${{ needs.set-env.outputs.prNumber }}
+          body: |
+            [${{ needs.set-env.outputs.env }}] [${{ steps.output-date.outputs.date }}] - Deployed ${{ needs.set-env.outputs.ref }} to ${{ needs.set-env.outputs.env }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-somnia.yml
+++ b/.github/workflows/deploy-somnia.yml
@@ -80,10 +80,12 @@ jobs:
         with:
           issue-number: ${{ needs.set-env.outputs.prNumber }}
           comment-author: 'github-actions[bot]'
+          body-includes: Deployed
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5
         if: ${{ needs.set-env.outputs.prNumber != '' }}
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ needs.set-env.outputs.prNumber }}
           body: |
             [${{ needs.set-env.outputs.env }}] [${{ steps.output-date.outputs.date }}] - Deployed ${{ needs.set-env.outputs.ref }} to ${{ needs.set-env.outputs.env }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-somnia.yml
+++ b/.github/workflows/deploy-somnia.yml
@@ -40,8 +40,6 @@ jobs:
     environment:
       name: ${{ needs.set-env.outputs.env }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
-    permissions:
-      id-token: write # This is required for requesting the JWT
     if: ${{ github.event.workflow_run.conclusion == 'success' && (needs.set-env.outputs.shouldDeploy == 'true' || needs.set-env.outputs.env == 'somnia-prod') }}
     steps:
       - name: Download build artifact
@@ -88,4 +86,4 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ needs.set-env.outputs.prNumber }}
           body: |
-            [${{ needs.set-env.outputs.env }}] [${{ steps.output-date.outputs.date }}] - Deployed ${{ needs.set-env.outputs.ref }} to ${{ needs.set-env.outputs.env }}" >> $GITHUB_OUTPUT
+            [${{ needs.set-env.outputs.env }}] [${{ steps.output-date.outputs.date }}] - Deployed ${{ needs.set-env.outputs.ref }} to ${{ needs.set-env.outputs.env }}


### PR DESCRIPTION
## Describe your changes

Add back comment maintenance in the action using a different set of actions

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Tested here https://github.com/nguyentvan7/genshin-optimizer/pull/60

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment workflows now reliably locate the existing deployment status comment and create or update it, preventing duplicate or stale entries.
  * Updated comments reflect the current environment, deployed ref, and UTC timestamp.
  * Frontend deployments also include the published GitHub Pages URL.
* **Improvements**
  * Deletion runs now update the same status comment with a “deleted deployment” notice and UTC timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->