### PR TITLE
ZO: Change opt target for crit rate to be non-capped version

### DIFF
--- a/libs/zzz/db/src/Database/DataManagers/TeamDataManager.ts
+++ b/libs/zzz/db/src/Database/DataManagers/TeamDataManager.ts
@@ -75,7 +75,7 @@ export const targetQ = [
   'def',
   'impact',
   'sheerForce',
-  'cappedCrit_',
+  'crit_',
   'crit_dmg_',
   'pen_',
   'pen',

--- a/libs/zzz/formula/src/data/char/util.ts
+++ b/libs/zzz/formula/src/data/char/util.ts
@@ -560,7 +560,7 @@ export function entriesForChar(data_gen: CharacterDatum): TagMapNodeEntries {
     ownBuff.listing.formulas.add(listingItem(own.final.def)),
     ownBuff.listing.formulas.add(listingItem(own.final.impact)),
     ownBuff.listing.formulas.add(listingItem(own.final.sheerForce)),
-    ownBuff.listing.formulas.add(listingItem(own.common.cappedCrit_)),
+    ownBuff.listing.formulas.add(listingItem(own.final.crit_)),
     ownBuff.listing.formulas.add(listingItem(own.final.crit_dmg_)),
     ownBuff.listing.formulas.add(listingItem(own.final.pen_)),
     ownBuff.listing.formulas.add(listingItem(own.final.pen)),


### PR DESCRIPTION
## Describe your changes

We were adding the `cappedCrit_` formula as the opt target and listing in the UI, which only exists in `own.common` space, and not `own.initial` nor `own.final`. The dropdown for initial vs final on this stat would still show, but when selecting either, would cause a crash.

Following GO, I just adjusted the opt target and listing in the UI to be the regular `crit_`, as users probably prefer to know if they have overcapped crit, and seeing the overflowing crit rate number may prove to be helpful in the near future...

For DBs that already have this value set for an opt target, it will just reset to no opt target, and the user can select a target again

## Issue or discord link

- https://discord.com/channels/785153694478893126/1539840245711896586

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated critical-stat targeting to use the current `crit_` key.
  * Updated formula listings to display the correct final critical-stat value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->