### PR TITLE
Add storage usage card to settings

### DIFF
--- a/libs/common/localization/assets/locales/en/common.json
+++ b/libs/common/localization/assets/locales/en/common.json
@@ -34,6 +34,8 @@
   "storage": {
     "title": "Storage Usage",
     "info": "Local storage is limited to 5 MB total, and this is shared across Genshin Optimizer and Zenless Optimizer. Each database stored will take up some space, and the currently active database will take additional space.\n\nIf you are nearing the storage limit, data may fail to save or may get erased.",
+    "category": "Category",
+    "size": "Space Used",
     "activeGo": "Active GO Database",
     "goDb1": "GO Database 1",
     "goDb2": "GO Database 2",

--- a/libs/common/localization/assets/locales/en/common.json
+++ b/libs/common/localization/assets/locales/en/common.json
@@ -33,7 +33,8 @@
   },
   "storage": {
     "title": "Storage Usage",
-    "info": "Local storage is limited to 5 MB total, and this is shared across Genshin Optimizer and Zenless Optimizer. Each database stored will take up some space, and the currently active database will take additional space.\n\nIf you are nearing the storage limit, data may fail to save or may get erased.",
+    "info": "Local storage is limited to 5 MB total, and this is shared across Genshin Optimizer and Zenless Optimizer. Each database stored will take up some space, and the currently active database will take additional space.\n\nIf you are nearing the storage limit, data may fail to save or may get erased without warning.",
+    "warning": "You are near the local storage limit, data may fail to save or may get erased without warning.",
     "category": "Category",
     "size": "Space Used",
     "activeGo": "Active GO Database",

--- a/libs/common/localization/assets/locales/en/common.json
+++ b/libs/common/localization/assets/locales/en/common.json
@@ -30,5 +30,19 @@
   "gender": {
     "F": "Female",
     "M": "Male"
+  },
+  "storage": {
+    "title": "Storage Usage",
+    "info": "Local storage is limited to 5 MB total, and this is shared across Genshin Optimizer and Zenless Optimizer. Each database stored will take up some space, and the currently active database will take additional space.\n\nIf you are nearing the storage limit, data may fail to save or may get erased.",
+    "activeGo": "Active GO Database",
+    "goDb1": "GO Database 1",
+    "goDb2": "GO Database 2",
+    "goDb3": "GO Database 3",
+    "goDb4": "GO Database 4",
+    "activeZo": "Active ZO Database",
+    "zoDb1": "ZO Database 1",
+    "zoDb2": "ZO Database 2",
+    "zoDb3": "ZO Database 3",
+    "zoDb4": "ZO Database 4"
   }
 }

--- a/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
+++ b/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
@@ -214,39 +214,39 @@ export function LocalStorageUsageCard() {
                   <TableCell sx={{ pl: 6 }}>{t('storage.category')}</TableCell>
                   <TableCell>{t('storage.size')}</TableCell>
                 </TableRow>
-                {Object.entries(MBByCategory)
-                  .sort((a, b) => b[1] - a[1])
-                  .map(([key, megabytes]) => (
-                    <TableRow
-                      sx={{
-                        opacity:
-                          percentByCategory[key] > DISPLAY_PERCENT_THRESH
-                            ? undefined
-                            : 0.5,
-                      }}
-                    >
-                      <TableCell>
-                        <Box
-                          display="inline-block"
-                          width="16px"
-                          height="16px"
-                          mr={2}
-                          sx={{
-                            backgroundColor:
-                              percentByCategory[key] > DISPLAY_PERCENT_THRESH
-                                ? COLORS[key]
-                                : undefined,
-                          }}
-                        />
-                        {t(`storage.${key}`)}
-                      </TableCell>
-                      <TableCell>
-                        {megabytes.toFixed(2)}MB (
-                        {percentByCategory[key].toFixed(2)}%)
-                      </TableCell>
-                    </TableRow>
-                  ))}
               </TableHead>
+              {Object.entries(MBByCategory)
+                .sort((a, b) => b[1] - a[1])
+                .map(([key, megabytes]) => (
+                  <TableRow
+                    sx={{
+                      opacity:
+                        percentByCategory[key] > DISPLAY_PERCENT_THRESH
+                          ? undefined
+                          : 0.5,
+                    }}
+                  >
+                    <TableCell>
+                      <Box
+                        display="inline-block"
+                        width="16px"
+                        height="16px"
+                        mr={2}
+                        sx={{
+                          backgroundColor:
+                            percentByCategory[key] > DISPLAY_PERCENT_THRESH
+                              ? COLORS[key]
+                              : undefined,
+                        }}
+                      />
+                      {t(`storage.${key}`)}
+                    </TableCell>
+                    <TableCell>
+                      {megabytes.toFixed(2)}MB (
+                      {percentByCategory[key].toFixed(2)}%)
+                    </TableCell>
+                  </TableRow>
+                ))}
             </Table>
           </TableContainer>
         </Box>

--- a/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
+++ b/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
@@ -108,96 +108,114 @@ export function LocalStorageUsageCard() {
       <CardContent
         sx={{
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'start',
           justifyContent: 'center',
           flexWrap: 'wrap',
           gap: 2,
         }}
       >
-        <Typography width={'100%'}>{t('storage.info')}</Typography>
-        {/* Stack a bunch of circle bars together */}
-        <CircularProgress
-          size={100}
-          thickness={5}
-          variant="determinate"
-          value={100}
+        <Box
           sx={{
-            color: 'contentNormal.main',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            flexBasis: 250,
+            flexGrow: 1,
+            gap: 2,
           }}
-        />
-        {Object.entries(percentByCategory)
-          .sort((a, b) => a[1] - b[1])
-          .filter(([, percent]) => percent > 1)
-          .map(([key, percent]) => {
-            const prog = (
-              <CircularProgress
-                key={key}
-                size={100}
-                thickness={5}
-                variant="determinate"
-                value={currentPercent}
-                sx={{ ml: '-116px', color: COLORS[key] }}
-              />
-            )
-            currentPercent -= percent
-            return prog
-          })}
-        {/* Text next to circle bars */}
-        <Typography variant="h6">
-          <Box
-            component="span"
-            color={
-              percent > 90 ? 'error' : percent > 75 ? 'warning.main' : undefined
-            }
-          >
-            {totalMB.toFixed(2)}MB
-          </Box>{' '}
-          /{' '}
-          <Box component="span" color="secondary.main">
-            {MAX_LOCAL_STORAGE_MB}MB
-          </Box>{' '}
-          <br />
-          {percent.toFixed(2)}%
-        </Typography>
-        {/* Table */}
-        <TableContainer sx={{ width: 'max-content' }}>
-          <Table
-            size="small"
+        >
+          <Typography pb={4}>{t('storage.info')}</Typography>
+          {/* Stack a bunch of circle bars together */}
+          <CircularProgress
+            size={100}
+            thickness={5}
+            variant="determinate"
+            value={100}
             sx={{
-              width: 'max-content',
-              [`& .${tableCellClasses.root}`]: {
-                borderBottom: 'none',
-              },
+              color: 'contentNormal.main',
             }}
-          >
-            <TableHead>
-              <TableRow>
-                <TableCell>{t('storage.category')}</TableCell>
-                <TableCell>{t('storage.size')}</TableCell>
-              </TableRow>
-              {Object.entries(MBByCategory)
-                .sort((a, b) => b[1] - a[1])
-                .map(([key, megabytes]) => (
-                  <TableRow>
-                    <TableCell>
-                      <Box
-                        display="inline-block"
-                        width="16px"
-                        height="16px"
-                        mr={2}
-                        sx={{ backgroundColor: COLORS[key] }}
-                      />
-                      {t(`storage.${key}`)}
-                    </TableCell>
-                    <TableCell>
-                      {megabytes.toFixed(2)}MB (
-                      {percentByCategory[key].toFixed(2)}%)
-                    </TableCell>
-                  </TableRow>
-                ))}
-            </TableHead>
-          </Table>
-        </TableContainer>
+          />
+          {Object.entries(percentByCategory)
+            .sort((a, b) => a[1] - b[1])
+            .filter(([, percent]) => percent > 1)
+            .map(([key, percent]) => {
+              const prog = (
+                <CircularProgress
+                  key={key}
+                  size={100}
+                  thickness={5}
+                  variant="determinate"
+                  value={currentPercent}
+                  sx={{ ml: '-116px', color: COLORS[key] }}
+                />
+              )
+              currentPercent -= percent
+              return prog
+            })}
+          {/* Text next to circle bars */}
+          <Typography variant="h6">
+            <Box
+              component="span"
+              color={
+                percent > 90
+                  ? 'error'
+                  : percent > 75
+                    ? 'warning.main'
+                    : undefined
+              }
+            >
+              {totalMB.toFixed(2)}MB
+            </Box>{' '}
+            /{' '}
+            <Box component="span" color="secondary.main">
+              {MAX_LOCAL_STORAGE_MB}MB
+            </Box>{' '}
+            <br />
+            {percent.toFixed(2)}%
+          </Typography>
+        </Box>
+        {/* Table */}
+        <Box display="flex">
+          <TableContainer sx={{ width: 'max-content' }}>
+            <Table
+              size="small"
+              sx={{
+                width: 'max-content',
+                [`& .${tableCellClasses.root}`]: {
+                  borderBottom: 'none',
+                },
+              }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('storage.category')}</TableCell>
+                  <TableCell>{t('storage.size')}</TableCell>
+                </TableRow>
+                {Object.entries(MBByCategory)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([key, megabytes]) => (
+                    <TableRow>
+                      <TableCell>
+                        <Box
+                          display="inline-block"
+                          width="16px"
+                          height="16px"
+                          mr={2}
+                          sx={{ backgroundColor: COLORS[key] }}
+                        />
+                        {t(`storage.${key}`)}
+                      </TableCell>
+                      <TableCell>
+                        {megabytes.toFixed(2)}MB (
+                        {percentByCategory[key].toFixed(2)}%)
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableHead>
+            </Table>
+          </TableContainer>
+        </Box>
       </CardContent>
     </CardThemed>
   )

--- a/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
+++ b/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
@@ -1,0 +1,159 @@
+import { CardThemed } from '@genshin-optimizer/common/ui'
+import { objMap } from '@genshin-optimizer/common/util'
+import { SdStorage } from '@mui/icons-material'
+import {
+  Box,
+  CardContent,
+  CircularProgress,
+  Divider,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+const MAX_LOCAL_STORAGE_MB = 5
+const COLORS = {
+  activeGo: '#550055',
+  goDb1: '#555500',
+  goDb2: '#005555',
+  goDb3: '#55aa55',
+  goDb4: '#5555aa',
+  activeZo: '#aa5555',
+  zoDb1: '#aaaa55',
+  zoDb2: '#55aaaa',
+  zoDb3: '#aa55aa',
+  zoDb4: '#ffaaff',
+}
+export function LocalStorageUsageCard() {
+  const { t } = useTranslation('common')
+  let totalBytes = 0
+  const bytesByCategory = {
+    activeGo: 0,
+    goDb1: 0,
+    goDb2: 0,
+    goDb3: 0,
+    goDb4: 0,
+    activeZo: 0,
+    zoDb1: 0,
+    zoDb2: 0,
+    zoDb3: 0,
+    zoDb4: 0,
+  }
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (!key) continue
+    // Calculate bytes for both the key and the value
+    const value = localStorage.getItem(key)
+    const size = new Blob(value ? [key, value] : [key]).size
+    totalBytes += size
+    if (key.startsWith('zzz_extraDatabase')) {
+      switch (key[key.length - 1]) {
+        case '1':
+          bytesByCategory.zoDb1 += size
+          continue
+        case '2':
+          bytesByCategory.zoDb2 += size
+          continue
+        case '3':
+          bytesByCategory.zoDb3 += size
+          continue
+        case '4':
+          bytesByCategory.zoDb4 += size
+          continue
+      }
+    } else if (key.startsWith('zzz_')) {
+      bytesByCategory.activeZo += size
+    } else if (key.startsWith('extraDatabase')) {
+      switch (key[key.length - 1]) {
+        case '1':
+          bytesByCategory.goDb1 += size
+          continue
+        case '2':
+          bytesByCategory.goDb2 += size
+          continue
+        case '3':
+          bytesByCategory.goDb3 += size
+          continue
+        case '4':
+          bytesByCategory.goDb4 += size
+          continue
+      }
+    } else {
+      bytesByCategory.activeGo += size
+    }
+  }
+  const MBByCategory = objMap(bytesByCategory, (v) => v / 1024 / 1024)
+  const percentByCategory = objMap(
+    MBByCategory,
+    (v) => (v / MAX_LOCAL_STORAGE_MB) * 100
+  )
+
+  const totalMB = totalBytes / 1024 / 1024
+  const percent = (totalMB / MAX_LOCAL_STORAGE_MB) * 100
+  let currentPercent = percent
+
+  return (
+    <CardThemed bgt="light">
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <SdStorage sx={{ fontSize: '40px' }} />
+        <Typography variant="h5">{t('storage.title')}</Typography>
+      </CardContent>
+      <Divider />
+      <CardContent
+        sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}
+      >
+        <Typography width={'100%'}>{t('storage.info')}</Typography>
+        <CircularProgress
+          size={100}
+          thickness={5}
+          variant="determinate"
+          value={100}
+          sx={{
+            color: '#222222',
+          }}
+        />
+        {Object.entries(percentByCategory)
+          .sort((a, b) => a[1] - b[1])
+          .map(([key, percent]) => {
+            const prog = (
+              <CircularProgress
+                key={key}
+                size={100}
+                thickness={5}
+                variant="determinate"
+                value={currentPercent}
+                sx={{ ml: '-116px', color: COLORS[key] }}
+              />
+            )
+            currentPercent -= percent
+            return prog
+          })}
+        <Typography
+          variant="h6"
+          color={percent > 90 ? 'error' : percent > 75 ? 'orange' : undefined}
+        >
+          {totalMB.toFixed(2)}MB / {MAX_LOCAL_STORAGE_MB}MB (
+          {percent.toFixed(2)}%)
+        </Typography>
+        <Box display="flex" flexWrap="wrap">
+          {Object.entries(MBByCategory)
+            .sort((a, b) => b[1] - a[1])
+            .map(([key, megabytes]) => (
+              <Box width="100%" display="flex" gap={1}>
+                <Box
+                  display="inline-block"
+                  width="16px"
+                  height="16px"
+                  sx={{ backgroundColor: COLORS[key] }}
+                />
+                <Typography key={key}>
+                  {t(`storage.${key}`)} - {megabytes.toFixed(2)}MB (
+                  {percentByCategory[key].toFixed(2)}%)
+                </Typography>
+              </Box>
+            ))}
+        </Box>
+      </CardContent>
+    </CardThemed>
+  )
+}

--- a/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
+++ b/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
@@ -6,22 +6,28 @@ import {
   CardContent,
   CircularProgress,
   Divider,
+  Table,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
   Typography,
+  tableCellClasses,
 } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 const MAX_LOCAL_STORAGE_MB = 5
 const COLORS = {
-  activeGo: '#550055',
-  goDb1: '#555500',
-  goDb2: '#005555',
-  goDb3: '#55aa55',
-  goDb4: '#5555aa',
-  activeZo: '#aa5555',
-  zoDb1: '#aaaa55',
-  zoDb2: '#55aaaa',
-  zoDb3: '#aa55aa',
-  zoDb4: '#ffaaff',
+  activeGo: '#55aaff',
+  goDb1: '#5577ff',
+  goDb2: '#22ff55',
+  goDb3: '#ffaa55',
+  goDb4: '#ff6655',
+  activeZo: '#ff2255',
+  zoDb1: '#aa55ff',
+  zoDb2: '#aaff55',
+  zoDb3: '#2255aa',
+  zoDb4: '#22aa55',
 }
 export function LocalStorageUsageCard() {
   const { t } = useTranslation('common')
@@ -100,20 +106,28 @@ export function LocalStorageUsageCard() {
       </CardContent>
       <Divider />
       <CardContent
-        sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
       >
         <Typography width={'100%'}>{t('storage.info')}</Typography>
+        {/* Stack a bunch of circle bars together */}
         <CircularProgress
           size={100}
           thickness={5}
           variant="determinate"
           value={100}
           sx={{
-            color: '#222222',
+            color: 'contentNormal.main',
           }}
         />
         {Object.entries(percentByCategory)
           .sort((a, b) => a[1] - b[1])
+          .filter(([, percent]) => percent > 1)
           .map(([key, percent]) => {
             const prog = (
               <CircularProgress
@@ -128,31 +142,62 @@ export function LocalStorageUsageCard() {
             currentPercent -= percent
             return prog
           })}
-        <Typography
-          variant="h6"
-          color={percent > 90 ? 'error' : percent > 75 ? 'orange' : undefined}
-        >
-          {totalMB.toFixed(2)}MB / {MAX_LOCAL_STORAGE_MB}MB (
-          {percent.toFixed(2)}%)
+        {/* Text next to circle bars */}
+        <Typography variant="h6">
+          <Box
+            component="span"
+            color={
+              percent > 90 ? 'error' : percent > 75 ? 'warning.main' : undefined
+            }
+          >
+            {totalMB.toFixed(2)}MB
+          </Box>{' '}
+          /{' '}
+          <Box component="span" color="secondary.main">
+            {MAX_LOCAL_STORAGE_MB}MB
+          </Box>{' '}
+          <br />
+          {percent.toFixed(2)}%
         </Typography>
-        <Box display="flex" flexWrap="wrap">
-          {Object.entries(MBByCategory)
-            .sort((a, b) => b[1] - a[1])
-            .map(([key, megabytes]) => (
-              <Box width="100%" display="flex" gap={1}>
-                <Box
-                  display="inline-block"
-                  width="16px"
-                  height="16px"
-                  sx={{ backgroundColor: COLORS[key] }}
-                />
-                <Typography key={key}>
-                  {t(`storage.${key}`)} - {megabytes.toFixed(2)}MB (
-                  {percentByCategory[key].toFixed(2)}%)
-                </Typography>
-              </Box>
-            ))}
-        </Box>
+        {/* Table */}
+        <TableContainer sx={{ width: 'max-content' }}>
+          <Table
+            size="small"
+            sx={{
+              width: 'max-content',
+              [`& .${tableCellClasses.root}`]: {
+                borderBottom: 'none',
+              },
+            }}
+          >
+            <TableHead>
+              <TableRow>
+                <TableCell>{t('storage.category')}</TableCell>
+                <TableCell>{t('storage.size')}</TableCell>
+              </TableRow>
+              {Object.entries(MBByCategory)
+                .sort((a, b) => b[1] - a[1])
+                .map(([key, megabytes]) => (
+                  <TableRow>
+                    <TableCell>
+                      <Box
+                        display="inline-block"
+                        width="16px"
+                        height="16px"
+                        mr={2}
+                        sx={{ backgroundColor: COLORS[key] }}
+                      />
+                      {t(`storage.${key}`)}
+                    </TableCell>
+                    <TableCell>
+                      {megabytes.toFixed(2)}MB (
+                      {percentByCategory[key].toFixed(2)}%)
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableHead>
+          </Table>
+        </TableContainer>
       </CardContent>
     </CardThemed>
   )

--- a/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
+++ b/libs/common/react-util/src/Components/LocalStorageUsageCard.tsx
@@ -2,6 +2,7 @@ import { CardThemed } from '@genshin-optimizer/common/ui'
 import { objMap } from '@genshin-optimizer/common/util'
 import { SdStorage } from '@mui/icons-material'
 import {
+  Alert,
   Box,
   CardContent,
   CircularProgress,
@@ -29,6 +30,9 @@ const COLORS = {
   zoDb3: '#2255aa',
   zoDb4: '#22aa55',
 }
+const DISPLAY_PERCENT_THRESH = 1
+const WARNING_PERCENT_THRESH = 75
+const ERROR_PERCENT_THRESH = 90
 export function LocalStorageUsageCard() {
   const { t } = useTranslation('common')
   let totalBytes = 0
@@ -114,6 +118,14 @@ export function LocalStorageUsageCard() {
           gap: 2,
         }}
       >
+        {percent > WARNING_PERCENT_THRESH && (
+          <Alert
+            sx={{ width: '100%' }}
+            severity={percent > ERROR_PERCENT_THRESH ? 'error' : 'warning'}
+          >
+            {t('storage.warning')}
+          </Alert>
+        )}
         <Box
           sx={{
             display: 'flex',
@@ -138,7 +150,7 @@ export function LocalStorageUsageCard() {
           />
           {Object.entries(percentByCategory)
             .sort((a, b) => a[1] - b[1])
-            .filter(([, percent]) => percent > 1)
+            .filter(([, percent]) => percent > DISPLAY_PERCENT_THRESH)
             .map(([key, percent]) => {
               const prog = (
                 <CircularProgress
@@ -158,21 +170,31 @@ export function LocalStorageUsageCard() {
             <Box
               component="span"
               color={
-                percent > 90
-                  ? 'error'
-                  : percent > 75
+                percent > ERROR_PERCENT_THRESH
+                  ? 'error.main'
+                  : percent > WARNING_PERCENT_THRESH
                     ? 'warning.main'
                     : undefined
               }
             >
               {totalMB.toFixed(2)}MB
             </Box>{' '}
-            /{' '}
             <Box component="span" color="secondary.main">
-              {MAX_LOCAL_STORAGE_MB}MB
+              / {MAX_LOCAL_STORAGE_MB}MB
             </Box>{' '}
             <br />
-            {percent.toFixed(2)}%
+            <Box
+              component="span"
+              color={
+                percent > ERROR_PERCENT_THRESH
+                  ? 'error.main'
+                  : percent > WARNING_PERCENT_THRESH
+                    ? 'warning.main'
+                    : undefined
+              }
+            >
+              {percent.toFixed(2)}%
+            </Box>
           </Typography>
         </Box>
         {/* Table */}
@@ -189,20 +211,32 @@ export function LocalStorageUsageCard() {
             >
               <TableHead>
                 <TableRow>
-                  <TableCell>{t('storage.category')}</TableCell>
+                  <TableCell sx={{ pl: 6 }}>{t('storage.category')}</TableCell>
                   <TableCell>{t('storage.size')}</TableCell>
                 </TableRow>
                 {Object.entries(MBByCategory)
                   .sort((a, b) => b[1] - a[1])
                   .map(([key, megabytes]) => (
-                    <TableRow>
+                    <TableRow
+                      sx={{
+                        opacity:
+                          percentByCategory[key] > DISPLAY_PERCENT_THRESH
+                            ? undefined
+                            : 0.5,
+                      }}
+                    >
                       <TableCell>
                         <Box
                           display="inline-block"
                           width="16px"
                           height="16px"
                           mr={2}
-                          sx={{ backgroundColor: COLORS[key] }}
+                          sx={{
+                            backgroundColor:
+                              percentByCategory[key] > DISPLAY_PERCENT_THRESH
+                                ? COLORS[key]
+                                : undefined,
+                          }}
                         />
                         {t(`storage.${key}`)}
                       </TableCell>

--- a/libs/common/react-util/src/index.ts
+++ b/libs/common/react-util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './Components/LocalStorageUsageCard'
 export * from './Components/ReadOnlyTextArea'
 export * from './hooks/useBoolState'
 export * from './hooks/useForceUpdate'

--- a/libs/common/react-util/tsconfig.lib.json
+++ b/libs/common/react-util/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node", "object-overrides"]
   },
   "files": [
     "../../../node_modules/@nx/react/typings/cssmodule.d.ts",

--- a/libs/common/react-util/tsconfig.lib.json
+++ b/libs/common/react-util/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
     "outDir": "../../../dist/out-tsc",
     "types": ["node", "object-overrides"]
   },

--- a/libs/gi/page-settings/src/index.tsx
+++ b/libs/gi/page-settings/src/index.tsx
@@ -1,6 +1,7 @@
+import { LocalStorageUsageCard } from '@genshin-optimizer/common/react-util'
 import { CardThemed } from '@genshin-optimizer/common/ui'
 import { DatabaseCard } from '@genshin-optimizer/gi/ui'
-import { CardContent, Divider, Typography } from '@mui/material'
+import { CardContent, Divider, Grid, Typography } from '@mui/material'
 import ReactGA from 'react-ga4'
 import { Trans, useTranslation } from 'react-i18next'
 import LanguageCard from './LanguageCard'
@@ -20,9 +21,22 @@ export default function PageSettings() {
       </CardContent>
       <Divider />
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <LanguageCard />
-        <SnowToggle />
-        <SillyCard />
+        <Grid container direction="row" spacing={1}>
+          <Grid item xs={6}>
+            <LanguageCard />
+          </Grid>
+          <Grid item xs={6}>
+            <SnowToggle />
+          </Grid>
+        </Grid>
+        <Grid container direction="row" spacing={1}>
+          <Grid item sm={12} md={6}>
+            <SillyCard />
+          </Grid>
+          <Grid item sm={12} md={6}>
+            <LocalStorageUsageCard />
+          </Grid>
+        </Grid>
         <DatabaseCard />
       </CardContent>
     </CardThemed>

--- a/libs/zzz/page-settings/src/index.tsx
+++ b/libs/zzz/page-settings/src/index.tsx
@@ -1,11 +1,15 @@
+import { LocalStorageUsageCard } from '@genshin-optimizer/common/react-util'
 import { CardThemed } from '@genshin-optimizer/common/ui'
 import { DatabaseCard } from '@genshin-optimizer/zzz/ui'
-import { CardContent } from '@mui/material'
+import { Box, CardContent } from '@mui/material'
 
 export default function PageSettings() {
   return (
     <CardThemed sx={{ my: 1 }}>
       <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box maxWidth="50%">
+          <LocalStorageUsageCard />
+        </Box>
         <DatabaseCard />
       </CardContent>
     </CardThemed>


### PR DESCRIPTION
## Describe your changes

Add a user-friendly view to localstorage usage in the settings tab for GO/ZO.
<img width="456" height="686" alt="image" src="https://github.com/user-attachments/assets/70dd251e-26bb-4423-a99a-67989dcf4f31" />



## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added a local-storage usage card to Settings.
* Displays total usage, capacity percentage, categorized usage, and alerts as storage approaches the shared 5 MB limit.
* Identifies storage used by active and numbered Genshin Optimizer and Zenless Optimizer databases.
* Warns that stored data may be erased without warning.
* Added localized labels for storage categories and database usage.

## UI Improvements

* Reorganized Settings cards into a responsive two-column layout for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->