### PR TITLE
Toofless/reshape initial value ui2

### DIFF
--- a/libs/gi/db/src/Database/DataManagers/ArtifactDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/ArtifactDataManager.ts
@@ -407,7 +407,29 @@ export function cachedArtifact(
       }
       substat.efficiency = efficiency(value, key)
 
-      const possibleRolls = getSubstatRolls(key, value, rarity)
+      let possibleRolls = getSubstatRolls(key, value, rarity)
+      // Pin the recorded initial roll as the first roll. If the initial value can't
+      // be applied to the current value (e.g. the value was just edited and `initialValue`
+      // hasn't been reconciled yet), fall back to any assumed decomposition.
+      if (substat.initialValue !== undefined && possibleRolls.length) {
+        const accurateValue = possibleRolls[0].reduce((a, b) => a + b, 0)
+        const ivAccurateValue = getSubstatRolls(
+          key,
+          substat.initialValue,
+          rarity
+        )[0]?.[0]
+        const lookupValue =
+          ivAccurateValue !== undefined ? accurateValue - ivAccurateValue : 0
+
+        if (ivAccurateValue !== undefined && lookupValue > 1e-3) {
+          const remainingRolls = getSubstatRolls(key, lookupValue, rarity)
+          if (remainingRolls.length)
+            possibleRolls = remainingRolls.map((roll) => [
+              ivAccurateValue,
+              ...roll,
+            ])
+        }
+      }
 
       if (possibleRolls.length) {
         // Valid Substat

--- a/libs/gi/localization/assets/locales/en/artifact.json
+++ b/libs/gi/localization/assets/locales/en/artifact.json
@@ -22,7 +22,8 @@
       "eff": "RV: <1></1>",
       "noSubstat": "Empty",
       "substatFormat": "Substat {{value}}",
-      "nextRolls": "Next rolls:"
+      "nextRolls": "Next rolls:",
+      "initialRoll": "Initial roll"
     },
     "preview": "Artifact Preview",
     "dupArt": "Duplicate artifact detected",

--- a/libs/gi/ui/src/components/artifact/ArtifactCard.tsx
+++ b/libs/gi/ui/src/components/artifact/ArtifactCard.tsx
@@ -33,6 +33,7 @@ import {
   getMainStatDisplayStr,
   getSubstatValue,
   getSubstatValuesPercent,
+  sortedSubstatRolls,
 } from '@genshin-optimizer/gi/util'
 import { Lock, LockOpen } from '@mui/icons-material'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
@@ -538,20 +539,22 @@ function SubstatDisplay({
           height="1.3em"
           sx={{ opacity: inFilter ? 1 : 0.3 }}
         >
-          {[...stat.rolls].sort().map((v, i) => (
-            <SmolProgress
-              key={`${i}${v}`}
-              value={(100 * v) / maxRoll}
-              color={`roll${clamp(
-                rollOffset + rollData.indexOf(v),
-                1,
-                6
-              )}.main`}
-            />
-          ))}
+          {sortedSubstatRolls(stat.rolls, stat.initialValue !== undefined).map(
+            (v, i) => (
+              <SmolProgress
+                key={`${i}${v}`}
+                value={(100 * v) / maxRoll}
+                color={`roll${clamp(
+                  rollOffset + rollData.indexOf(v),
+                  1,
+                  6
+                )}.main`}
+              />
+            )
+          )}
         </Box>
       ),
-    [inFilter, stat.rolls, maxRoll, rollData, rollOffset]
+    [inFilter, stat.rolls, stat.initialValue, maxRoll, rollData, rollOffset]
   )
   const getSubstatColor = (
     numRolls: number,

--- a/libs/gi/ui/src/components/artifact/editor/ArtifactReducer.test.ts
+++ b/libs/gi/ui/src/components/artifact/editor/ArtifactReducer.test.ts
@@ -117,6 +117,27 @@ describe('artifactReducer', () => {
     expect(artifact?.totalRolls).toBeUndefined()
   })
 
+  it('sets and clears the initial roll of a substat', () => {
+    const withInitial = artifactReducer(
+      {
+        ...baseArtifact,
+        substats: [
+          { key: 'atk_', value: 46.6 },
+          ...baseArtifact.substats.slice(1),
+        ],
+      },
+      { type: 'initialValue', index: 0, value: 5.8 }
+    )
+    expect(withInitial?.substats[0].initialValue).toBe(5.8)
+
+    const cleared = artifactReducer(withInitial!, {
+      type: 'initialValue',
+      index: 0,
+      value: undefined,
+    })
+    expect(cleared?.substats[0].initialValue).toBeUndefined()
+  })
+
   it('preserves initialValue when editing substats', () => {
     const editedArtifact = artifactReducer(baseArtifact, {
       type: 'substat',

--- a/libs/gi/ui/src/components/artifact/editor/ArtifactReducer.ts
+++ b/libs/gi/ui/src/components/artifact/editor/ArtifactReducer.ts
@@ -11,12 +11,18 @@ type UnactivatedSubstatMessage = {
 }
 type OverwriteMessage = { type: 'overwrite'; artifact: IArtifact }
 type UpdateMessage = { type: 'update'; artifact: Partial<IArtifact> }
+type InitialValueMessage = {
+  type: 'initialValue'
+  index: number
+  value: number | undefined
+}
 export type ArtifactReducerMessage =
   | ResetMessage
   | SubstatMessage
   | OverwriteMessage
   | UpdateMessage
   | UnactivatedSubstatMessage
+  | InitialValueMessage
 
 function activeSubstatCount(artifact: IArtifact): number {
   return artifact.substats.filter(({ key }) => key).length
@@ -145,6 +151,15 @@ export function artifactReducer(
           state.substats[3] = { key: '', value: 0 }
         }
 
+        return { ...state! }
+      }
+      case 'initialValue': {
+        const { index, value } = action
+        const substat = state!.substats[index]
+        state!.substats[index] =
+          value === undefined
+            ? { key: substat.key, value: substat.value }
+            : { ...substat, initialValue: value }
         return { ...state! }
       }
       case 'overwrite':

--- a/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
@@ -89,7 +89,6 @@ export function SubstatInput({
     rollNum = rolls.length
 
   let error = '',
-    rollData: readonly number[] = [],
     allowedRolls = 0
 
   if (artifact) {
@@ -98,8 +97,8 @@ export function SubstatInput({
     const { numUpgrades, high } = artSubstatRollData[rarity]
     const maxRollNum = numUpgrades + high - 3
     allowedRolls = maxRollNum - rollNum
-    rollData = key ? getSubstatValuesPercent(key, rarity) : []
   }
+  const rollData = artifact && key ? getSubstatValuesPercent(key, rarity) : []
   const rollOffset = 7 - rollData.length
 
   if (!rollNum && key && value)
@@ -120,10 +119,6 @@ export function SubstatInput({
     [key, rarity]
   )
 
-  // Once an artifact is +20, its substats are done rolling and the very first
-  // roll of each substat can be recorded via `initialValue`. The possible
-  // initial rolls are exactly the single-roll values, which line up with the
-  // first few dots (marks) on the slider.
   const showInitialValue = level === 20 && !!key
 
   // With exactly one total roll, the substat's value is unambiguously its
@@ -140,12 +135,22 @@ export function SubstatInput({
     setInitialSubstatValue,
   ])
 
-  // Only the ambiguous case (multiple rolls) needs the slider to pick which of
-  // the possible first rolls was the initial one.
-  const initialRollValues =
-    showInitialValue && rollNum > 1
-      ? rollData.map((v) => Number.parseFloat(artDisplayValue(v, unit)))
-      : []
+  const initialRollValues = useMemo(() => {
+    if (!(showInitialValue && rollNum > 1) || !rollData.length) return []
+    const minRoll = Math.min(...rollData)
+    const maxRoll = Math.max(...rollData)
+    const remainingRolls = rollNum - 1
+    const eps = 1e-6
+    return rollData
+      .filter((v) => {
+        const remaining = accurateValue - v
+        return (
+          remaining >= remainingRolls * minRoll - eps &&
+          remaining <= remainingRolls * maxRoll + eps
+        )
+      })
+      .map((v) => Number.parseFloat(artDisplayValue(v, unit)))
+  }, [showInitialValue, rollNum, rollData, accurateValue, unit])
 
   return (
     <CardThemed bgt="light">

--- a/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
@@ -122,9 +122,11 @@ export function SubstatInput({
   const showInitialValue = level === 20 && !!key
 
   // With exactly one total roll, the substat's value is unambiguously its
-  // initial roll, so record it automatically (and don't offer the slider).
+  // initial roll, so keep it recorded automatically (and don't offer the
+  // slider). This also corrects a stale value carried over from when the
+  // substat had multiple rolls.
   useEffect(() => {
-    if (showInitialValue && rollNum === 1 && initialValue === undefined)
+    if (showInitialValue && rollNum === 1 && initialValue !== value)
       setInitialSubstatValue(index, value)
   }, [
     showInitialValue,
@@ -137,20 +139,40 @@ export function SubstatInput({
 
   const initialRollValues = useMemo(() => {
     if (!(showInitialValue && rollNum > 1) || !rollData.length) return []
-    const minRoll = Math.min(...rollData)
-    const maxRoll = Math.max(...rollData)
-    const remainingRolls = rollNum - 1
-    const eps = 1e-6
+    const minRoll = Math.min(...rollData),
+      maxRoll = Math.max(...rollData)
     return rollData
       .filter((v) => {
         const remaining = accurateValue - v
         return (
-          remaining >= remainingRolls * minRoll - eps &&
-          remaining <= remainingRolls * maxRoll + eps
+          remaining >= (rollNum - 1) * minRoll - 1e-6 &&
+          remaining <= (rollNum - 1) * maxRoll + 1e-6
         )
       })
       .map((v) => Number.parseFloat(artDisplayValue(v, unit)))
   }, [showInitialValue, rollNum, rollData, accurateValue, unit])
+
+  // If a change to the roll value makes the currently selected initial roll no
+  // longer a possible first roll, reset it.
+  useEffect(() => {
+    if (
+      showInitialValue &&
+      rollNum > 1 &&
+      initialValue !== undefined &&
+      !initialRollValues.some(
+        (v) => artDisplayValue(v, unit) === artDisplayValue(initialValue, unit)
+      )
+    )
+      setInitialSubstatValue(index, undefined)
+  }, [
+    showInitialValue,
+    rollNum,
+    initialValue,
+    initialRollValues,
+    unit,
+    index,
+    setInitialSubstatValue,
+  ])
 
   return (
     <CardThemed bgt="light">

--- a/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
@@ -19,6 +19,7 @@ import {
   artDisplayValue,
   getSubstatSummedRolls,
   getSubstatValuesPercent,
+  sortedSubstatRolls,
 } from '@genshin-optimizer/gi/util'
 import {
   Box,
@@ -319,20 +320,22 @@ export function SubstatInput({
             </Grid>
             <Grid item>
               {!!rolls.length &&
-                [...rolls].sort().map((val, i) => (
-                  <Typography
-                    component="span"
-                    key={`${i}.${val}`}
-                    color={`roll${clamp(
-                      rollOffset + rollData.indexOf(val),
-                      1,
-                      6
-                    )}.main`}
-                    sx={{ ml: 1 }}
-                  >
-                    {artDisplayValue(val, unit)}
-                  </Typography>
-                ))}
+                sortedSubstatRolls(rolls, initialValue !== undefined).map(
+                  (val, i) => (
+                    <Typography
+                      component="span"
+                      key={`${i}.${val}`}
+                      color={`roll${clamp(
+                        rollOffset + rollData.indexOf(val),
+                        1,
+                        6
+                      )}.main`}
+                      sx={{ ml: 1 }}
+                    >
+                      {artDisplayValue(val, unit)}
+                    </Typography>
+                  )
+                )}
             </Grid>
             <Grid item flexGrow={1}>
               {index === 3 ? (

--- a/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/SubstatInput.tsx
@@ -5,6 +5,7 @@ import {
   SqBadge,
   TextButton,
 } from '@genshin-optimizer/common/ui'
+import type { Unit } from '@genshin-optimizer/common/util'
 import { clamp, getUnitStr } from '@genshin-optimizer/common/util'
 import {
   allSubstatKeys,
@@ -58,6 +59,7 @@ export function SubstatInput({
   index,
   artifact,
   setSubstat,
+  setInitialSubstatValue,
   onChange,
   isUnactivatedSubstat,
 }: {
@@ -68,6 +70,7 @@ export function SubstatInput({
     substat: ISubstat,
     isUnactivatedSubstat: boolean
   ) => void
+  setInitialSubstatValue: (index: number, value: number | undefined) => void
   onChange: (index: number, substat: ISubstat, isChecked: boolean) => void
   isUnactivatedSubstat: boolean
 }) {
@@ -78,6 +81,7 @@ export function SubstatInput({
     value = 0,
     rolls = [],
     efficiency = 0,
+    initialValue,
   } = getCorrectSubstats(artifact, isUnactivatedSubstat, index) ?? {}
 
   const accurateValue = rolls.reduce((a, b) => a + b, 0)
@@ -115,6 +119,33 @@ export function SubstatInput({
         : [{ value: 0 }],
     [key, rarity]
   )
+
+  // Once an artifact is +20, its substats are done rolling and the very first
+  // roll of each substat can be recorded via `initialValue`. The possible
+  // initial rolls are exactly the single-roll values, which line up with the
+  // first few dots (marks) on the slider.
+  const showInitialValue = level === 20 && !!key
+
+  // With exactly one total roll, the substat's value is unambiguously its
+  // initial roll, so record it automatically (and don't offer the slider).
+  useEffect(() => {
+    if (showInitialValue && rollNum === 1 && initialValue === undefined)
+      setInitialSubstatValue(index, value)
+  }, [
+    showInitialValue,
+    rollNum,
+    initialValue,
+    value,
+    index,
+    setInitialSubstatValue,
+  ])
+
+  // Only the ambiguous case (multiple rolls) needs the slider to pick which of
+  // the possible first rolls was the initial one.
+  const initialRollValues =
+    showInitialValue && rollNum > 1
+      ? rollData.map((v) => Number.parseFloat(artDisplayValue(v, unit)))
+      : []
 
   return (
     <CardThemed bgt="light">
@@ -235,6 +266,10 @@ export function SubstatInput({
             )
           }
           disabled={!key || (isUnactivatedSubstat && index === 3)}
+          initialRollValues={initialRollValues}
+          initialValue={initialValue}
+          unit={unit}
+          setInitialValue={(v) => setInitialSubstatValue(index, v)}
         />
       </Box>
       <Box sx={{ px: 1, pb: 1 }}>
@@ -327,25 +362,128 @@ function SliderWrapper({
   setValue,
   marks,
   disabled = false,
+  initialRollValues = [],
+  initialValue,
+  unit,
+  setInitialValue,
 }: {
   value: number
   setValue: (v: number) => void
   marks: Array<{ value: number }>
   disabled: boolean
+  initialRollValues?: number[]
+  initialValue?: number
+  unit?: Unit
+  setInitialValue?: (v: number | undefined) => void
 }) {
   const [innerValue, setinnerValue] = useState(value)
   useEffect(() => setinnerValue(value), [value])
+  const max = marks[marks.length - 1]?.value ?? 0
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <Slider
+        value={innerValue}
+        step={null}
+        disabled={disabled}
+        marks={marks}
+        min={0}
+        max={max}
+        onChange={(_e, v) => setinnerValue(v as number)}
+        onChangeCommitted={(_e, v) => setValue(v as number)}
+        valueLabelDisplay="auto"
+      />
+      {!disabled && !!initialRollValues.length && max > 0 && (
+        <InitialValueSlider
+          initialRollValues={initialRollValues}
+          initialValue={initialValue}
+          unit={unit}
+          max={max}
+          setInitialValue={setInitialValue}
+        />
+      )}
+    </Box>
+  )
+}
+
+// An invisible slider layered on top of the substat slider. Only its thumb is
+// shown, so the user can drag it to the first-roll dots to record/save the
+// substat's `initialValue`. When no initial value is set the thumb is parked
+// (grayed) at the minimum; dragging it back there clears the value again.
+function InitialValueSlider({
+  initialRollValues,
+  initialValue,
+  unit,
+  max,
+  setInitialValue,
+}: {
+  initialRollValues: number[]
+  initialValue?: number
+  unit?: Unit
+  max: number
+  setInitialValue?: (v: number | undefined) => void
+}) {
+  const { t } = useTranslation('artifact')
+  const marks = useMemo(
+    () => [{ value: 0 }, ...initialRollValues.map((v) => ({ value: v }))],
+    [initialRollValues]
+  )
+  const defined = initialValue !== undefined
+  const [innerValue, setInnerValue] = useState(initialValue ?? 0)
+  useEffect(() => setInnerValue(initialValue ?? 0), [initialValue])
   return (
     <Slider
       value={innerValue}
       step={null}
-      disabled={disabled}
       marks={marks}
       min={0}
-      max={marks[marks.length - 1]?.value ?? 0}
-      onChange={(_e, v) => setinnerValue(v as number)}
-      onChangeCommitted={(_e, v) => setValue(v as number)}
+      max={max}
+      aria-label={t('editor.substat.initialRoll')}
       valueLabelDisplay="auto"
+      valueLabelFormat={(v) => (v ? artDisplayValue(v, unit ?? '') : '—')}
+      onChange={(_e, v) => setInnerValue(v as number)}
+      onChangeCommitted={(_e, v) =>
+        setInitialValue?.((v as number) === 0 ? undefined : (v as number))
+      }
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        // Let clicks fall through to the substat slider underneath; only the
+        // thumb itself stays interactive.
+        pointerEvents: 'none',
+        '& .MuiSlider-rail, & .MuiSlider-track, & .MuiSlider-mark': {
+          display: 'none',
+        },
+        // Small diamond thumb. The diamond is drawn on a rotated ::before so it
+        // can carry a real outline (a border on a clip-path'd thumb would be
+        // clipped away), while the thumb keeps its centering transform.
+        '& .MuiSlider-thumb': {
+          pointerEvents: 'auto',
+          width: 12,
+          height: 12,
+          backgroundColor: 'transparent',
+          boxShadow: 'none',
+          '&:hover, &.Mui-focusVisible, &.Mui-active': { boxShadow: 'none' },
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            width: 9,
+            height: 9,
+            // Reset the thumb's inherited 50% radius, otherwise the rotated
+            // square renders as a circle.
+            borderRadius: 0,
+            transform: 'translate(-50%, -50%) rotate(45deg)',
+            boxShadow: 'none',
+            border: '1px solid',
+            borderColor: (theme) => theme.palette.common.black,
+            backgroundColor: (theme) =>
+              defined ? theme.palette.primary.main : theme.palette.grey[500],
+          },
+        },
+      }}
     />
   )
 }

--- a/libs/gi/ui/src/components/artifact/editor/index.tsx
+++ b/libs/gi/ui/src/components/artifact/editor/index.tsx
@@ -273,6 +273,12 @@ export function ArtifactEditor({
     },
     [artifactDispatch]
   )
+  const setInitialSubstatValue = useCallback(
+    (index: number, value?: number) => {
+      artifactDispatch({ type: 'initialValue', index, value })
+    },
+    [artifactDispatch]
+  )
   const isValid = !errors.length
   const canClearArtifact = (): boolean =>
     window.confirm(t('editor.clearPrompt') as string)
@@ -713,6 +719,7 @@ export function ArtifactEditor({
                   index={index}
                   artifact={cArtifact}
                   setSubstat={setSubstat}
+                  setInitialSubstatValue={setInitialSubstatValue}
                   onChange={handleChange}
                   isUnactivatedSubstat={isUnactivatedSubstat}
                 />

--- a/libs/gi/util/src/artifact/artifact.ts
+++ b/libs/gi/util/src/artifact/artifact.ts
@@ -55,6 +55,17 @@ export function getSubstatRolls(
   )
 }
 
+// Sorts substat rolls for display; keeps initial value first if it exists.
+export function sortedSubstatRolls(
+  rolls: readonly number[],
+  hasInitialValue: boolean
+): number[] {
+  if (!hasInitialValue || rolls.length <= 1)
+    return [...rolls].sort((a, b) => a - b)
+  const [initial, ...rest] = rolls
+  return [initial, ...rest.sort((a, b) => a - b)]
+}
+
 export function getSubstatSummedRolls(
   rarity: ArtifactRarity,
   key: SubstatKey


### PR DESCRIPTION
## Describe your changes

Visualize initialValue(s) for artifacts & allow user to edit them. In the artifact editor screen, added small diamonds floating above the stat sliders; values locked to valid initial values. If there's only 1 roll in a stat, it's assumed to be the initial value.
<img width="584" height="473" alt="Screenshot 2026-07-30 at 12 09 23 AM" src="https://github.com/user-attachments/assets/b9ad6587-fd7a-438b-91e6-e4bc6acbd4a7" />

If initial value is undefined, that diamond is greyed out. If the initial value is invalidated while sliding the substat value around (e.g. forced 3x max roll) then that initial value will be cleared.
<img width="584" height="77" alt="Screenshot 2026-07-30 at 12 13 18 AM" src="https://github.com/user-attachments/assets/14105fd1-408c-4e7a-96bd-7165b1467bad" />

Initial value is reflected on the roll% pips as the 1st roll in the list (not sure; kinda ugly tho)
<img width="454" height="128" alt="Screenshot 2026-07-30 at 12 09 37 AM" src="https://github.com/user-attachments/assets/feed5053-14b7-4b6c-ac59-f970ed3a4d4e" />


## Issue or discord link
To support upopt reshape feature; right now only available from Irminsul scans.

## Testing/validation

Hand-tested by playing with UI.
- Move slider to 1 roll and back (initial value sticks at 1 roll location)
- Set i.v. to max roll, move slider to 2x min roll (i.v. <- undefined)
- i.v. selector only allows valid inputs (cannot select max roll if values is 2x min)
- Ambiguous values disambiguated by initial value (changing i.v. changes 4 or 5 roll)

Remaining bug(s):
Occasional issues with lookup table & rounding. Selected initial value is 4.7, but rolls array doesn't include 4.7. This happened because subtracting the accurate value 13.41 - 4.66 = 8.75, which rounds to 8.8 (doesn't exist in lookup table). Need to lookup 8.7 for this particular value, but the rounding is very inconsistent.
<img width="296" height="115" alt="image" src="https://github.com/user-attachments/assets/338052dc-9720-4fee-bf38-90ef9fd1a708" />



## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording and displaying an artifact substat’s initial roll.
  * Added an interactive slider control for selecting or clearing the initial roll value.
  * Updated substat roll displays to preserve the initial roll while sorting subsequent rolls.

* **Bug Fixes**
  * Improved substat roll reconciliation, efficiency calculations, and accurate value detection when an initial roll is provided.

* **Localization**
  * Added the “Initial roll” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->