### PR TITLE
GO: Add config to not delete chars missing from import by default

### DIFF
--- a/libs/gi/db/src/Database/ArtCharDatabase.test.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.test.ts
@@ -26,14 +26,14 @@ describe(
       const database1 = new ArtCharDatabase(1, dbStorage1)
 
       const input = structuredClone(testDatabaseJson) as any
-      database1.importGOOD(input, false, false)
+      database1.importGOOD(input, false, false, false)
       const firstExport = database1.exportGOOD()
 
       // Second cycle: import normalized data, export again
       const dbStorage2 = createTestDBStorage('go')
       const database2 = new ArtCharDatabase(1, dbStorage2)
 
-      database2.importGOOD(firstExport, false, false)
+      database2.importGOOD(firstExport, false, false, false)
       const secondExport = database2.exportGOOD()
 
       // The normalized JSON should be identical

--- a/libs/gi/db/src/Database/ArtCharDatabase.ts
+++ b/libs/gi/db/src/Database/ArtCharDatabase.ts
@@ -158,7 +158,8 @@ export class ArtCharDatabase extends Database {
   }
   importGOOD(
     good: IGOOD & IGO,
-    keepNotInImport: boolean,
+    keepWepArtiNotInImport: boolean,
+    keepCharNotInImport: boolean,
     ignoreDups: boolean
   ): ImportResult {
     good = migrateGOOD(good)
@@ -172,7 +173,8 @@ export class ArtCharDatabase extends Database {
     }
     const result: ImportResult = newImportResult(
       source,
-      keepNotInImport,
+      keepWepArtiNotInImport,
+      keepCharNotInImport,
       ignoreDups
     )
 

--- a/libs/gi/db/src/Database/DataManagers/ArtifactDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/ArtifactDataManager.ts
@@ -261,7 +261,7 @@ export class ArtifactDataManager extends DataManager<
       this.set(importId, importArt, !foundDupOrUpgrade)
     })
     const idtoRemoveArr = Array.from(idsToRemove)
-    if (result.keepNotInImport || result.ignoreDups)
+    if (result.keepWepArtiNotInImport || result.ignoreDups)
       result.artifacts.notInImport = idtoRemoveArr.length
     else idtoRemoveArr.forEach((k) => this.remove(k))
 

--- a/libs/gi/db/src/Database/DataManagers/CharacterDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/CharacterDataManager.ts
@@ -214,7 +214,7 @@ export class CharacterDataManager extends DataManager<
       idsToRemove.delete('Somnia')
 
       const idtoRemoveArr = Array.from(idsToRemove)
-      if (result.keepNotInImport || result.ignoreDups)
+      if (result.keepCharNotInImport || result.ignoreDups)
         result.characters.notInImport = idtoRemoveArr.length
       else idtoRemoveArr.forEach((k) => this.remove(k))
       result.characters.unchanged = []

--- a/libs/gi/db/src/Database/DataManagers/WeaponDataManager.ts
+++ b/libs/gi/db/src/Database/DataManagers/WeaponDataManager.ts
@@ -231,7 +231,7 @@ export class WeaponDataManager extends DataManager<
     const idtoRemoveArr = Array.from(idsToRemove).filter(
       (id) => this.get(id)?.key !== 'QuantumCatalyst'
     )
-    if (result.keepNotInImport || result.ignoreDups)
+    if (result.keepWepArtiNotInImport || result.ignoreDups)
       result.weapons.notInImport = idtoRemoveArr.length
     else idtoRemoveArr.forEach((k) => this.remove(k))
 

--- a/libs/gi/db/src/Database/Database.test.ts
+++ b/libs/gi/db/src/Database/Database.test.ts
@@ -48,7 +48,7 @@ describe('Database', () => {
 
     const newDB = new ArtCharDatabase(dbIndex, new SandboxStorage())
     const good = database.exportGOOD()
-    newDB.importGOOD(good, false, false)!
+    newDB.importGOOD(good, false, false, false)!
     expect(
       database.storage.entries.filter(
         ([k]) =>
@@ -224,7 +224,12 @@ describe('Database', () => {
       artifacts: [art1, art2],
       weapons: [amberWeapon],
     }
-    const importResult = database.importGOOD(good as IGOOD & IGO, false, false)
+    const importResult = database.importGOOD(
+      good as IGOOD & IGO,
+      false,
+      false,
+      false
+    )
     expect(importResult.characters?.new?.length).toEqual(2)
     expect(importResult.artifacts.invalid.length).toEqual(0)
     expect(importResult.artifacts?.new?.length).toEqual(2)
@@ -248,7 +253,7 @@ describe('Database', () => {
     }
 
     // Import the new artifact, with no location. this should respect current equipment
-    database.importGOOD(good as IGOOD & IGO, false, false)
+    database.importGOOD(good as IGOOD & IGO, false, false, false)
     expect(database.chars.get('Amber')?.equippedArtifacts.circlet).toEqual(id)
   })
 
@@ -287,7 +292,12 @@ describe('Database', () => {
       ],
       weapons: [{ ...initialWeapon('CinnabarSpindle'), location: 'Albedo' }],
     }
-    const importResult = database.importGOOD(good1 as IGOOD & IGO, true, false)
+    const importResult = database.importGOOD(
+      good1 as IGOOD & IGO,
+      true,
+      false,
+      false
+    )
     expect(importResult.artifacts.new.length).toEqual(2)
     expect(importResult.weapons.new.length).toEqual(1)
     expect(importResult.characters.new.length).toEqual(0)
@@ -328,7 +338,12 @@ describe('Database', () => {
       source: 'Scanner',
       weapons: [a1, a2new, a4],
     }
-    const importResult = database.importGOOD(good1 as IGOOD & IGO, true, false)
+    const importResult = database.importGOOD(
+      good1 as IGOOD & IGO,
+      true,
+      false,
+      false
+    )
     expect(importResult.weapons.upgraded.length).toEqual(1)
     expect(importResult.weapons.unchanged.length).toEqual(1)
     expect(importResult.weapons.notInImport).toEqual(1)
@@ -382,7 +397,12 @@ describe('Database', () => {
       source: 'Scanner',
       artifacts: [a1, a2new, a4],
     }
-    const importResult = database.importGOOD(good1 as IGOOD & IGO, true, false)
+    const importResult = database.importGOOD(
+      good1 as IGOOD & IGO,
+      true,
+      false,
+      false
+    )
     expect(importResult.artifacts.upgraded.length).toEqual(1)
     expect(importResult.artifacts.unchanged.length).toEqual(1)
     expect(importResult.artifacts.notInImport).toEqual(1)
@@ -413,7 +433,12 @@ describe('Database', () => {
         },
       ],
     }
-    const importResult = database.importGOOD(good as IGOOD & IGO, false, false)
+    const importResult = database.importGOOD(
+      good as IGOOD & IGO,
+      false,
+      false,
+      false
+    )
     expect(importResult.weapons.new.length).toEqual(1)
     expect(importResult.characters.new.length).toEqual(1)
     expect(database.chars.get('Dori')?.equippedWeapon).toBeTruthy()
@@ -450,7 +475,12 @@ describe('Database', () => {
         ],
       }
 
-      const importResult = database.importGOOD(good as IGOOD & IGO, true, false)
+      const importResult = database.importGOOD(
+        good as IGOOD & IGO,
+        true,
+        false,
+        false
+      )
       expect(importResult.artifacts.notInImport).toEqual(0)
       expect(importResult.artifacts.unchanged.length).toEqual(4)
       expect(database.arts.values.length).toEqual(4)
@@ -492,7 +522,12 @@ describe('Database', () => {
         ],
       }
 
-      const importResult = database.importGOOD(good as IGOOD & IGO, true, false)
+      const importResult = database.importGOOD(
+        good as IGOOD & IGO,
+        true,
+        false,
+        false
+      )
       expect(importResult.weapons.notInImport).toEqual(0)
       expect(importResult.weapons.unchanged.length).toEqual(4)
       expect(database.weapons.values.length).toEqual(4)
@@ -525,7 +560,12 @@ describe('Database', () => {
         ],
       }
 
-      const importResult = database.importGOOD(good as IGOOD & IGO, true, false)
+      const importResult = database.importGOOD(
+        good as IGOOD & IGO,
+        true,
+        false,
+        false
+      )
       expect(importResult.artifacts.notInImport).toEqual(2)
       expect(database.arts.values.length).toEqual(4)
       // Expect imports to overwrite the id of old
@@ -560,7 +600,12 @@ describe('Database', () => {
         ],
       }
 
-      const importResult = database.importGOOD(good as IGOOD & IGO, true, false)
+      const importResult = database.importGOOD(
+        good as IGOOD & IGO,
+        true,
+        false,
+        false
+      )
       expect(importResult.weapons.notInImport).toEqual(2)
       expect(database.weapons.values.length).toEqual(4)
       // Expect imports to overwrite the id of old
@@ -706,7 +751,12 @@ describe('Database', () => {
         { ...initialWeapon('AlleyHunter'), location: 'Albedo' },
       ],
     }
-    const importResult = database.importGOOD(good1 as IGOOD & IGO, true, false)
+    const importResult = database.importGOOD(
+      good1 as IGOOD & IGO,
+      true,
+      false,
+      false
+    )
     expect(importResult.weapons.invalid.length).toEqual(1)
     expect(importResult.characters.new.length).toEqual(0)
     expect(

--- a/libs/gi/db/src/Database/exim.ts
+++ b/libs/gi/db/src/Database/exim.ts
@@ -25,7 +25,8 @@ function newImportCounter(): ImportResultCounter {
 
 export function newImportResult(
   source: string,
-  keepNotInImport: boolean,
+  keepWepArtiNotInImport: boolean,
+  keepCharNotInImport: boolean,
   ignoreDups: boolean
 ): ImportResult {
   return {
@@ -38,7 +39,8 @@ export function newImportResult(
     buildTcs: newImportCounter(),
     teams: newImportCounter(),
     teamChars: newImportCounter(),
-    keepNotInImport,
+    keepWepArtiNotInImport,
+    keepCharNotInImport,
     ignoreDups,
   }
 }
@@ -76,6 +78,7 @@ export type ImportResult = {
   buildTcs: ImportResultCounter
   teams: ImportResultCounter
   teamChars: ImportResultCounter
-  keepNotInImport: boolean
+  keepWepArtiNotInImport: boolean
+  keepCharNotInImport: boolean
   ignoreDups: boolean
 }

--- a/libs/gi/localization/assets/locales/en/settings.json
+++ b/libs/gi/localization/assets/locales/en/settings.json
@@ -58,13 +58,16 @@
     "buttons": {
       "open": "Open",
       "detectDups": "Detect Updates/Dupes",
-      "delNotInImport": "Delete items not in import"
+      "delWepArtiNotInImport": "Delete weapons/artifacts not in import",
+      "delCharNotInImport": "Delete characters not in import"
     },
     "tooltip": {
       "detectdup": "Find upgrades/duplicates in the GO inventory and merge the import into GO.",
       "ignoreDup": "Do not detect upgrades/duplicates. The import will be added on top of existing GO inventory.",
-      "delNotInImport": "Assume the import is your full inventory. Items in the GO Inventory that don't exist in the import will be deleted.",
-      "keepNotInImport": "Assume the import is a partial inventory. Nothing will be deleted."
+      "delWepArtiNotInImport": "Assume the import is your full inventory of weapons and artifacts. Weapons and artifacts in the GO Inventory that don't exist in the import will be deleted.",
+      "keepWepArtiNotInImport": "Assume the import is a partial inventory of weapons and artifacts. Nothing will be deleted.",
+      "delCharNotInImport": "Assume the import is your full inventory of characters. Characters in the GO Inventory that don't exist in the import will be deleted.",
+      "keepCharNotInImport": "Assume the import is a partial inventory of characters. Nothing will be deleted."
     }
   }
 }

--- a/libs/gi/ui/src/components/database/UploadCard.tsx
+++ b/libs/gi/ui/src/components/database/UploadCard.tsx
@@ -43,7 +43,8 @@ export function UploadCard({
   const [data, setdata] = useState('')
   const [filename, setfilename] = useState('')
   const [errorMsg, setErrorMsg] = useState('') // TODO localize error msg
-  const [keepNotInImport, setKeepNotInImport] = useState(false)
+  const [keepWepArtiNotInImport, setKeepWepArtiNotInImport] = useState(false)
+  const [keepCharNotInImport, setKeepCharNotInImport] = useState(true)
   const [ignoreDups, setIgnoreDups] = useState(false)
   const { importResult, importedDatabase } =
     useMemo(() => {
@@ -70,7 +71,8 @@ export function UploadCard({
         )
         const importResult = importedDatabase.importGOOD(
           parsed,
-          keepNotInImport,
+          keepWepArtiNotInImport,
+          keepCharNotInImport,
           ignoreDups
         )
         if (!importResult) {
@@ -82,7 +84,14 @@ export function UploadCard({
       }
       setErrorMsg('uploadCard.error.unknown')
       return undefined
-    }, [data, database, keepNotInImport, ignoreDups, index]) ?? {}
+    }, [
+      data,
+      database,
+      keepWepArtiNotInImport,
+      keepCharNotInImport,
+      ignoreDups,
+      index,
+    ]) ?? {}
   const reset = () => {
     setdata('')
     setfilename('')
@@ -173,9 +182,9 @@ export function UploadCard({
           <Tooltip
             title={
               <Typography>
-                {keepNotInImport
-                  ? t('uploadCard.tooltip.keepNotInImport')
-                  : t('uploadCard.tooltip.delNotInImport')}
+                {keepWepArtiNotInImport
+                  ? t('uploadCard.tooltip.keepWepArtiNotInImport')
+                  : t('uploadCard.tooltip.delWepArtiNotInImport')}
               </Typography>
             }
             placement="top"
@@ -185,13 +194,44 @@ export function UploadCard({
               <Button
                 fullWidth
                 disabled={!data}
-                color={keepNotInImport ? 'primary' : 'success'}
-                onClick={() => setKeepNotInImport(!keepNotInImport)}
+                color={keepWepArtiNotInImport ? 'primary' : 'success'}
+                onClick={() =>
+                  setKeepWepArtiNotInImport(!keepWepArtiNotInImport)
+                }
                 startIcon={
-                  keepNotInImport ? <CheckBoxOutlineBlank /> : <CheckBox />
+                  keepWepArtiNotInImport ? (
+                    <CheckBoxOutlineBlank />
+                  ) : (
+                    <CheckBox />
+                  )
                 }
               >
-                {t('uploadCard.buttons.delNotInImport')}
+                {t('uploadCard.buttons.delWepArtiNotInImport')}
+              </Button>
+            </Box>
+          </Tooltip>
+          <Tooltip
+            title={
+              <Typography>
+                {keepCharNotInImport
+                  ? t('uploadCard.tooltip.keepCharNotInImport')
+                  : t('uploadCard.tooltip.delCharNotInImport')}
+              </Typography>
+            }
+            placement="top"
+            arrow
+          >
+            <Box sx={{ flexGrow: 1, flexBasis: '10em' }}>
+              <Button
+                fullWidth
+                disabled={!data}
+                color={keepCharNotInImport ? 'primary' : 'success'}
+                onClick={() => setKeepCharNotInImport(!keepCharNotInImport)}
+                startIcon={
+                  keepCharNotInImport ? <CheckBoxOutlineBlank /> : <CheckBox />
+                }
+              >
+                {t('uploadCard.buttons.delCharNotInImport')}
               </Button>
             </Box>
           </Tooltip>


### PR DESCRIPTION
## Describe your changes

Irminsul is updated to only include the current traveler element (e.g. `TravelerCryo`) instead of the generic traveler key (`Traveler`). Without this option, many users will just import the JSON and leave the "Delete items not in scan" option enabled, which will delete all the other traveler elements.

This new setting is off by default, since most users don't lose characters, so deleting characters would likely be due to an erroneous scan or mistake, rather than an intended effect

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate import settings for retaining or removing weapons and artifacts versus characters.
  - Added dedicated controls, labels, and tooltips for each inventory category.
  - Characters are now retained by default, while weapons and artifacts are removed by default when absent from an import.
  - Import settings are applied independently, giving you finer control over inventory cleanup.

- **Bug Fixes**
  - Import processing now consistently applies the selected retention setting to each category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->