### PR TITLE
Group nodes by hash in deduplicate()

### DIFF
--- a/libs/gi/upopt/src/deduplicate.ts
+++ b/libs/gi/upopt/src/deduplicate.ts
@@ -11,10 +11,6 @@ type weightedNode = { p: number; n: MarkovNode }
 /**
  * Deduplicate nodes by merging identical nodes and summing their probabilities.
  * Note: modifies input nodes in place.
- *
- * Grouping is by hash, not by sort, so the result is in first-seen order rather than
- * `cmpNodes` order. Producers therefore don't have to emit any particular order to make
- * this a no-op: on a list with no duplicates it returns the same nodes, unchanged.
  */
 export function deduplicate(
   obj: Objective,

--- a/libs/gi/upopt/src/deduplicate.ts
+++ b/libs/gi/upopt/src/deduplicate.ts
@@ -11,6 +11,10 @@ type weightedNode = { p: number; n: MarkovNode }
 /**
  * Deduplicate nodes by merging identical nodes and summing their probabilities.
  * Note: modifies input nodes in place.
+ *
+ * Grouping is by hash, not by sort, so the result is in first-seen order rather than
+ * `cmpNodes` order. Producers therefore don't have to emit any particular order to make
+ * this a no-op: on a list with no duplicates it returns the same nodes, unchanged.
  */
 export function deduplicate(
   obj: Objective,
@@ -20,17 +24,47 @@ export function deduplicate(
     if (n.type === 'substat') simplifySubstatNode(obj, n)
     else if (n.type === 'rolls') simplifyRollsNode(obj, n)
   })
-  nodes = nodes.filter(({ p }) => p > 0)
-  nodes.sort((a, b) => -cmpNodes(a.n, b.n))
-  let prev: weightedNode | undefined
-  return nodes.filter((cur) => {
-    if (prev && cmpNodes(prev.n, cur.n) === 0) {
-      prev.p += cur.p
-      return false
-    }
-    prev = cur
-    return true
-  })
+  const groups = new Map<string, weightedNode>()
+  for (const cur of nodes) {
+    if (cur.p <= 0) continue
+    const key = nodeKey(cur.n)
+    const prev = groups.get(key)
+    if (prev) prev.p += cur.p
+    else groups.set(key, cur)
+  }
+  return [...groups.values()]
+}
+
+/**
+ * Identity of a node under `deduplicate`: two nodes share a key exactly when
+ * `cmpNodes` rates them equal. `:`/`,`/`;` are safe separators because stat keys, set keys
+ * and numeric literals never contain them.
+ */
+function nodeKey(n: MarkovNode): string {
+  if (n.type === 'substat') {
+    const subkeys = n.subkeys.map(({ key, baseRolls }) => `${key}:${baseRolls}`)
+    const reshape = n.reshape
+      ? `${n.reshape.mintotal}:${n.reshape.affixes.join(',')}`
+      : ''
+    return `s;${n.rarity};${n.rollsLeft};${reshape};${subkeys.join(',')};${baseKey(n.base)}`
+  }
+  if (n.type === 'rolls') {
+    const subs = n.subs.map(({ key, rolls }) => `${key}:${rolls}`)
+    return `r;${n.rarity};${subs.join(',')};${baseKey(n.base)}`
+  }
+  // `ValuesLevelNode` has no `base` of its own; `cmpValuesNode` reads the distribution's.
+  return `v;${baseKey(n.subDistr.base)}`
+}
+
+/**
+ * Mirrors `cmpBase`'s notion of equality: same key set, same values. Number->string is
+ * round-trippable for doubles, so this loses no precision.
+ */
+function baseKey(base: DynStat): string {
+  return Object.keys(base)
+    .sort()
+    .map((k) => `${k}:${base[k]}`)
+    .join(',')
 }
 
 function simplifySubstatNode(obj: Objective, node: SubstatLevelNode) {
@@ -57,7 +91,13 @@ function simplifyRollsNode(obj: Objective, node: RollsLevelNode) {
   )
 }
 
-function cmpNodes(a: MarkovNode, b: MarkovNode): number {
+/**
+ * Total order over nodes, whose `=== 0` case is the equivalence relation `deduplicate`
+ * merges on. `deduplicate` groups by `nodeKey` instead of sorting with this, so these
+ * comparators are now the independent specification of node identity -- they exist to hold
+ * `nodeKey` honest in tests rather than to be called on any hot path.
+ */
+export function cmpNodes(a: MarkovNode, b: MarkovNode): number {
   if (a.type === 'substat') {
     if (b.type !== 'substat') return -1
     return cmpSubstatNode(a, b)

--- a/libs/gi/upopt/src/upOpt.test.ts
+++ b/libs/gi/upopt/src/upOpt.test.ts
@@ -1,11 +1,12 @@
 import type { SubstatKey } from '@genshin-optimizer/gi/consts'
 import { allSubstatKeys } from '@genshin-optimizer/gi/consts'
 import type { ICachedArtifact } from '@genshin-optimizer/gi/db'
+import type { DynStat } from '@genshin-optimizer/gi/solver'
 import { getMainStatValue, getSubstatValue } from '@genshin-optimizer/gi/util'
 import { dynRead, prod, sum } from '@genshin-optimizer/gi/wr'
 
 import { substatWeights } from './consts'
-import { deduplicate } from './deduplicate'
+import { cmpNodes, deduplicate } from './deduplicate'
 import { expandRollsLevel } from './expandRolls'
 import {
   expandSubstatLevel,
@@ -22,6 +23,7 @@ import {
   elixirDefinition,
   expandNode,
   expandNodes,
+  freshArtifact,
   levelUpArtifact,
 } from './upOpt'
 import type { MarkovNode, SubstatLevelNode } from './upOpt.types'
@@ -72,6 +74,49 @@ function checkExpandedEvalCorrectness(
   const baseEval = evaluateGaussian(obj, g)
   expect(mean).toBeCloseTo(baseEval.f_mu[0])
   expect(sig2).toBeCloseTo(baseEval.f_cov[0][0])
+}
+
+/**
+ * Order-independent identity for a node: everything `deduplicate()` treats as
+ * distinguishing, with `base` canonicalized since key insertion order differs
+ * between the memoized and reference construction paths. Deliberately written
+ * independently of `deduplicate`'s own internal key, so these comparisons don't end up
+ * validating the implementation against itself.
+ */
+function canonicalNodeKey(n: SubstatLevelNode): string {
+  return JSON.stringify([
+    n.rarity,
+    n.rollsLeft,
+    n.reshape ?? null,
+    n.subkeys,
+    Object.entries(n.base).sort(([a], [b]) => a.localeCompare(b)),
+    n.subDistr.subs,
+    n.subDistr.mu,
+    n.subDistr.cov,
+  ])
+}
+
+/**
+ * Compares two weighted node lists as distributions: same set of distinct nodes,
+ * same total probability on each. Node order carries no meaning -- `deduplicate` groups by
+ * hash and hands back its producer's order -- so this is the real contract.
+ */
+function expectSameDistribution(
+  got: { p: number; n: SubstatLevelNode }[],
+  want: { p: number; n: MarkovNode }[]
+) {
+  const tally = (nodes: { p: number; n: MarkovNode }[]) => {
+    const m = new Map<string, number>()
+    nodes.forEach(({ p, n }) => {
+      const k = canonicalNodeKey(n as SubstatLevelNode)
+      m.set(k, (m.get(k) ?? 0) + p)
+    })
+    return m
+  }
+  const g = tally(got)
+  const w = tally(want)
+  expect([...g.keys()].sort()).toEqual([...w.keys()].sort())
+  g.forEach((p, k) => expect(p).toBeCloseTo(w.get(k)!, 12))
 }
 
 describe('upOpt components', () => {
@@ -398,6 +443,153 @@ describe('upOpt components', () => {
       deduplicate(obj, valuesLevel),
       substatNode.subDistr
     )
+  })
+
+  describe('deduplicate groups exactly what cmpNodes calls equal', () => {
+    // `deduplicate` merges by hashing an internal node key; `cmpNodes` is the independent
+    // specification of that equivalence. A key that under-distinguishes silently merges
+    // unrelated nodes and corrupts probabilities, so check the two agree across all three
+    // node types on real trees rather than trusting the key by inspection.
+    const objLinear = makeObjective([nodeLinear], [4000])
+    const noBuild = {
+      flower: undefined,
+      plume: undefined,
+      sands: undefined,
+      goblet: undefined,
+      circlet: undefined,
+    }
+    const fresh = () =>
+      freshArtifact(
+        { sets: ['GladiatorsFinale'], p3sub: 0.2, rarity: 5 },
+        noBuild
+      )
+    // Each builds a fresh tree: `deduplicate` mutates its input, so fixtures can't be shared.
+    const levels: Record<string, () => { p: number; n: MarkovNode }[]> = {
+      substat: fresh,
+      rolls: () => expandNodes(deduplicate(objLinear, fresh())),
+      // Trimmed to keep the O(n log n) cmpNodes oracle quick.
+      values: () =>
+        expandNodes(
+          deduplicate(
+            objLinear,
+            expandNodes(deduplicate(objLinear, fresh()))
+          ).slice(0, 300)
+        ),
+    }
+
+    /** Number of distinct nodes under `cmpNodes`, via its own sort. */
+    function distinctByCmp(nodes: { p: number; n: MarkovNode }[]) {
+      const sorted = [...nodes].sort((a, b) => -cmpNodes(a.n, b.n))
+      return sorted.filter(
+        (cur, i) => i === 0 || cmpNodes(sorted[i - 1].n, cur.n) !== 0
+      ).length
+    }
+
+    // The tree fixtures above contain no reshape nodes and no zero-probability nodes, so
+    // they can't see a key that ignores `reshape` or a merge loop that forgets to drop
+    // p <= 0. Pin down each distinguishing field directly instead.
+    test('nodes differing in exactly one field are not merged', () => {
+      const ref = {
+        base: { atk: 100 } as DynStat,
+        rarity: 5 as const,
+        subkeys: [
+          { key: 'atk' as SubstatKey, baseRolls: 1 },
+          { key: 'atk_' as SubstatKey, baseRolls: 1 },
+        ],
+        rollsLeft: 5,
+      }
+      const reshape = { affixes: ['atk'] as SubstatKey[], mintotal: 2 }
+      const variants: Record<string, () => MarkovNode> = {
+        rollsLeft: () => makeSubstatNode({ ...ref, rollsLeft: 4 }),
+        rarity: () => makeSubstatNode({ ...ref, rarity: 4 }),
+        'reshape present': () => makeSubstatNode({ ...ref, reshape }),
+        'reshape affixes': () =>
+          makeSubstatNode({
+            ...ref,
+            reshape: { ...reshape, affixes: ['atk_'] },
+          }),
+        'reshape mintotal': () =>
+          makeSubstatNode({ ...ref, reshape: { ...reshape, mintotal: 1 } }),
+        'subkeys length': () =>
+          makeSubstatNode({ ...ref, subkeys: ref.subkeys.slice(0, 1) }),
+        'subkeys baseRolls': () =>
+          makeSubstatNode({
+            ...ref,
+            subkeys: [{ key: 'atk', baseRolls: 2 }, ref.subkeys[1]],
+          }),
+        'base value': () => makeSubstatNode({ ...ref, base: { atk: 101 } }),
+        'base extra key': () =>
+          makeSubstatNode({ ...ref, base: { atk: 100, def: 1 } }),
+      }
+
+      // Control: two builds of the same node really do merge.
+      expect(
+        deduplicate(objLinear, [
+          { p: 0.5, n: makeSubstatNode(ref) },
+          { p: 0.5, n: makeSubstatNode(ref) },
+        ])
+      ).toHaveLength(1)
+
+      Object.entries(variants).forEach(([field, makeVariant]) => {
+        const pair = [
+          { p: 0.5, n: makeSubstatNode(ref) },
+          { p: 0.5, n: makeVariant() },
+        ]
+        // The oracle must agree that these are distinct, or the test proves nothing.
+        expect(`${field}: ${cmpNodes(pair[0].n, pair[1].n)}`).not.toBe(
+          `${field}: 0`
+        )
+        expect(`${field}: ${deduplicate(objLinear, pair).length}`).toBe(
+          `${field}: 2`
+        )
+      })
+    })
+
+    test('drops nodes with zero or negative probability', () => {
+      const mk = (atk: number) =>
+        makeSubstatNode({
+          base: { atk },
+          rarity: 5,
+          subkeys: [{ key: 'atk', baseRolls: 1 }],
+          rollsLeft: 5,
+        })
+      const out = deduplicate(objLinear, [
+        { p: 0.5, n: mk(100) },
+        { p: 0, n: mk(200) },
+        { p: -1, n: mk(300) },
+        { p: 0.5, n: mk(400) },
+      ])
+      const bases = out.map(({ n }) => (n as SubstatLevelNode).base['atk'])
+      expect(bases).toEqual([100, 400])
+    })
+
+    Object.entries(levels).forEach(([level, makeInput]) => {
+      test(`${level} level`, () => {
+        const input = makeInput()
+        // Merging is `prev.p += cur.p` on the input's own node objects, so total the input
+        // before `deduplicate` mutates it.
+        const before = input.reduce((a, { p }) => (p > 0 ? a + p : a), 0)
+        const output = deduplicate(objLinear, input)
+        expect(output.length).toBeGreaterThan(0)
+
+        // No wrong merges: one output node per cmpNodes-equivalence class of the input.
+        expect(output.length).toBe(
+          distinctByCmp(input.filter(({ p }) => p > 0))
+        )
+        // No missed merges: no two output nodes are cmpNodes-equal.
+        expect(distinctByCmp(output)).toBe(output.length)
+        // Nothing gained or lost.
+        expect(output.reduce((a, { p }) => a + p, 0)).toBeCloseTo(before, 10)
+
+        // Idempotent, down to object identity and order.
+        const again = deduplicate(objLinear, [...output])
+        expect(again.length).toBe(output.length)
+        again.forEach(({ p, n }, i) => {
+          expect(n).toBe(output[i].n)
+          expect(p).toBe(output[i].p)
+        })
+      })
+    })
   })
 
   test('substatProbs 4th sub', () => {
@@ -756,28 +948,15 @@ describe('upOpt makeSubstatNode(s)', () => {
         },
       ]
 
-      // Merged probabilities are summed pre-scaling in the cache but post-scaling in the
-      // reference pipeline, so p can differ by float rounding; everything else is exact.
-      function expectNodesClose(
-        got: { p: number; n: SubstatLevelNode }[],
-        want: { p: number; n: MarkovNode }[]
-      ) {
-        expect(got.length).toBe(want.length)
-        got.forEach(({ p, n }, i) => {
-          expect(p).toBeCloseTo(want[i].p, 12)
-          expect(n).toEqual(want[i].n)
-        })
-      }
-
       test('simplified cache matches dedup(elixirDefinition)', () => {
         const cache: ElixirSimplifiedCache = new Map()
         queries.forEach((q) => {
           const expected = deduplicate(obj, elixirDefinition(q, emptyBuild))
-          expectNodesClose(
+          expectSameDistribution(
             elixirDefinitionMemoSimplified(q, emptyBuild, obj, cache),
             expected
           )
-          expectNodesClose(
+          expectSameDistribution(
             elixirDefinitionMemoSimplified(q, emptyBuild, obj, cache),
             expected
           )
@@ -791,7 +970,7 @@ describe('upOpt makeSubstatNode(s)', () => {
           obj,
           elixirDefinitionMemoSimplified(q, emptyBuild, obj, cache)
         )
-        expectNodesClose(
+        expectSameDistribution(
           elixirDefinitionMemoSimplified(q, emptyBuild, obj, cache),
           deduplicate(obj, elixirDefinition(q, emptyBuild))
         )

--- a/libs/gi/upopt/src/upOptMemoize.ts
+++ b/libs/gi/upopt/src/upOptMemoize.ts
@@ -119,8 +119,6 @@ export function elixirDefinitionMemoSimplified(
 ): WeightedNode[] {
   const base = toStats(currentBuild, { ...info, rarity })
   const affixes = info.affixes.sort((a, b) => a.localeCompare(b)) // Ensure consistent ordering
-  // deduplicate() sorts 4-line (rollsLeft 5) nodes ahead of 3-line, so concatenating the
-  // two template blocks reproduces its output ordering.
   const t4 = getSimplifiedTemplates(info.mainStatKey, affixes, 4, obj, cache)
   const t3 = getSimplifiedTemplates(info.mainStatKey, affixes, 3, obj, cache)
   return [


### PR DESCRIPTION
## Describe your changes

During performance profiling on upopt I noticed the deduplicate() calls were taking really long. This change should speed that up since I used to sort the whole node list; now we're checking a hashmap keyed on a string identity to deduplicate nodes. Nothing relied the sorted node list down the line, so returning an unsorted list is okay & faster.

## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

Updated many tests

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-result handling so equivalent entries are merged consistently.
  * Excluded entries with zero or negative probability from results.
  * Preserved probability totals and stable result ordering during deduplication.

* **Tests**
  * Added broader coverage for node identity, probability conservation, repeated deduplication, and cache consistency.
  * Improved comparisons to validate distributions regardless of result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->