### PR TITLE
feat(zzz): infer team buff listing from entry et

### DIFF
--- a/libs/zzz/formula/src/data/char/sheets/Alice.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Alice.ts
@@ -128,9 +128,7 @@ const sheet = register(
     'core_anom_mv_mult_',
     teamBuff.dmg.anom_mv_mult_.physical.add(
       physical_anomaly_inflicted.ifOn(percent(dm.core.dmg))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_addl_disorder_',
@@ -142,9 +140,7 @@ const sheet = register(
         ),
         percent(dm.core.max_addl_disorder_)
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_physical_anomBuildup_',
@@ -174,27 +170,21 @@ const sheet = register(
     'm1_defRed_',
     enemyDebuff.common.defRed_.add(
       cmpGE(char.mindscape, 1, assault_triggered.ifOn(percent(dm.m1.defRed_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_physical_anomaly_buff_',
     teamBuff.combat.buff_.physical.addWithDmgType(
       'anomaly',
       cmpGE(char.mindscape, 2, percent(dm.m2.physical_buff_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_physical_disorder_buff_',
     teamBuff.combat.buff_.physical.addWithDmgType(
       'disorder',
       cmpGE(char.mindscape, 2, percent(dm.m2.disorder_buff_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_physical_resIgn_',

--- a/libs/zzz/formula/src/data/char/sheets/Anton.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Anton.ts
@@ -258,9 +258,7 @@ const sheet = register(
     'm4_crit_',
     teamBuff.combat.crit_.add(
       cmpGE(char.mindscape, 4, chain_ult_used.ifOn(percent(dm.m4.crit_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m6_dmg_', m6_dmg_, undefined, false, false)
 )

--- a/libs/zzz/formula/src/data/char/sheets/AstraYao.ts
+++ b/libs/zzz/formula/src/data/char/sheets/AstraYao.ts
@@ -154,9 +154,7 @@ const sheet = register(
       idyllic_cadenza.ifOn(
         sum(percent(0.08), prod(char.special, percent(0.01)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'crit_dmg_',
@@ -164,9 +162,7 @@ const sheet = register(
       idyllic_cadenza.ifOn(
         sum(percent(0.07), prod(char.special, percent(0.015)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_atk',
@@ -181,9 +177,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_resRed_',
@@ -203,9 +197,7 @@ const sheet = register(
           4,
           idyllic_cadenza.ifOn(prod(own.final.atk, percent(dm.m4.attack)))
         )
-      ),
-    undefined,
-    true
+      )
   ),
   registerBuff(
     'm4_anomaly_quickAssist_anomBuildup_',
@@ -214,9 +206,7 @@ const sheet = register(
       .addWithDmgType(
         'quickAssist',
         cmpGE(char.mindscape, 4, idyllic_cadenza.ifOn(dm.m4.anomaly))
-      ),
-    undefined,
-    true
+      )
   ),
   registerBuff(
     'm4_stun_quickAssist_dazeInc_',
@@ -225,9 +215,7 @@ const sheet = register(
       .addWithDmgType(
         'quickAssist',
         cmpGE(char.mindscape, 4, idyllic_cadenza.ifOn(dm.m4.stun))
-      ),
-    undefined,
-    true
+      )
   ),
   registerBuff('m6_crit_', m6_crit_, undefined, undefined, false),
   registerBuff('m6_mv_mult_', m6_mv_mult, undefined, undefined, false),

--- a/libs/zzz/formula/src/data/char/sheets/Ben.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Ben.ts
@@ -140,17 +140,13 @@ const sheet = register(
         3,
         shieldOn.ifOn(percent(dm.ability.crit_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_dmg_red_',
     teamBuff.combat.dmg_red_.add(
       cmpGE(char.mindscape, 1, enemyBlocked.ifOn(percent(dm.m1.dmg_red_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m4_dmg_', m4_dmg_, undefined, undefined, false),
   registerBuff(

--- a/libs/zzz/formula/src/data/char/sheets/Burnice.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Burnice.ts
@@ -218,9 +218,7 @@ const sheet = register(
     'm2_pen_',
     teamBuff.combat.pen_.add(
       cmpGE(char.mindscape, 2, prod(thermal_penetration, percent(dm.m2.pen_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_exSpecial_crit_',

--- a/libs/zzz/formula/src/data/char/sheets/Caesar.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Caesar.ts
@@ -111,9 +111,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_dmgInc_',
@@ -126,17 +124,13 @@ const sheet = register(
         2,
         ability_debuff.ifOn(dm.ability.dmg_)
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_resRed_',
     enemyDebuff.common.resRed_.add(
       cmpGE(char.mindscape, 1, radiant_aegis.ifOn(dm.m1.attrRes_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_enerRegen_',

--- a/libs/zzz/formula/src/data/char/sheets/Dialyn.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Dialyn.ts
@@ -146,9 +146,7 @@ const sheet = register(
     'core_stun_',
     enemyDebuff.common.stun_.add(
       malicious_complaint.ifOn(percent(subscript(char.core, dm.core.stun_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_exSpecial_crit_dmg_',
@@ -162,9 +160,7 @@ const sheet = register(
       ability_check(
         overwhelmingly_positive.ifOn(percent(dm.ability.common_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_attack_dmg',
@@ -188,17 +184,13 @@ const sheet = register(
         1,
         ability_check(overwhelmingly_positive.ifOn(percent(dm.m1.resIgn_)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_stun_',
     enemyDebuff.common.stun_.add(
       cmpGE(char.mindscape, 2, malicious_complaint.ifOn(percent(dm.m2.stun_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_common_dmg_',
@@ -208,9 +200,7 @@ const sheet = register(
         2,
         malicious_complaint.ifOn(percent(dm.m2.common_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_atk',

--- a/libs/zzz/formula/src/data/char/sheets/Grace.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Grace.ts
@@ -105,9 +105,7 @@ const sheet = register(
     'm2_electric_resRed_',
     enemyDebuff.common.resRed_.electric.add(
       cmpGE(char.mindscape, 2, grenadeHit.ifOn(percent(dm.m2.electric_resRed_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_electric_anomBuildupResRed_',
@@ -117,9 +115,7 @@ const sheet = register(
         2,
         grenadeHit.ifOn(percent(-dm.m2.electric_anomBuildupResRed_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_enerRegen_',

--- a/libs/zzz/formula/src/data/char/sheets/Jane.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Jane.ts
@@ -79,17 +79,13 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_assault_crit_dmg_',
     teamBuff.combat.anom_crit_dmg_.physical.add(
       gnawed.ifOn(subscript(char.core, dm.core.assault_crit_dmg_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_physical_anomBuildup_',
@@ -143,17 +139,13 @@ const sheet = register(
     notOwnBuff.combat.defIgn_.physical.addWithDmgType(
       'anomaly',
       cmpGE(char.mindscape, 2, gnawed.ifOn(dm.m2.defIgn_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_assault_crit_dmg_',
     teamBuff.combat.anom_crit_dmg_.physical.add(
       cmpGE(char.mindscape, 2, gnawed.ifOn(dm.m2.assault_crit_dmg_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_anomaly_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/JuFufu.ts
+++ b/libs/zzz/formula/src/data/char/sheets/JuFufu.ts
@@ -113,27 +113,21 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_chain_dmg_',
     teamBuff.combat.dmg_.addWithDmgType(
       'chain',
       tigers_roar.ifOn(percent(subscript(char.core, dm.core.chain_dmg_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_ult_dmg_',
     teamBuff.combat.dmg_.addWithDmgType(
       'ult',
       tigers_roar.ifOn(percent(subscript(char.core, dm.core.ult_dmg_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_impact',
@@ -149,17 +143,13 @@ const sheet = register(
     'm1_stun_',
     enemyDebuff.common.stun_.add(
       cmpGE(char.mindscape, 1, chain_hit.ifOn(percent(dm.m1.stun_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_crit_dmg_',
     teamBuff.combat.crit_dmg_.add(
       cmpGE(char.mindscape, 2, percent(dm.m2.crit_dmg_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_crit_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Koleda.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Koleda.ts
@@ -148,9 +148,7 @@ const sheet = register(
         3,
         isStunned.ifOn(prod(exSpecial_debuff, percent(dm.ability.chain_dmg_)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_special_dazeInc_',

--- a/libs/zzz/formula/src/data/char/sheets/Lighter.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Lighter.ts
@@ -173,15 +173,11 @@ const sheet = register(
   ),
   registerBuff(
     'ability_ice_dmg_',
-    teamBuff.combat.dmg_.ice.add(ability_ice_fire_dmg_check),
-    undefined,
-    true
+    teamBuff.combat.dmg_.ice.add(ability_ice_fire_dmg_check)
   ),
   registerBuff(
     'ability_fire_dmg_',
-    teamBuff.combat.dmg_.fire.add(ability_ice_fire_dmg_check),
-    undefined,
-    true
+    teamBuff.combat.dmg_.fire.add(ability_ice_fire_dmg_check)
   ),
   registerBuff(
     'm1_ice_resRed_',
@@ -212,9 +208,7 @@ const sheet = register(
     'm4_enerRegen_',
     notOwnBuff.combat.enerRegen_.add(
       cmpGE(char.mindscape, 4, percent(dm.m4.enerRegen_))
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/char/sheets/Lucia.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Lucia.ts
@@ -226,9 +226,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'exSpecial_harmony_dmg_',
@@ -239,9 +237,7 @@ const sheet = register(
   ),
   registerBuff(
     'core_hp_',
-    teamBuff.combat.hp_.add(etherVeil.ifOn(percent(dm.core.hp_))),
-    undefined,
-    true
+    teamBuff.combat.hp_.add(etherVeil.ifOn(percent(dm.core.hp_)))
   ),
   registerBuff(
     'core_common_dmg_',
@@ -262,9 +258,7 @@ const sheet = register(
         1,
         darkbreaker.ifOn(percent(dm.ability.crit_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_resIgn_',
@@ -274,9 +268,7 @@ const sheet = register(
         1,
         dreamersNurseryRhyme.ifOn(percent(dm.m1.resIgn_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m2_harmony_dmg_', m2_harmony_dmg_, undefined, false, false),
   registerBuff(
@@ -287,9 +279,7 @@ const sheet = register(
         2,
         darkbreaker.ifOn(etherVeil.ifOn(percent(dm.m2.sheer_dmg_)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm6_atk_',

--- a/libs/zzz/formula/src/data/char/sheets/Lucy.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Lucy.ts
@@ -200,9 +200,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('core_atk', core_atk, undefined, undefined, false),
   registerBuff('ability_crit_', ability_crit_, undefined, undefined, false),
@@ -217,9 +215,7 @@ const sheet = register(
     'm4_crit_dmg_',
     teamBuff.combat.crit_dmg_.add(
       cmpGE(char.mindscape, 4, cheerOn.ifOn(percent(dm.m4.crit_dmg_)))
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/char/sheets/Miyabi.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Miyabi.ts
@@ -232,9 +232,7 @@ const sheet = register(
   ),
   registerBuff(
     'core_anomBuildup_',
-    teamBuff.combat.anomBuildup_.add(frostburn.ifOn(dm.core.anomBuildup_)),
-    undefined,
-    true
+    teamBuff.combat.anomBuildup_.add(frostburn.ifOn(dm.core.anomBuildup_))
   ),
   registerBuff('ability_dmg_', ability_dmg_, undefined, undefined, false),
   registerBuff(
@@ -249,9 +247,7 @@ const sheet = register(
     'm1_anomBuildup_',
     teamBuff.combat.anomBuildup_.add(
       cmpGE(char.mindscape, 1, level_3_charge_hit.ifOn(dm.m1.anomBuildup_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m2_dmg_', m2_dmg_, undefined, undefined, false),
   registerBuff(

--- a/libs/zzz/formula/src/data/char/sheets/Nicole.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Nicole.ts
@@ -271,8 +271,7 @@ const sheet = register(
     teamBuff.combat.crit_.add(
       cmpGE(char.mindscape, 6, prod(fieldHitsEnemy, percent(dm.m6.crit_)))
     ),
-    cmpGE(char.mindscape, 6, 'infer', ''),
-    true
+    cmpGE(char.mindscape, 6, 'infer', '')
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/char/sheets/OrphieMagus.ts
+++ b/libs/zzz/formula/src/data/char/sheets/OrphieMagus.ts
@@ -224,9 +224,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_aftershock_defIgn_',
@@ -240,18 +238,14 @@ const sheet = register(
         1,
         zeroedIn.ifOn(percent(dm.ability.aftershock_defIgn_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m1_fire_resIgn_', m1_fire_resIgn_, undefined, undefined, false),
   registerBuff(
     'm1_common_dmg_',
     teamBuff.combat.common_dmg_.add(
       cmpGE(char.mindscape, 1, zeroedIn.ifOn(percent(dm.m1.dmg_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_atk_',

--- a/libs/zzz/formula/src/data/char/sheets/PanYinhu.ts
+++ b/libs/zzz/formula/src/data/char/sheets/PanYinhu.ts
@@ -84,9 +84,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_dmgInc_',

--- a/libs/zzz/formula/src/data/char/sheets/Piper.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Piper.ts
@@ -141,9 +141,7 @@ const sheet = register(
           dm.ability.common_dmg_
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_physical_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Pulchra.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Pulchra.ts
@@ -90,9 +90,7 @@ const sheet = register(
         6,
         abilityCheck(binding_trap.ifOn(percent(dm.ability.aftershock_dmg_)))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_crit_',
@@ -119,9 +117,7 @@ const sheet = register(
         6,
         abilityCheck(percent(dm.ability.aftershock_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/char/sheets/Rina.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Rina.ts
@@ -104,9 +104,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_electric_dmg_',
@@ -119,9 +117,7 @@ const sheet = register(
         3,
         shocked_enemy.ifOn(percent(dm.ability.electric_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_common_dmg_',
@@ -143,9 +139,7 @@ const sheet = register(
         6,
         exSpecial_chain_ult_hit.ifOn(percent(dm.m6.electric_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/char/sheets/Seed.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Seed.ts
@@ -172,9 +172,7 @@ const sheet = register(
       directStrike.ifOn(
         directStrikeCheck(subscript(char.core, dm.core.direct_strike_atk))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_vanguard_crit_dmg_',
@@ -184,9 +182,7 @@ const sheet = register(
           percent(subscript(char.core, dm.core.direct_strike_crit_dmg_))
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_dmg_',
@@ -241,9 +237,7 @@ const sheet = register(
     'm2_vanguard_defIgn_',
     notOwnBuff.combat.defIgn_.add(
       cmpGE(char.mindscape, 2, besiegeDisplay(percent(dm.m2.besiege_defIgn_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_basic_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Seth.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Seth.ts
@@ -184,9 +184,7 @@ const sheet = register(
     'core_anomProf',
     teamBuff.combat.anomProf.add(
       shield_active.ifOn(percent(subscript(char.core, dm.core.anomProf)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_anomBuildupRes_',
@@ -201,9 +199,7 @@ const sheet = register(
         3,
         chain_finish_hit.ifOn(percent(-dm.ability.anomBuildupRes_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_basic_electric_anomBuildup_',

--- a/libs/zzz/formula/src/data/char/sheets/Soldier0Anby.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Soldier0Anby.ts
@@ -132,9 +132,7 @@ const sheet = register(
           percent(subscript(char.core, dm.core.aftershock_crit_dmg_scaling_))
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_crit_',
@@ -161,9 +159,7 @@ const sheet = register(
         1,
         markedWithSilverStar.ifOn(dm.ability.aftershock_dmg_)
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_crit_',

--- a/libs/zzz/formula/src/data/char/sheets/Soukaku.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Soukaku.ts
@@ -162,9 +162,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_ice_dmg_',
@@ -183,9 +181,7 @@ const sheet = register(
     'm4_ice_resRed_',
     enemyDebuff.common.resRed_.ice.add(
       cmpGE(char.mindscape, 4, flyTheFlagHit.ifOn(percent(dm.m4.ice_resRed_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m6_common_dmg_', m6_dmg_, undefined, undefined, false)
 )

--- a/libs/zzz/formula/src/data/char/sheets/Trigger.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Trigger.ts
@@ -174,9 +174,7 @@ const sheet = register(
     'm2_crit_dmg_',
     teamBuff.combat.crit_dmg_.add(
       cmpGE(char.mindscape, 2, prod(hunters_gaze, percent(dm.m2.crit_dmg_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm6_armor_break_rounds_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Vivian.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Vivian.ts
@@ -123,9 +123,7 @@ const sheet = register(
           own.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_electric_abloom',
@@ -138,9 +136,7 @@ const sheet = register(
           target.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_fire_abloom',
@@ -153,9 +149,7 @@ const sheet = register(
           target.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_physical_abloom',
@@ -168,9 +162,7 @@ const sheet = register(
           target.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_ice_abloom',
@@ -183,45 +175,35 @@ const sheet = register(
           target.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_corruption_dmg_',
     teamBuff.combat.buff_.ether.addWithDmgType(
       'anomaly',
       abilityCheck(dm.ability.ether_anom_dmg_)
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_corruption_disorder_dmg_',
     teamBuff.combat.buff_.ether.addWithDmgType(
       'disorder',
       abilityCheck(dm.ability.ether_anom_dmg_)
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_anomaly_dmg_',
     teamBuff.combat.buff_.addWithDmgType(
       'anomaly',
       cmpGE(char.mindscape, 1, prophecy.ifOn(dm.m1.anomaly_disorder_dmg_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_disorder_dmg_',
     teamBuff.combat.buff_.addWithDmgType(
       'disorder',
       cmpGE(char.mindscape, 1, prophecy.ifOn(dm.m1.anomaly_disorder_dmg_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_ether_anomBuildup_',
@@ -233,18 +215,14 @@ const sheet = register(
     'm2_anom_mv_mult_',
     teamBuff.dmg.anom_mv_mult_.add(
       cmpGE(char.mindscape, 2, abloom.ifOn(dm.m2.abloom_bonus))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_resIgn_',
     teamBuff.combat.resIgn_.addWithDmgType(
       'anomaly',
       cmpGE(char.mindscape, 2, abloom.ifOn(dm.m2.resIgn_))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff('m4_crit_', m4_crit_, undefined, undefined, false),
   registerBuff(

--- a/libs/zzz/formula/src/data/char/sheets/Yanagi.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yanagi.ts
@@ -173,9 +173,7 @@ const sheet = register(
           percent(-0.85)
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'exSpecial_anom_flat_dmg',
@@ -189,9 +187,7 @@ const sheet = register(
           own.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ult_anom_flat_dmg',
@@ -205,17 +201,13 @@ const sheet = register(
           own.final.anomProf
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_addl_disorder_',
     teamBuff.combat.addl_disorder_.add(
       exSpecial_used.ifOn(percent(subscript(char.core, dm.core.addl_disorder_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_electric_dmg_',
@@ -234,9 +226,7 @@ const sheet = register(
         3,
         basic_hit.ifOn(percent(dm.ability.electric_anomBuildup_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_anomProf',
@@ -255,9 +245,7 @@ const sheet = register(
     'm4_pen_',
     teamBuff.combat.pen_.add(
       cmpGE(char.mindscape, 4, exposed.ifOn(percent(dm.m4.pen_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm6_exSpecial_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Yidhari.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yidhari.ts
@@ -47,9 +47,7 @@ const sheet = register(
   // Buffs
   registerBuff(
     'etherVeil_hp_',
-    teamBuff.combat.hp_.add(etherVeil.ifOn(percent(0.05))),
-    undefined,
-    true
+    teamBuff.combat.hp_.add(etherVeil.ifOn(percent(0.05)))
   ),
   registerBuff(
     'core_hpSheerForce',

--- a/libs/zzz/formula/src/data/char/sheets/Yuzuha.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yuzuha.ts
@@ -124,15 +124,11 @@ const sheet = register(
           prod(own.initial.atk, percent(dm.core.atk))
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'core_common_dmg_',
-    teamBuff.combat.common_dmg_.add(tanuki_wish.ifOn(dm.core.common_dmg_)),
-    undefined,
-    true
+    teamBuff.combat.common_dmg_.add(tanuki_wish.ifOn(dm.core.common_dmg_))
   ),
   registerBuff(
     'ability_anomBuildup_',
@@ -148,9 +144,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_anomaly_buff_',
@@ -171,9 +165,7 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ability_disorder_buff_',
@@ -194,17 +186,13 @@ const sheet = register(
           )
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm1_resRed_',
     enemyDebuff.common.resRed_.add(
       cmpGE(char.mindscape, 1, sweet_scare.ifOn(percent(dm.m1.resRed_)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_common_dmg_',
@@ -214,9 +202,7 @@ const sheet = register(
         2,
         exSpecial_ult_hit.ifOn(percent(dm.m2.common_dmg_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm2_anomBuildup_',
@@ -226,9 +212,7 @@ const sheet = register(
         2,
         exSpecial_ult_hit.ifOn(percent(dm.m2.anomBuildup_))
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'm4_assistFollowUp_dmg_',
@@ -252,9 +236,7 @@ const sheet = register(
         6,
         prod(powerful_shell_hits, percent(dm.m6.add_disorder_))
       )
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/common/anomaly.ts
+++ b/libs/zzz/formula/src/data/common/anomaly.ts
@@ -18,16 +18,12 @@ export default register(
     'frostbite_crit_dmg_',
     teamBuff.combat.crit_dmg_.add(
       cmpGE(team.common.count.ice, 1, frostbite.ifOn(percent(0.1)))
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'windswept_direct_dmg_',
     teamBuff.combat.direct_dmg_.add(
       cmpGE(team.common.count.wind, 1, windswept.ifOn(percent(0.1)))
-    ),
-    undefined,
-    true
+    )
   )
 )

--- a/libs/zzz/formula/src/data/disc/sheets/BunnyInWonderland.ts
+++ b/libs/zzz/formula/src/data/disc/sheets/BunnyInWonderland.ts
@@ -35,8 +35,7 @@ const sheet = registerDisc(
         )
       )
     ),
-    showCond4Set,
-    true
+    showCond4Set
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/disc/sheets/MoonlightLullaby.ts
+++ b/libs/zzz/formula/src/data/disc/sheets/MoonlightLullaby.ts
@@ -35,8 +35,7 @@ const sheet = registerDisc(
         )
       )
     ),
-    showCond4Set,
-    true
+    showCond4Set
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -80,8 +80,8 @@ export function registerBuff(
 ): TagMapNodeEntries {
   if (!Array.isArray(entries)) entries = [entries]
   return entries.flatMap((entry) => {
-    const namedReader = displayNamedReader(entry, name)
-    const buffListing = buffListingRoot(resolveTeamBuffListing(entry, team))
+    const namedReader = getDisplayNamedReader(entry, name)
+    const buffListing = getBuffListingRoot(resolveTeamBuffListing(entry, team))
       .listing.buffs
     return [
       buffListing.add(listingItem(namedReader, cond)),
@@ -107,8 +107,8 @@ export function registerBuffFormula(
   cond: string | StrNode = 'infer',
   team?: boolean
 ): TagMapNodeEntries {
-  const namedReader = displayNamedReader(entry, name)
-  const listingRoot = buffListingRoot(resolveTeamBuffListing(entry, team))
+  const namedReader = getDisplayNamedReader(entry, name)
+  const listingRoot = getBuffListingRoot(resolveTeamBuffListing(entry, team))
   return [
     listingRoot.listing.buffs.add(listingItem(namedReader, cond)),
     listingRoot.listing.formulas.add(listingItem(namedReader, cond)),

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -40,7 +40,7 @@ function getBuffListingRoot(useTeamListing: boolean) {
   return useTeamListing ? teamBuff : ownBuff
 }
 
-function displayNamedReader(entry: TagMapNodeEntry, name: string) {
+function getDisplayNamedReader(entry: TagMapNodeEntry, name: string) {
   // Cannot use `sheet: null`; namedReader is also used as a `Tag` in `listingItem`.
   const { sheet: _sheet, ...tag } = entry.tag
   return reader.withTag({ ...tag, et: 'display', name })

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -36,7 +36,7 @@ function resolveTeamBuffListing(
   return team ?? TEAM_LISTING_ENTRY_TYPES.has(entry.tag.et)
 }
 
-function buffListingRoot(useTeamListing: boolean) {
+function getBuffListingRoot(useTeamListing: boolean) {
   return useTeamListing ? teamBuff : ownBuff
 }
 

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -20,6 +20,26 @@ export type DmgTag = Partial<
   Pick<Tag, 'damageType1' | 'damageType2' | 'attribute' | 'skillType'>
 >
 
+function isTeamBuffListing(
+  entry: TagMapNodeEntry,
+  team: boolean | undefined
+): boolean {
+  // `team` here is about *UI listing placement*, not calc targeting.
+  // If omitted, we infer the right listing from the entry's `et` so sheets
+  // don't have to repeat `team: true` for every `teamBuff.*` registration.
+  if (team === true) return true
+  if (team === false) return false
+  switch (entry.tag.et) {
+    case 'teamBuff':
+    case 'notOwnBuff':
+    case 'enemy':
+    case 'enemyDeBuff':
+      return true
+    default:
+      return false
+  }
+}
+
 export function register(
   sheet: Sheet,
   ...data: (TagMapNodeEntry | TagMapNodeEntries)[]
@@ -41,7 +61,7 @@ export function register(
  * @param name Unqiue name of buff
  * @param entries Buff/Buffs to register
  * @param cond Hide this buff behind this check
- * @param team Add to team formula listings if true
+ * @param team Add to team buff listings if true, own buff listings if false, or infer from entry `et` if omitted
  * @param includeOriginalEntry Set to false for buffs that are applied as additional entries into specific moves, so this buff won't get added to the character's stats
  * @returns Listing components to register the buff + the buff itself so it can be passed to `register`.
  */
@@ -49,7 +69,7 @@ export function registerBuff(
   name: string,
   entries: TagMapNodeEntry | TagMapNodeEntry[],
   cond: string | StrNode = 'infer',
-  team = false,
+  team?: boolean,
   includeOriginalEntry = true
 ): TagMapNodeEntries {
   if (!Array.isArray(entries)) entries = [entries]
@@ -58,7 +78,8 @@ export function registerBuff(
     // `namedReader` is also used as a `Tag` inside `listingItem`.
     const { sheet: _sheet, ...tag } = entry.tag
     const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
-    const listing = (team ? teamBuff : ownBuff).listing.buffs
+    const listing = (isTeamBuffListing(entry, team) ? teamBuff : ownBuff)
+      .listing.buffs
     return [
       // Add this buff to listing listing
       listing.add(listingItem(namedReader, cond)),
@@ -77,21 +98,22 @@ export function registerBuff(
  * @param name Unqiue name of buff
  * @param entry Buff to register
  * @param cond Hide this buff behind this check
- * @param team Add to team formula listings if true
+ * @param team Add to team buff listings if true, own buff listings if false, or infer from entry `et` if omitted
  * @returns Listing components to register the buff + the buff itself so it can be passed to `register`.
  */
 export function registerBuffFormula(
   name: string,
   entry: TagMapNodeEntry,
   cond: string | StrNode = 'infer',
-  team = false
+  team?: boolean
 ): TagMapNodeEntries {
   // Remove unused tags. We cannot use `sheet:null` here because
   // `namedReader` is also used as a `Tag` inside `listingItem`.
   const { sheet: _sheet, ...tag } = entry.tag
   const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
-  const buffListing = (team ? teamBuff : ownBuff).listing.buffs
-  const formulaListing = (team ? teamBuff : ownBuff).listing.formulas
+  const teamListing = isTeamBuffListing(entry, team)
+  const buffListing = (teamListing ? teamBuff : ownBuff).listing.buffs
+  const formulaListing = (teamListing ? teamBuff : ownBuff).listing.formulas
   return [
     // Add this buff to listing listing
     buffListing.add(listingItem(namedReader, cond)),

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -33,9 +33,7 @@ function resolveTeamBuffListing(
   entry: TagMapNodeEntry,
   team?: boolean
 ): boolean {
-  if (team === true) return true
-  if (team === false) return false
-  return TEAM_LISTING_ENTRY_TYPES.has(entry.tag.et)
+  return team ?? TEAM_LISTING_ENTRY_TYPES.has(entry.tag.et)
 }
 
 function buffListingRoot(useTeamListing: boolean) {

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -83,9 +83,8 @@ export function registerBuff(
   if (!Array.isArray(entries)) entries = [entries]
   return entries.flatMap((entry) => {
     const namedReader = displayNamedReader(entry, name)
-    const buffListing = buffListingRoot(
-      resolveTeamBuffListing(entry, team)
-    ).listing.buffs
+    const buffListing = buffListingRoot(resolveTeamBuffListing(entry, team))
+      .listing.buffs
     return [
       buffListing.add(listingItem(namedReader, cond)),
       namedReader.toEntry(entry.value),

--- a/libs/zzz/formula/src/data/util/sheet.ts
+++ b/libs/zzz/formula/src/data/util/sheet.ts
@@ -20,24 +20,32 @@ export type DmgTag = Partial<
   Pick<Tag, 'damageType1' | 'damageType2' | 'attribute' | 'skillType'>
 >
 
-function isTeamBuffListing(
+/** Entry types that register on `teamBuff.listing` when `team` is omitted. */
+const TEAM_LISTING_ENTRY_TYPES = new Set<Tag['et']>([
+  'teamBuff',
+  'notOwnBuff',
+  'enemy',
+  'enemyDeBuff',
+])
+
+/** UI listing placement (not calc targeting). Explicit `team` overrides inference. */
+function resolveTeamBuffListing(
   entry: TagMapNodeEntry,
-  team: boolean | undefined
+  team?: boolean
 ): boolean {
-  // `team` here is about *UI listing placement*, not calc targeting.
-  // If omitted, we infer the right listing from the entry's `et` so sheets
-  // don't have to repeat `team: true` for every `teamBuff.*` registration.
   if (team === true) return true
   if (team === false) return false
-  switch (entry.tag.et) {
-    case 'teamBuff':
-    case 'notOwnBuff':
-    case 'enemy':
-    case 'enemyDeBuff':
-      return true
-    default:
-      return false
-  }
+  return TEAM_LISTING_ENTRY_TYPES.has(entry.tag.et)
+}
+
+function buffListingRoot(useTeamListing: boolean) {
+  return useTeamListing ? teamBuff : ownBuff
+}
+
+function displayNamedReader(entry: TagMapNodeEntry, name: string) {
+  // Cannot use `sheet: null`; namedReader is also used as a `Tag` in `listingItem`.
+  const { sheet: _sheet, ...tag } = entry.tag
+  return reader.withTag({ ...tag, et: 'display', name })
 }
 
 export function register(
@@ -74,18 +82,13 @@ export function registerBuff(
 ): TagMapNodeEntries {
   if (!Array.isArray(entries)) entries = [entries]
   return entries.flatMap((entry) => {
-    // Remove unused tags. We cannot use `sheet:null` here because
-    // `namedReader` is also used as a `Tag` inside `listingItem`.
-    const { sheet: _sheet, ...tag } = entry.tag
-    const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
-    const listing = (isTeamBuffListing(entry, team) ? teamBuff : ownBuff)
-      .listing.buffs
+    const namedReader = displayNamedReader(entry, name)
+    const buffListing = buffListingRoot(
+      resolveTeamBuffListing(entry, team)
+    ).listing.buffs
     return [
-      // Add this buff to listing listing
-      listing.add(listingItem(namedReader, cond)),
-      // Hook for listing
+      buffListing.add(listingItem(namedReader, cond)),
       namedReader.toEntry(entry.value),
-      // Still include the original entry
       ...(includeOriginalEntry ? [entry] : []),
     ]
   })
@@ -107,20 +110,12 @@ export function registerBuffFormula(
   cond: string | StrNode = 'infer',
   team?: boolean
 ): TagMapNodeEntries {
-  // Remove unused tags. We cannot use `sheet:null` here because
-  // `namedReader` is also used as a `Tag` inside `listingItem`.
-  const { sheet: _sheet, ...tag } = entry.tag
-  const namedReader = reader.withTag({ ...tag, et: 'display', name }) // register name:<name>
-  const teamListing = isTeamBuffListing(entry, team)
-  const buffListing = (teamListing ? teamBuff : ownBuff).listing.buffs
-  const formulaListing = (teamListing ? teamBuff : ownBuff).listing.formulas
+  const namedReader = displayNamedReader(entry, name)
+  const listingRoot = buffListingRoot(resolveTeamBuffListing(entry, team))
   return [
-    // Add this buff to listing listing
-    buffListing.add(listingItem(namedReader, cond)),
-    formulaListing.add(listingItem(namedReader, cond)),
-    // Hook for listing
+    listingRoot.listing.buffs.add(listingItem(namedReader, cond)),
+    listingRoot.listing.formulas.add(listingItem(namedReader, cond)),
     namedReader.toEntry(entry.value),
-    // Still include the original entry
     entry,
   ]
 }

--- a/libs/zzz/formula/src/data/wengine/sheets/ChiefSidekick.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/ChiefSidekick.ts
@@ -65,9 +65,7 @@ const sheet = registerWengine(
           prod(fireExSpecialUsed, percent(subscript(phase, dm.common_dmg_)))
         )
       )
-    ),
-    undefined,
-    true
+    )
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/wengine/sheets/DreamlitHearth.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/DreamlitHearth.ts
@@ -45,8 +45,7 @@ const sheet = registerWengine(
         etherVeilActive.ifOn(percent(subscript(phase, dm.common_dmg_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   ),
   registerBuff(
     'hp_',
@@ -56,8 +55,7 @@ const sheet = registerWengine(
         etherVeilActive.ifOn(percent(subscript(phase, dm.hp_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/wengine/sheets/HalfSugarBunny.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/HalfSugarBunny.ts
@@ -40,16 +40,14 @@ const sheet = registerWengine(
     teamBuff.combat.atk_.add(
       cmpSpecialtyAndEquipped(key, percent(subscript(phase, dm.atk_)))
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   ),
   registerBuff(
     'passive_hp_',
     teamBuff.combat.hp_.add(
       cmpSpecialtyAndEquipped(key, percent(subscript(phase, dm.hp_)))
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   ),
   registerBuff(
     'cond_crit_dmg_',
@@ -59,8 +57,7 @@ const sheet = registerWengine(
         activateExtendEtherVeil.ifOn(percent(subscript(phase, dm.crit_dmg_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/wengine/sheets/NeonFantasies.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/NeonFantasies.ts
@@ -43,8 +43,7 @@ const sheet = registerWengine(
         prod(ether_exSpecial_basic, percent(subscript(phase, dm.common_dmg_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   ),
   registerBuff(
     'cond_anomProf',

--- a/libs/zzz/formula/src/data/wengine/sheets/OdeOfResurrectedWings.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/OdeOfResurrectedWings.ts
@@ -56,8 +56,7 @@ const sheet = registerWengine(
         refringeTriggered.ifOn(percent(subscript(phase, dm.common_dmg_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/wengine/sheets/Thoughtbop.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/Thoughtbop.ts
@@ -48,8 +48,7 @@ const sheet = registerWengine(
         prod(physExSpecialUsed, percent(subscript(phase, dm.common_dmg_)))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   ),
   registerBuff(
     'team_atk_',
@@ -59,8 +58,7 @@ const sheet = registerWengine(
         cmpGE(physExSpecialUsed, dm.stackThreshold, subscript(phase, dm.atk_))
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   )
 )
 export default sheet

--- a/libs/zzz/formula/src/data/wengine/sheets/YesterdayCalls.ts
+++ b/libs/zzz/formula/src/data/wengine/sheets/YesterdayCalls.ts
@@ -62,8 +62,7 @@ const sheet = registerWengine(
         )
       )
     ),
-    showSpecialtyAndEquipped(key),
-    true
+    showSpecialtyAndEquipped(key)
   )
 )
 export default sheet


### PR DESCRIPTION
## Summary
- Infer egisterBuff / egisterBuffFormula listing from entry `et` when `team` is omitted (	eamBuff / 
otOwnBuff / enemy / enemyDeBuff → team listing). Explicit `true` / `false` still override.
- Drop 110 redundant `, true` call sites now covered by inference.
- Leave Seed `core_dmg_` and Yanagi `exSpecial_anom_base_` (`ownBuff` + `true`) for a follow-up sheet fix.

Fixes teammate optimize UI missing discs/wengines that used `teamBuff.*` but never passed `team: true` (e.g. Astral Voice, Swing Jazz, King of the Summit, Yunkui Tales sheer), after #3225.

## Test plan
- [ ] Teammate with Astral Voice / Swing Jazz / King of the Summit / Yunkui Tales 4pc shows team buffs on optimize page
- [ ] Bunny / Moonlight / Freedom Blues still show
- [ ] Blazing Laurel Wilt / Lucia Nursery Rhyme show when applicable
- [ ] Own-only buffs stay off teammate team-buff panel
- [ ] Anton/Lucia move-scoped `includeOriginalEntry: false` buffs still behave (not global self)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and accuracy of buff and effect calculations across numerous characters, equipment items, and sets.
  * Conditional effects now follow their intended activation and placement rules, including team-wide and individual bonuses.
  * Preserved existing formulas and conditions while reducing discrepancies in displayed calculation results.

* **Refactor**
  * Standardized effect registration behavior for more reliable and maintainable future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->