### PR TITLE
ZO: Fix Thorned Rose and Feathered Fate 2p effects

### DIFF
--- a/libs/zzz/consts/src/disc.ts
+++ b/libs/zzz/consts/src/disc.ts
@@ -211,8 +211,8 @@ export const disc2pEffect: Record<
   YunkuiTales: { hp_: 0.1 },
   WutheringSalon: { wind_dmg_: 0.1 },
   TheSkyAblaze: { ether_dmg_: 0.1 },
-  ThornedRose: { anomProf: 30 },
-  FeatheredFate: { def_: 0.16 },
+  ThornedRose: { def_: 0.16 },
+  FeatheredFate: { anomProf: 30 },
 }
 
 // Copied from libs\zzz\dm\src\dm\disc\discNames.json, mainly used for scanner.

--- a/libs/zzz/formula/src/meta/disc/FeatheredFate/buffs.ts
+++ b/libs/zzz/formula/src/meta/disc/FeatheredFate/buffs.ts
@@ -6,7 +6,7 @@ export const buffs = {
     tag: {
       et: 'display',
       qt: 'initial',
-      q: 'def_',
+      q: 'anomProf',
       sheet: 'FeatheredFate',
       name: 'set2',
     },

--- a/libs/zzz/formula/src/meta/disc/ThornedRose/buffs.ts
+++ b/libs/zzz/formula/src/meta/disc/ThornedRose/buffs.ts
@@ -6,7 +6,7 @@ export const buffs = {
     tag: {
       et: 'display',
       qt: 'initial',
-      q: 'anomProf',
+      q: 'def_',
       sheet: 'ThornedRose',
       name: 'set2',
     },


### PR DESCRIPTION
## Describe your changes

Swaps Thorned Rose and Feathered Fate 2p effects

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the 2-piece bonuses for ThornedRose and FeatheredFate.
  * ThornedRose now grants Defense, while FeatheredFate grants Anomaly Proficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->