### PR TITLE
fix(zzz): Seed Besiege/Vanguard and teammate conditional toggles

### DIFF
--- a/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
@@ -72,6 +72,22 @@ export function ConditionalsDisplay({
   const [dst, setDst] = useState<string | null>(
     targeted ? Object.keys(dstDisplay)[0] : null
   )
+  // Hide the empty adder when every concrete src×dst pair is already used.
+  // "All" (dst=null) is not counted — it kept a duplicate empty row after a
+  // named target was already set.
+  const canAddTargeted = useMemo(() => {
+    if (!targeted) return false
+    const srcKeys = Object.keys(srcDisplay)
+    const dstKeys = Object.keys(dstDisplay)
+    if (!dstKeys.length) return false
+    return srcKeys.some((s) => dstKeys.some((d) => !hasExisting(s, d)))
+  }, [targeted, srcDisplay, dstDisplay, hasExisting])
+  const showEmptyConditional = targeted
+    ? canAddTargeted
+    : !filteredConditionals.length
+  // Avoid disabled one-option src/dst dropdowns that look like dead toggles.
+  const canPickSrc = Object.keys(srcDisplay).length > 1
+  const canPickDst = Object.keys(dstDisplay).length > 1
   return (
     <Stack spacing={1}>
       {filteredConditionals.map(({ src, dst, condKey, condValue }) => (
@@ -85,15 +101,14 @@ export function ConditionalsDisplay({
           bgt={bgt}
         />
       ))}
-      {/* // empty default conditional UI */}
-      {(targeted || !filteredConditionals.length) && (
+      {showEmptyConditional && (
         <ConditionalDisplay
           conditional={conditional}
           bgt={bgt}
           src={src}
-          setSrc={setSrc}
+          setSrc={canPickSrc ? setSrc : undefined}
           dst={dst}
-          setDst={setDst}
+          setDst={canPickDst ? setDst : undefined}
           value={0}
           setValue={(v) => setConditional(sheet, name, src, dst, v)}
           disabled={hasExisting(src, dst)}

--- a/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
+++ b/libs/game-opt/sheet-ui/src/components/ConditionalDisplay.tsx
@@ -12,7 +12,6 @@ import type {
   INumConditionalData,
 } from '@genshin-optimizer/game-opt/engine'
 import { CalcContext, TagContext } from '@genshin-optimizer/game-opt/formula-ui'
-import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import type { SliderProps } from '@mui/material'
@@ -45,6 +44,7 @@ export function ConditionalsDisplay({
 }) {
   const { srcDisplay, dstDisplay } = useContext(SrcDstDisplayContext)
   const setConditional = useContext(SetConditionalContext)
+  const tag = useContext(TagContext)
   const {
     metadata: { sheet, name },
     targeted,
@@ -67,27 +67,30 @@ export function ConditionalsDisplay({
     [filteredConditionals]
   )
 
-  const [src, setSrc] = useState<string>(Object.keys(srcDisplay)[0])
+  // Src is implied by TagContext (main kit or per-teammate card) — no picker.
+  const src =
+    (typeof tag?.src === 'string' && tag.src in srcDisplay
+      ? tag.src
+      : undefined) ?? Object.keys(srcDisplay)[0]
+
   // Set to first dst if targeted, else null
   const [dst, setDst] = useState<string | null>(
     targeted ? Object.keys(dstDisplay)[0] : null
   )
-  // Hide the empty adder when every concrete src×dst pair is already used.
+  // Hide the empty adder when every dst for this src is already used.
   // "All" (dst=null) is not counted — it kept a duplicate empty row after a
   // named target was already set.
   const canAddTargeted = useMemo(() => {
-    if (!targeted) return false
-    const srcKeys = Object.keys(srcDisplay)
+    if (!targeted || !src) return false
     const dstKeys = Object.keys(dstDisplay)
     if (!dstKeys.length) return false
-    return srcKeys.some((s) => dstKeys.some((d) => !hasExisting(s, d)))
-  }, [targeted, srcDisplay, dstDisplay, hasExisting])
+    return dstKeys.some((d) => !hasExisting(src, d))
+  }, [targeted, src, dstDisplay, hasExisting])
   const showEmptyConditional = targeted
     ? canAddTargeted
     : !filteredConditionals.length
-  // Avoid disabled one-option src/dst dropdowns that look like dead toggles.
-  const canPickSrc = Object.keys(srcDisplay).length > 1
-  const canPickDst = Object.keys(dstDisplay).length > 1
+  // Only offer a dst dropdown when there is more than one concrete target.
+  const canPickDst = targeted && Object.keys(dstDisplay).length > 1
   return (
     <Stack spacing={1}>
       {filteredConditionals.map(({ src, dst, condKey, condValue }) => (
@@ -106,7 +109,6 @@ export function ConditionalsDisplay({
           conditional={conditional}
           bgt={bgt}
           src={src}
-          setSrc={canPickSrc ? setSrc : undefined}
           dst={dst}
           setDst={canPickDst ? setDst : undefined}
           value={0}
@@ -121,7 +123,6 @@ export function ConditionalsDisplay({
 const ConditionalDisplay = memo(function ConditionalDisplay({
   conditional,
   src,
-  setSrc,
   dst,
   setDst,
   value,
@@ -131,7 +132,6 @@ const ConditionalDisplay = memo(function ConditionalDisplay({
 }: {
   conditional: Conditional
   src: string
-  setSrc?: (src: string) => void
   dst: string | null
   setDst?: (dst: string | null) => void
   value: number
@@ -139,8 +139,8 @@ const ConditionalDisplay = memo(function ConditionalDisplay({
   bgt?: CardBackgroundColor
   disabled?: boolean
 }) {
-  const { header, fields, targeted } = conditional
-  const { srcDisplay, dstDisplay } = useContext(SrcDstDisplayContext)
+  const { header, fields } = conditional
+  const { dstDisplay } = useContext(SrcDstDisplayContext)
   const tag = useContext(TagContext)
   const newTag = useMemo(
     () => ({
@@ -154,15 +154,9 @@ const ConditionalDisplay = memo(function ConditionalDisplay({
   return (
     <CardThemed bgt={bgt}>
       {!!header && <HeaderDisplay header={header} />}
-      {targeted && (
-        <CondSrcDst
-          src={src}
-          srcDisplay={srcDisplay}
-          setSrc={setSrc}
-          dst={dst}
-          dstDisplay={dstDisplay}
-          setDst={setDst}
-        />
+      {/* Src is fixed by sheet context; only dst is selectable when targeted. */}
+      {setDst && (
+        <CondDst dst={dst} dstDisplay={dstDisplay} setDst={setDst} />
       )}
       <ConditionalSelector
         disabled={disabled}
@@ -347,85 +341,21 @@ function CondSlider(props: Omit<SliderProps, 'onChange'>) {
   )
 }
 
-function CondSrcDst<S extends string, D extends string>({
-  src,
-  srcDisplay,
-  setSrc,
+function CondDst<D extends string>({
   dst,
   dstDisplay,
   setDst,
 }: {
-  src: S
-  srcDisplay: Record<S, ReactNode>
-  setSrc?: (src: S) => void
   dst: D | null
   dstDisplay: Record<D, ReactNode>
-  setDst?: (dst: D | null) => void
+  setDst: (dst: D | null) => void
 }) {
-  if (!Object.keys(srcDisplay).length || !Object.keys(dstDisplay).length)
-    return null
+  if (!Object.keys(dstDisplay).length) return null
   return (
-    <Box display="flex" alignItems="center" justifyContent="space-between">
-      <SrcDisplay target={src} targetMap={srcDisplay} setTarget={setSrc} />
-      <ArrowRightAltIcon />
-      <DstDisplay target={dst} targetMap={dstDisplay} setTarget={setDst} />
+    <Box display="flex" alignItems="center" justifyContent="flex-end">
+      <DstDropDown target={dst} targetMap={dstDisplay} onChange={setDst} />
     </Box>
   )
-}
-
-function SrcDisplay<T extends string>({
-  target,
-  targetMap,
-  setTarget,
-}: {
-  target: T
-  targetMap: Record<T, ReactNode>
-  setTarget?: (t: T) => void
-}) {
-  if (setTarget)
-    return (
-      <SrcDropDown target={target} targetMap={targetMap} onChange={setTarget} />
-    )
-  return targetMap[target]
-}
-
-function SrcDropDown<K extends string>({
-  target,
-  targetMap,
-  onChange,
-}: {
-  target: K
-  targetMap: Record<K, ReactNode>
-  onChange: (target: K) => void
-}) {
-  const onlyOption = Object.keys(targetMap).length === 1
-  // TODO: Translate
-  return (
-    <DropdownButton title={targetMap[target]} disabled={onlyOption}>
-      {Object.entries(targetMap).map(([key, display]) => (
-        <MenuItem key={key} onClick={() => onChange(key as K)}>
-          {display}
-        </MenuItem>
-      ))}
-    </DropdownButton>
-  )
-}
-
-function DstDisplay<T extends string>({
-  target,
-  targetMap,
-  setTarget,
-}: {
-  target: T | null
-  targetMap: Record<T, ReactNode>
-  setTarget?: (t: T | null) => void
-}) {
-  if (setTarget)
-    return (
-      <DstDropDown target={target} targetMap={targetMap} onChange={setTarget} />
-    )
-  if (target) return targetMap[target]
-  return 'All'
 }
 
 function DstDropDown<K extends string>({
@@ -437,13 +367,9 @@ function DstDropDown<K extends string>({
   targetMap: Record<K, ReactNode>
   onChange: (target: K | null) => void
 }) {
-  const onlyOption = Object.keys(targetMap).length === 1
   // TODO: Translate
   return (
-    <DropdownButton
-      title={target ? targetMap[target] : 'All'}
-      disabled={onlyOption}
-    >
+    <DropdownButton title={target ? targetMap[target] : 'All'}>
       <MenuItem key="all" onClick={() => onChange(null)}>
         All
       </MenuItem>

--- a/libs/zzz/formula-ui/src/char/sheets/Seed.tsx
+++ b/libs/zzz/formula-ui/src/char/sheets/Seed.tsx
@@ -30,8 +30,8 @@ const sheet = createBaseSheet(key, {
         fields: [
           fieldForBuff(buff.core_vanguard_atk),
           fieldForBuff(buff.core_vanguard_crit_dmg_),
+          fieldForBuff(buff.core_vanguard_dmg_),
         ],
-        targeted: true,
       },
     },
     {
@@ -95,7 +95,6 @@ const sheet = createBaseSheet(key, {
       conditional: {
         label: ch('coreCond.directStrike'),
         metadata: cond.directStrike,
-        targeted: true,
       },
     },
     {

--- a/libs/zzz/formula/src/data/char/sheets/Seed.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Seed.ts
@@ -2,6 +2,7 @@ import type { NumNode } from '@genshin-optimizer/pando/engine'
 import {
   cmpEq,
   cmpGE,
+  cmpNE,
   prod,
   subscript,
   sum,
@@ -44,11 +45,13 @@ const { energy_consumed } = allNumConditionals(
   dm.m2.max_energy_consumed - dm.m2.energy_consumed
 )
 
+// Vanguard = Attack teammate, not Seed. Old check used team.initial.atk.max,
+// so Seed (also Attack) could be the max and block every ally from the buff.
 const directStrikeCheck = (node: NumNode | number) =>
   cmpGE(
     sum(
-      cmpEq(team.initial.atk.max, target.initial.atk, 1),
-      cmpEq(target.char.specialty, 'attack', 1)
+      cmpEq(target.char.specialty, 'attack', 1),
+      cmpNE(target.char.key, char.key, 1)
     ),
     2,
     node
@@ -184,13 +187,18 @@ const sheet = register(
       )
     )
   ),
+  // Besiege DMG%: Seed (own) and Vanguard (notOwn), matching kit + M2 defIgn split.
   registerBuff(
     'core_dmg_',
     ownBuff.combat.common_dmg_.add(
       besiege(percent(subscript(char.core, dm.core.dmg_)))
-    ),
-    undefined,
-    true
+    )
+  ),
+  registerBuff(
+    'core_vanguard_dmg_',
+    notOwnBuff.combat.common_dmg_.add(
+      besiege(directStrikeCheck(percent(subscript(char.core, dm.core.dmg_))))
+    )
   ),
   registerBuff(
     'ability_basic_dmg_',

--- a/libs/zzz/formula/src/data/char/sheets/Yanagi.ts
+++ b/libs/zzz/formula/src/data/char/sheets/Yanagi.ts
@@ -125,7 +125,7 @@ const sheet = register(
   registerBuff('basic_pen_', ownBuff.combat.pen_.add(kagen.ifOn(percent(0.1)))),
   registerBuff(
     'exSpecial_anom_base_',
-    ownBuff.combat.anom_base_.addWithDmgType(
+    teamBuff.combat.anom_base_.addWithDmgType(
       'disorder',
       cmpEq(
         polarityDisorder.value,
@@ -146,9 +146,7 @@ const sheet = register(
           percent(-0.85)
         )
       )
-    ),
-    undefined,
-    true
+    )
   ),
   registerBuff(
     'ult_anom_base_',

--- a/libs/zzz/formula/src/meta/char/Seed/buffs.ts
+++ b/libs/zzz/formula/src/meta/char/Seed/buffs.ts
@@ -55,6 +55,17 @@ export const buffs = {
       name: 'core_dmg_',
     },
   },
+  core_vanguard_dmg_: {
+    sheet: 'Seed',
+    name: 'core_vanguard_dmg_',
+    tag: {
+      et: 'display',
+      qt: 'combat',
+      q: 'common_dmg_',
+      sheet: 'Seed',
+      name: 'core_vanguard_dmg_',
+    },
+  },
   ability_basic_dmg_: {
     sheet: 'Seed',
     name: 'ability_basic_dmg_',

--- a/libs/zzz/page-optimize/src/Teammates.tsx
+++ b/libs/zzz/page-optimize/src/Teammates.tsx
@@ -179,7 +179,10 @@ function TeammateBuffs({
   )
 
   return (
-    <TeammateConditionalProvider teammateKey={teammateKey}>
+    <TeammateConditionalProvider
+      teammateKey={teammateKey}
+      mainCharacterKey={mainCharacterKey}
+    >
       <TagContext.Provider value={tag}>
         <TeammateBuffsContent
           teammateKey={teammateKey}
@@ -249,27 +252,43 @@ function TeammateBuffsContent({
 
 function TeammateConditionalProvider({
   teammateKey,
+  mainCharacterKey,
   children,
 }: {
   teammateKey: CharacterKey
+  mainCharacterKey: CharacterKey
   children: ReactNode
 }) {
-  // Route sheet conditionals through this teammate as `src` (main unit stays `dst` via TagContext).
+  // Route sheet conditionals through this teammate as `src`. Clear main-dst
+  // leftovers and store dst=null so ownBuff + notOwnBuff both see the toggle;
+  // coalesce still shows legacy All/main rows as checked.
   const parentSetConditional = useContext(SetConditionalContext)
   const parentConditionals = useContext(ConditionalValuesContext)
   const parentSrcDstDisplay = useContext(SrcDstDisplayContext)
   const setConditional = useCallback<SetConditionalFunc>(
-    (sheet, condKey, _src, dst, condValue) =>
-      parentSetConditional?.(sheet, condKey, teammateKey, dst, condValue),
-    [parentSetConditional, teammateKey]
+    (sheet, condKey, _src, _dst, condValue) => {
+      parentSetConditional?.(sheet, condKey, teammateKey, mainCharacterKey, 0)
+      parentSetConditional?.(sheet, condKey, teammateKey, null, condValue)
+    },
+    [parentSetConditional, teammateKey, mainCharacterKey]
   )
   const teammateConditionals = useMemo(
-    () => parentConditionals.filter(({ src }) => src === teammateKey),
-    [parentConditionals, teammateKey]
+    () =>
+      coalesceTeammateConditionals(
+        parentConditionals,
+        teammateKey,
+        mainCharacterKey
+      ),
+    [parentConditionals, teammateKey, mainCharacterKey]
   )
   const srcDstDisplay = useMemo(
-    () => mergeTeammateSrcDstDisplay(parentSrcDstDisplay, teammateKey),
-    [parentSrcDstDisplay, teammateKey]
+    () =>
+      mergeTeammateSrcDstDisplay(
+        parentSrcDstDisplay,
+        teammateKey,
+        mainCharacterKey
+      ),
+    [parentSrcDstDisplay, teammateKey, mainCharacterKey]
   )
 
   return (
@@ -347,17 +366,55 @@ function teammateCalcTag(
   }
 }
 
+function coalesceTeammateConditionals(
+  conditionals: readonly {
+    sheet: string
+    src: string
+    dst: string | null
+    condKey: string
+    condValue: number
+  }[],
+  teammateKey: CharacterKey,
+  mainCharacterKey: CharacterKey
+) {
+  // Include legacy dst=null ("All") so an already-on buff still shows as checked.
+  // Prefer an explicit main dst when both exist; always display as main.
+  const byCond = new Map<
+    string,
+    {
+      sheet: string
+      src: string
+      dst: string | null
+      condKey: string
+      condValue: number
+    }
+  >()
+  for (const conditional of conditionals) {
+    if (conditional.src !== teammateKey) continue
+    if (conditional.dst !== mainCharacterKey && conditional.dst !== null)
+      continue
+    const key = `${conditional.sheet}:${conditional.condKey}`
+    const existing = byCond.get(key)
+    if (!existing || conditional.dst === mainCharacterKey) {
+      byCond.set(key, { ...conditional, dst: mainCharacterKey })
+    }
+  }
+  return [...byCond.values()]
+}
+
 function mergeTeammateSrcDstDisplay(
   parent: SrcDstDisplayContextObj,
-  teammateKey: CharacterKey
+  teammateKey: CharacterKey,
+  mainCharacterKey: CharacterKey
 ): SrcDstDisplayContextObj {
-  // Keep parent dst labels (main unit) for targeted conditional UI.
+  // Teammate card: src = this teammate, dst = main only (no All / other ally).
   return {
     srcDisplay: {
-      ...parent.srcDisplay,
       [teammateKey]: <CharacterName characterKey={teammateKey} />,
     },
-    dstDisplay: parent.dstDisplay,
+    dstDisplay: {
+      [mainCharacterKey]: parent.dstDisplay[mainCharacterKey],
+    },
   }
 }
 

--- a/libs/zzz/page-optimize/src/Teammates.tsx
+++ b/libs/zzz/page-optimize/src/Teammates.tsx
@@ -259,9 +259,9 @@ function TeammateConditionalProvider({
   mainCharacterKey: CharacterKey
   children: ReactNode
 }) {
-  // Route sheet conditionals through this teammate as `src`. Clear main-dst
-  // leftovers and store dst=null so ownBuff + notOwnBuff both see the toggle;
-  // coalesce still shows legacy All/main rows as checked.
+  // Src is fixed by TagContext (this teammate); clear main-dst leftovers and
+  // store dst=null so ownBuff + notOwnBuff both see the toggle. Coalesce still
+  // shows legacy All/main rows as checked.
   const parentSetConditional = useContext(SetConditionalContext)
   const parentConditionals = useContext(ConditionalValuesContext)
   const parentSrcDstDisplay = useContext(SrcDstDisplayContext)


### PR DESCRIPTION
## Summary
- **Seed:** Add Vanguard `notOwnBuff` Besiege DMG%; keep Seed own Besiege as `ownBuff` (drop listing `true`). Vanguard ATK/CDMG gated by Attack + not Seed. Direct Strike is plain on/off; Vanguard is formula-selected.
- **Yanagi:** EX Special `anom_base_` → `teamBuff` (same polarity as Ult; removes `ownBuff` + `true` listing override).
- **Optimize teammate cards:** Lock writes to that teammate; coalesce legacy All/main rows; clear main then store `dst=null` on toggle.
- **Conditionals UI:** Remove src picker (src from TagContext / per-teammate card). Dst dropdown only when targeted with multiple targets.

## Test plan
- [ ] Optimize Harumasa with Seed + Astra: toggle Seed Direct Strike — Harumasa ATK/CRIT DMG move; Astra does not get Vanguard ATK
- [ ] With Direct Strike + Onslaught on: Besiege DMG% on both Seed and Harumasa
- [ ] Toggle Direct Strike off: leftover All/main rows don't keep the buff stuck
- [ ] Teammate conditionals show checkbox only (no src → dst chrome)
- [ ] Astra teammate conditionals still toggle and apply to main