### PR TITLE
Memoize freshArtifact() over set keys

### DIFF
--- a/libs/gi/upopt/src/testArtifacts.json
+++ b/libs/gi/upopt/src/testArtifacts.json
@@ -1,5 +1,6 @@
 {
   "lvl20": {
+    "id": "lvl20",
     "setKey": "GladiatorsFinale",
     "slotKey": "flower",
     "level": 20,

--- a/libs/gi/upopt/src/upOpt.test.ts
+++ b/libs/gi/upopt/src/upOpt.test.ts
@@ -1,4 +1,8 @@
-import type { SubstatKey } from '@genshin-optimizer/gi/consts'
+import type {
+  ArtifactSetKey,
+  ArtifactSlotKey,
+  SubstatKey,
+} from '@genshin-optimizer/gi/consts'
 import { allSubstatKeys } from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
 import { getMainStatValue, getSubstatValue } from '@genshin-optimizer/gi/util'
@@ -22,13 +26,22 @@ import {
   elixirDefinition,
   expandNode,
   expandNodes,
+  freshArtifact,
   levelUpArtifact,
 } from './upOpt'
 import type { MarkovNode, SubstatLevelNode } from './upOpt.types'
-import type { ElixirDefineQuery, ElixirSimplifiedCache } from './upOptMemoize'
-import { elixirDefinitionMemoSimplified } from './upOptMemoize'
+import type {
+  ElixirDefineQuery,
+  ElixirSimplifiedCache,
+  FreshArtifactCache,
+} from './upOptMemoize'
+import {
+  elixirDefinitionMemoSimplified,
+  freshArtifactMemoized,
+} from './upOptMemoize'
 
-const emptyBuild = {
+type Build = Record<ArtifactSlotKey, ICachedArtifact | undefined>
+const emptyBuild: Build = {
   flower: undefined,
   plume: undefined,
   sands: undefined,
@@ -72,6 +85,49 @@ function checkExpandedEvalCorrectness(
   const baseEval = evaluateGaussian(obj, g)
   expect(mean).toBeCloseTo(baseEval.f_mu[0])
   expect(sig2).toBeCloseTo(baseEval.f_cov[0][0])
+}
+
+/**
+ * Order-independent identity for a node: everything `deduplicate()` treats as
+ * distinguishing, with `base` canonicalized since key insertion order differs
+ * between the memoized and reference construction paths. Deliberately written
+ * independently of `deduplicate`'s own internal key, so these comparisons don't end up
+ * validating the implementation against itself.
+ */
+function canonicalNodeKey(n: SubstatLevelNode): string {
+  return JSON.stringify([
+    n.rarity,
+    n.rollsLeft,
+    n.reshape ?? null,
+    n.subkeys,
+    Object.entries(n.base).sort(([a], [b]) => a.localeCompare(b)),
+    n.subDistr.subs,
+    n.subDistr.mu,
+    n.subDistr.cov,
+  ])
+}
+
+/**
+ * Compares two weighted node lists as distributions: same set of distinct nodes,
+ * same total probability on each. Node order carries no meaning -- `deduplicate` groups by
+ * hash and hands back its producer's order -- so this is the real contract.
+ */
+function expectSameDistribution(
+  got: { p: number; n: SubstatLevelNode }[],
+  want: { p: number; n: MarkovNode }[]
+) {
+  const tally = (nodes: { p: number; n: MarkovNode }[]) => {
+    const m = new Map<string, number>()
+    nodes.forEach(({ p, n }) => {
+      const k = canonicalNodeKey(n as SubstatLevelNode)
+      m.set(k, (m.get(k) ?? 0) + p)
+    })
+    return m
+  }
+  const g = tally(got)
+  const w = tally(want)
+  expect([...g.keys()].sort()).toEqual([...w.keys()].sort())
+  g.forEach((p, k) => expect(p).toBeCloseTo(w.get(k)!, 12))
 }
 
 describe('upOpt components', () => {
@@ -545,7 +601,148 @@ describe('upOpt makeSubstatNode(s)', () => {
       })
     })
   })
-  test('fresh/domain/strongbox', () => {})
+  describe('fresh/domain/strongbox', () => {
+    const p3sub = 0.2
+    const rarity = 5 as const
+    const oneSet: ArtifactSetKey[] = ['GladiatorsFinale']
+    const twoSets: ArtifactSetKey[] = [
+      'GladiatorsFinale',
+      'ShimenawasReminiscence',
+    ]
+    // A build whose equipped pieces contribute to `base` (and, for the flower slot,
+    // get excluded from it) so cache entries are build-dependent.
+    const build: Build = {
+      ...emptyBuild,
+      flower: lvl20 as ICachedArtifact,
+      plume: {
+        ...lvl20,
+        id: 'lvl20-plume',
+        slotKey: 'plume',
+        mainStatKey: 'atk',
+      } as ICachedArtifact,
+    }
+
+    const reference = (sets: ArtifactSetKey[], currentBuild: Build, o = obj) =>
+      deduplicate(o, freshArtifact({ sets, p3sub, rarity }, currentBuild))
+    const memoized = (
+      sets: ArtifactSetKey[],
+      currentBuild: Build,
+      cache: FreshArtifactCache,
+      o = obj
+    ) => freshArtifactMemoized({ sets, p3sub }, currentBuild, o, cache)
+
+    test('sanity: reference is a distribution over 3- and 4-line starts', () => {
+      const fresh = freshArtifact({ sets: twoSets, p3sub, rarity }, emptyBuild)
+      expect(fresh.reduce((a, { p }) => a + p, 0)).toBeCloseTo(1, 8)
+      expect(
+        fresh.reduce((a, { p, n }) => (n.rollsLeft === 4 ? a + p : a), 0)
+      ).toBeCloseTo(p3sub, 8)
+      expect(
+        fresh.reduce((a, { p, n }) => (n.rollsLeft === 5 ? a + p : a), 0)
+      ).toBeCloseTo(1 - p3sub, 8)
+    })
+
+    test('memoized matches dedup(freshArtifact), single set', () => {
+      const cache: FreshArtifactCache = new Map()
+      const expected = reference(oneSet, emptyBuild)
+      expectSameDistribution(memoized(oneSet, emptyBuild, cache), expected)
+      // Second call goes through the populated cache.
+      expectSameDistribution(memoized(oneSet, emptyBuild, cache), expected)
+    })
+
+    test('memoized matches dedup(freshArtifact), multiple sets', () => {
+      const cache: FreshArtifactCache = new Map()
+      const expected = reference(twoSets, emptyBuild)
+      expectSameDistribution(memoized(twoSets, emptyBuild, cache), expected)
+      expectSameDistribution(memoized(twoSets, emptyBuild, cache), expected)
+    })
+
+    test('memoized matches dedup(freshArtifact), non-empty build', () => {
+      // `build` is all GladiatorsFinale, which is also in `twoSets` -- so some templates
+      // already carry the set key that `insertSetKey` adds, the case most likely to
+      // perturb `cmpBase`'s key-count comparison and hence the ordering.
+      const cache: FreshArtifactCache = new Map()
+      const expected = reference(twoSets, build)
+      expectSameDistribution(memoized(twoSets, build, cache), expected)
+      expectSameDistribution(memoized(twoSets, build, cache), expected)
+    })
+
+    test('memoized matches dedup(freshArtifact) under a different objective', () => {
+      // obj3 reads only critRate_, so `deduplicate` strips almost every substat and
+      // merges aggressively -- the hardest case for the template merge to reproduce.
+      const cache: FreshArtifactCache = new Map()
+      const expected = reference(twoSets, emptyBuild, obj3)
+      expectSameDistribution(
+        memoized(twoSets, emptyBuild, cache, obj3),
+        expected
+      )
+    })
+
+    test('memoized total probability is 1 and splits by line count', () => {
+      const cache: FreshArtifactCache = new Map()
+      const got = memoized(twoSets, emptyBuild, cache)
+      expect(got.reduce((a, { p }) => a + p, 0)).toBeCloseTo(1, 8)
+      expect(
+        got.reduce((a, { p, n }) => (n.rollsLeft === 4 ? a + p : a), 0)
+      ).toBeCloseTo(p3sub, 8)
+      expect(
+        got.reduce((a, { p, n }) => (n.rollsLeft === 5 ? a + p : a), 0)
+      ).toBeCloseTo(1 - p3sub, 8)
+    })
+
+    test('a cache warmed on one set list is reusable for another', () => {
+      const cache: FreshArtifactCache = new Map()
+      memoized(oneSet, emptyBuild, cache)
+      expectSameDistribution(
+        memoized(twoSets, emptyBuild, cache),
+        reference(twoSets, emptyBuild)
+      )
+    })
+
+    test('a cache warmed on one build is not reused for another', () => {
+      // Templates bake in build-dependent `base` stats, so the cache key must
+      // distinguish builds.
+      const cache: FreshArtifactCache = new Map()
+      memoized(oneSet, emptyBuild, cache)
+      expectSameDistribution(
+        memoized(oneSet, build, cache),
+        reference(oneSet, build)
+      )
+    })
+
+    test('downstream dedup does not corrupt the cache', () => {
+      const cache: FreshArtifactCache = new Map()
+      // `deduplicate` rewrites node/subDistr fields in place; the cached templates
+      // must survive it intact.
+      deduplicate(obj, memoized(oneSet, emptyBuild, cache))
+      expectSameDistribution(
+        memoized(oneSet, emptyBuild, cache),
+        reference(oneSet, emptyBuild)
+      )
+    })
+
+    test('result does not depend on the order `sets` is given in', () => {
+      const cache: FreshArtifactCache = new Map()
+      expectSameDistribution(
+        memoized([...twoSets].reverse(), emptyBuild, cache),
+        reference(twoSets, emptyBuild)
+      )
+    })
+
+    test('deduplicate() on the memoized output is a no-op', () => {
+      // The point of the exercise: callers can skip the second `deduplicate` pass.
+      // Equal length means nothing merged, which is the claim -- deliberately not
+      // asserting order, which is `deduplicate`'s business and not part of the contract.
+      const cache: FreshArtifactCache = new Map()
+      const got = memoized(twoSets, build, cache)
+      const redone = deduplicate(obj, [...got]) as {
+        p: number
+        n: SubstatLevelNode
+      }[]
+      expect(redone.length).toBe(got.length)
+      expectSameDistribution(redone, got)
+    })
+  })
   describe('reshape', () => {
     test('reshape/4line basic', () => {
       const [reshaped] = dustReshape(

--- a/libs/gi/upopt/src/upOptMemoize.ts
+++ b/libs/gi/upopt/src/upOptMemoize.ts
@@ -151,7 +151,8 @@ export function elixirDefinitionMemoSimplified(
 }
 
 /**
- * Memoized variant of `freshArtifact()`. For a fixed number of initial rolls, the substat crawl produces
+ * Memoized variant of `freshArtifact()`. Assumes we're generating 5* artifacts, so the only variable is the set key.
+ * For a fixed number of initial rolls, the substat crawl produces
  * the same node list down to the base stats; only the set key varies per query.
  * Entries are simplified against a specific objective, so all calls sharing a
  * cache MUST use the same objective; clear (or replace) the cache when it changes.

--- a/libs/gi/upopt/src/upOptMemoize.ts
+++ b/libs/gi/upopt/src/upOptMemoize.ts
@@ -155,10 +155,6 @@ export function elixirDefinitionMemoSimplified(
  * the same node list down to the base stats; only the set key varies per query.
  * Entries are simplified against a specific objective, so all calls sharing a
  * cache MUST use the same objective; clear (or replace) the cache when it changes.
- *
- * Returns the same distribution as `deduplicate(obj, freshArtifact(...))` over the same set
- * of nodes, in a different (set, line count) grouping -- `deduplicate` groups by hash, so its
- * output order is its producer's, and neither order is meaningful.
  */
 export type FreshArtifactQuery = {
   sets: ArtifactSetKey[]
@@ -167,10 +163,9 @@ export type FreshArtifactQuery = {
 export type FreshArtifactCache = Map<string, WeightedNode[]>
 
 /**
- * Templates bake the build's contribution into each node's `base` (it differs per slot,
- * since `toStats` drops the piece being replaced), so entries are only valid for the build
- * they were built from. Key on the equipped artifact ids so a cache outlives a build change
- * instead of silently serving stale bases.
+ * FreshArtifactCache depends on the current build because the `base` stats of each node are baked in at
+ * the time of construction. The cache key is concatenates artifact ids, so we assume that the db is immutable
+ * and that the artifact ids are unique.
  */
 function buildCacheKey(currentBuild: Build): string {
   return allArtifactSlotKeys

--- a/libs/gi/upopt/src/upOptMemoize.ts
+++ b/libs/gi/upopt/src/upOptMemoize.ts
@@ -4,10 +4,15 @@ import type {
   MainStatKey,
   SubstatKey,
 } from '@genshin-optimizer/gi/consts'
-import { allSubstatKeys } from '@genshin-optimizer/gi/consts'
+import {
+  allArtifactSlotKeys,
+  allSubstatKeys,
+  artSlotMainKeys,
+} from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
 import type { DynStat } from '@genshin-optimizer/gi/solver'
 import { getRollsRemaining } from '@genshin-optimizer/gi/util'
+import { allMainStatProbs } from './consts'
 import { deduplicate } from './deduplicate'
 import { makeSubstatNode } from './expandSubstat'
 import type { Objective } from './markov-tree/markov.types'
@@ -61,6 +66,19 @@ function mainStatCacheKey(mainStatKey: MainStatKey) {
  */
 function rebase(n: SubstatLevelNode, base: DynStat): SubstatLevelNode {
   return { ...n, base, subDistr: { ...n.subDistr, base } }
+}
+
+function insertSetKey(
+  n: SubstatLevelNode,
+  setKey: ArtifactSetKey | ''
+): SubstatLevelNode {
+  const base = { ...n.base }
+  if (setKey !== '') base[setKey] = (base[setKey] ?? 0) + 1
+  return {
+    ...n,
+    base,
+    subDistr: { ...n.subDistr, base },
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,4 +148,97 @@ export function elixirDefinitionMemoSimplified(
       n: rebase(n, base),
     })),
   ]
+}
+
+/**
+ * Memoized variant of `freshArtifact()`. For a fixed number of initial rolls, the substat crawl produces
+ * the same node list down to the base stats; only the set key varies per query.
+ * Entries are simplified against a specific objective, so all calls sharing a
+ * cache MUST use the same objective; clear (or replace) the cache when it changes.
+ *
+ * Returns the same distribution as `deduplicate(obj, freshArtifact(...))` over the same set
+ * of nodes, in a different (set, line count) grouping -- `deduplicate` groups by hash, so its
+ * output order is its producer's, and neither order is meaningful.
+ */
+export type FreshArtifactQuery = {
+  sets: ArtifactSetKey[]
+  p3sub: number
+}
+export type FreshArtifactCache = Map<string, WeightedNode[]>
+
+/**
+ * Templates bake the build's contribution into each node's `base` (it differs per slot,
+ * since `toStats` drops the piece being replaced), so entries are only valid for the build
+ * they were built from. Key on the equipped artifact ids so a cache outlives a build change
+ * instead of silently serving stale bases.
+ */
+function buildCacheKey(currentBuild: Build): string {
+  return allArtifactSlotKeys
+    .map((slotKey) => currentBuild[slotKey]?.id ?? '')
+    .join('|')
+}
+
+function getFreshTemplates(
+  currentBuild: Build,
+  obj: Objective,
+  lines: 3 | 4,
+  cache: FreshArtifactCache
+): WeightedNode[] {
+  const cacheKey = `${lines};${buildCacheKey(currentBuild)}`
+  const hit = cache.get(cacheKey)
+  if (hit) return hit
+
+  const out: WeightedNode[] = []
+  allArtifactSlotKeys.forEach((slotKey) => {
+    const pSlot = 1 / 5
+    artSlotMainKeys[slotKey].forEach((mainStatKey) => {
+      const pMain = allMainStatProbs[slotKey][mainStatKey] ?? 0
+      const base = toStats(currentBuild, {
+        slotKey,
+        rarity,
+        mainStatKey,
+        setKey: '',
+      })
+
+      const subsToConsider = allSubstatKeys.filter((s) => s !== mainStatKey)
+      crawlSubstats([], subsToConsider).forEach(({ p, subs }) => {
+        const rollsLeft =
+          lines === 4
+            ? getRollsRemaining(0, rarity)
+            : getRollsRemaining(0, rarity) - 1
+        const nodeInfo = {
+          base,
+          rarity,
+          subkeys: subs.map((key) => ({ key, baseRolls: 1 })),
+          rollsLeft,
+        }
+        const n = makeSubstatNode(nodeInfo)
+        out.push({ p: p * pMain * pSlot, n })
+      })
+    })
+  })
+  const templates = deduplicate(obj, out) as WeightedNode[]
+  cache.set(cacheKey, templates)
+  return templates
+}
+
+export function freshArtifactMemoized(
+  info: FreshArtifactQuery,
+  currentBuild: Build,
+  obj: Objective,
+  cache: FreshArtifactCache
+): WeightedNode[] {
+  const t3 = getFreshTemplates(currentBuild, obj, 3, cache)
+  const t4 = getFreshTemplates(currentBuild, obj, 4, cache)
+  const pSet = 1 / info.sets.length
+  return info.sets.flatMap((setKey) => [
+    ...t3.map(({ p, n }) => ({
+      p: p * info.p3sub * pSet,
+      n: insertSetKey(n, setKey),
+    })),
+    ...t4.map(({ p, n }) => ({
+      p: p * (1 - info.p3sub) * pSet,
+      n: insertSetKey(n, setKey),
+    })),
+  ])
 }


### PR DESCRIPTION
## Describe your changes

The distribution of freshArtifact() is static independent of the selected set, so it's essentially fixed & can be memoized & we can add the setKey in afterwards. The cache key includes the equipped artifact ids because templates bake the build's contribution into each node's `base`. `toStats` drops the piece being replaced, so the base differs per slot and a cache would otherwise outlive a build change and serve stale bases. Entries are also simplified against a specific objective, so callers sharing a cache must share an objective; the tests cover a changed objective explicitly.

## Issue or discord link

--

## Testing/validation

Tests assert the memoized output matches deduplicate(obj, freshArtifact(...)) as a distribution -- same distinct nodes, same total probability on each -- across single set, multiple sets, non-empty build, reversed set order, and a second objective, plus that a downstream deduplicate() does not corrupt the cached templates (it rewrites node fields in place) and that deduplicating the memoized output merges nothing.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved artifact optimization calculations for fresh artifact generation across slots, main stats, substats, and set bonuses.
  * Added more consistent handling of build variations, objectives, and artifact set ordering.
  * Improved reuse of calculated results while preventing duplicate downstream outcomes.
  * Enhanced stability and consistency of probability distributions and optimization results.

* **Tests**
  * Expanded coverage for probability splits, caching behavior, set combinations, and memoized result consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->