### PR TITLE
GO: Fix issues with Odette and Mizuki sheets

### DIFF
--- a/libs/gi/sheets/src/Characters/Odette/index.tsx
+++ b/libs/gi/sheets/src/Characters/Odette/index.tsx
@@ -737,6 +737,7 @@ const sheet: TalentSheet = {
         ),
     }),
     ct.headerTem('constellation2', {
+      canShow: unequal(condA1TeamSplendor, undefined, 1),
       teamBuff: true,
       fields: [
         {
@@ -748,6 +749,7 @@ const sheet: TalentSheet = {
       ],
     }),
     ct.headerTem('constellation6', {
+      canShow: unequal(condA1TeamSplendor, undefined, 1),
       teamBuff: true,
       fields: Object.values(c6Team_stellar_specialDmg_obj).map((node) => ({
         node,

--- a/libs/gi/sheets/src/Characters/Odette/index.tsx
+++ b/libs/gi/sheets/src/Characters/Odette/index.tsx
@@ -188,13 +188,17 @@ const a1TeamSplendor_stellar_dmg_obj = objKeyValMap(
   (k) => [`${k}_dmg_`, { ...a1TeamSplendor_stellar_dmg_ }]
 )
 
-const a1SelfSplendor = threshold(
-  input.constellation,
-  6,
-  maxSplendor,
-  sum(
-    threshold(input.constellation, 1, maxSplendor, dm.passive1.stackGain),
-    prod(-1, a1TeamSplendor)
+const a1SelfSplendor = unequal(
+  condA1TeamSplendor,
+  undefined,
+  threshold(
+    input.constellation,
+    6,
+    maxSplendor,
+    sum(
+      threshold(input.constellation, 1, maxSplendor, dm.passive1.stackGain),
+      prod(-1, a1TeamSplendor)
+    )
   )
 )
 const a1SelfSplendor_stellar_dmg_ = greaterEq(
@@ -223,10 +227,22 @@ const a4_stellar_mult_disp = greaterEq(
 )
 const a4_stellar_mult_ = sum(one, a4_stellar_mult_disp)
 
-const c2TeamSplendor_atk_ = greaterEq(
-  input.constellation,
-  2,
-  greaterEq(input.asc, 1, prod(a1TeamSplendor, percent(dm.constellation2.atk_)))
+const c2TeamSplendor_atk_disp = infoMut(
+  greaterEq(
+    input.constellation,
+    2,
+    greaterEq(
+      input.asc,
+      1,
+      prod(a1TeamSplendor, percent(dm.constellation2.atk_))
+    )
+  ),
+  { path: 'atk_', isTeamBuff: true }
+)
+const c2TeamSplendor_atk_ = unequal(
+  target.charKey,
+  key,
+  c2TeamSplendor_atk_disp
 )
 const c2SelfSplendor_atk_ = greaterEq(
   input.constellation,
@@ -727,7 +743,7 @@ const sheet: TalentSheet = {
           node: c2SelfSplendor_atk_,
         },
         {
-          node: c2TeamSplendor_atk_,
+          node: c2TeamSplendor_atk_disp,
         },
       ],
     }),

--- a/libs/gi/sheets/src/Characters/YumemizukiMizuki/index.tsx
+++ b/libs/gi/sheets/src/Characters/YumemizukiMizuki/index.tsx
@@ -161,7 +161,7 @@ const lockDream_eleMas = equal(
     'on',
     equal(
       input.activeCharKey,
-      'on',
+      key,
       prod(percent(dm.lockedPassive.eleMas), input.premod.eleMas)
     )
   )
@@ -197,7 +197,7 @@ const c2Dream_dmg_ = objKeyValMap(absorbableEle, (ele) => [
       'on',
       equal(
         input.activeCharKey,
-        'on',
+        key,
         prod(percent(dm.constellation2.phec_dmg_), input.total.eleMas)
       )
     )
@@ -208,7 +208,15 @@ const c2Dream_res_ = objKeyValMap([...absorbableEle, 'anemo'], (ele) => [
   greaterEq(
     input.constellation,
     2,
-    equal(condLockRevelation, 'on', dm.constellation2.eleRes_)
+    equal(
+      condSkillDream,
+      'on',
+      equal(
+        condLockRevelation,
+        'on',
+        equal(input.activeCharKey, key, dm.constellation2.eleRes_)
+      )
+    )
   ),
 ])
 
@@ -652,7 +660,7 @@ const sheet: TalentSheet = {
         },
       },
     }),
-    ct.condTem('passive3', {
+    ct.condTem('lockedPassive', {
       path: condLockStellarRadiancePath,
       value: condLockStellarRadiance,
       teamBuff: true,


### PR DESCRIPTION
## Describe your changes

* Fix Odette self Splendor stacks applying when the conditional was not set
* Fix Mizuki C2 not working at all
* Fix Mizuki locked passive having the wrong text

## Issue or discord link

- Fix #3286 
- Fix #3283 
- https://discord.com/channels/785153694478893126/1539820659692019812

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Odette’s Splendor calculations so personal and team buffs are applied appropriately.
  * Updated Odette’s constellation display to clearly identify team buffs and show relevant nodes only when conditions are set.
  * Fixed Mizuki’s active-character checks and constellation resistance reduction conditions.
  * Corrected registration of Mizuki’s Stellar Radiance condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->