### PR TITLE
Fix per-hit buffs being multiplied by 3

### DIFF
--- a/libs/zzz/formula/src/data/char/util.ts
+++ b/libs/zzz/formula/src/data/char/util.ts
@@ -99,11 +99,12 @@ export function dmgDazeAndAnom(
   const anom = arg.cond ? cmpNE(arg.cond, '', anomBase) : anomBase
   return [
     stat === 'sheerForce'
-      ? customSheerDmg(name, dmgTag, dmg, arg, ...extra)
-      : customDmg(name, dmgTag, dmg, arg, ...extra),
-    customDaze(name, dmgTag, daze, arg, ...extra),
-    // TODO: No clue if this is right
-    customAnomalyBuildup(name, dmgTag, anom, arg, ...extra),
+      ? customSheerDmg(name, dmgTag, dmg, arg)
+      : customDmg(name, dmgTag, dmg, arg),
+    customDaze(name, dmgTag, daze, arg),
+    customAnomalyBuildup(name, dmgTag, anom, arg),
+    // Apply buffs one time, since all of these custom instances will share a name
+    extra.map(({ tag, value }) => ({ tag: { ...tag, name }, value })),
   ]
 }
 
@@ -150,19 +151,19 @@ export function dmgDazeAndAnomMerge(
   )
   return [
     stat === 'sheerForce'
-      ? customSheerDmg(name, dmgTag, dmgBase, arg, ...extra)
-      : customDmg(name, dmgTag, dmgBase, arg, ...extra),
-    customDaze(name, dmgTag, dazeBase, arg, ...extra),
-    // TODO: No clue if this is right
+      ? customSheerDmg(name, dmgTag, dmgBase, arg)
+      : customDmg(name, dmgTag, dmgBase, arg),
+    customDaze(name, dmgTag, dazeBase, arg),
     customAnomalyBuildup(
       name,
       dmgTag,
       constant(
         skillParam.reduce((acc, sp) => acc + sp.AttributeInfliction, 0) / 100
       ),
-      arg,
-      ...extra
+      arg
     ),
+    // Apply buffs one time, since all of these custom instances will share a name
+    extra.map(({ tag, value }) => ({ tag: { ...tag, name }, value })),
   ]
 }
 


### PR DESCRIPTION
## Describe your changes

After #3207, names for dmg/daze/anom inside pando were made to be the same, but we still applied `extra` buffs to the name on each dmg/daze/anom registration, effectively multiplying all `extra` buffs by 3. This registers the buffs a single time now instead.

## Issue or discord link

- https://discord.com/channels/785153694478893126/1252702983561543750/1531078728992555028

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extra buffs being applied multiple times in damage, daze, and anomaly calculations.
  * Ensured additional buffs are now applied exactly once across combined formula results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->