### PR TITLE
Show which sets Define is considering

### DIFF
--- a/libs/gi/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/gi/localization/assets/locales/en/page_character_optimize.json
@@ -42,7 +42,7 @@
     "substats": "Substats to consider for defining:",
     "sets": "Sets being considered:",
     "setsEmpty": "No sets are being considered. Enable Define with at least 2 substats, and pick an optimization target.",
-    "setsArbitrary": "No available set affects the optimization target in these slots, so an arbitrary set (highlighted above) was picked there just so results show up. Treat those candidates as set-agnostic — the set itself isn't a recommendation."
+    "setsArbitrary": "No available set affects the optimization target in these slots, so an arbitrary set (highlighted above) was picked just so results show up."
   },
   "upOptChart": {
     "est": " (est.)",

--- a/libs/gi/localization/assets/locales/en/page_character_optimize.json
+++ b/libs/gi/localization/assets/locales/en/page_character_optimize.json
@@ -39,7 +39,10 @@
   "upOptDefine": {
     "label": "Define",
     "tooltip": "Evaluate hypothetical artifacts created by defining (Sanctifying Elixirs). Candidates are generated for the selected sets, slots, main stats, and every pair of the selected substats below.",
-    "substats": "Substats to consider for defining:"
+    "substats": "Substats to consider for defining:",
+    "sets": "Sets being considered:",
+    "setsEmpty": "No sets are being considered. Enable Define with at least 2 substats, and pick an optimization target.",
+    "setsArbitrary": "No available set affects the optimization target in these slots, so an arbitrary set (highlighted above) was picked there just so results show up. Treat those candidates as set-agnostic — the set itself isn't a recommendation."
   },
   "upOptChart": {
     "est": " (est.)",

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/index.tsx
@@ -1,5 +1,11 @@
 import { useForceUpdate } from '@genshin-optimizer/common/react-util'
-import { CardThemed, InfoTooltip, SqBadge } from '@genshin-optimizer/common/ui'
+import { iconInlineProps } from '@genshin-optimizer/common/svgicons'
+import {
+  CardThemed,
+  ImgIcon,
+  InfoTooltip,
+  SqBadge,
+} from '@genshin-optimizer/common/ui'
 import {
   bulkCatTotal,
   clamp,
@@ -9,6 +15,7 @@ import {
   objPathValue,
   range,
 } from '@genshin-optimizer/common/util'
+import { artifactDefIcon } from '@genshin-optimizer/gi/assets'
 import type {
   ArtifactSetKey,
   ArtifactSlotKey,
@@ -33,12 +40,14 @@ import {
   type FilterOption,
   initialFilterOption,
 } from '@genshin-optimizer/gi/schema'
-import { StatIcon } from '@genshin-optimizer/gi/svgicons'
+import { SlotIcon, StatIcon } from '@genshin-optimizer/gi/svgicons'
 import type { dataContextObj } from '@genshin-optimizer/gi/ui'
 import {
   AddArtInfo,
   ArtifactEditor,
   ArtifactSetMultiAutocomplete,
+  ArtifactSetName,
+  ArtifactSetTooltip,
   ArtifactSlotToggle,
   DataContext,
   getTeamData,
@@ -430,6 +439,41 @@ export default function TabUpopt() {
     equippedArts,
   ])
 
+  /**
+   * Sets Define is actually generating candidates for, mapped to the slots they
+   * apply to. Sets are dropped when excluded by set exclusion, or when they have
+   * no effect on the optimization target. `arbitrary` marks the sets that were
+   * only picked because no set mattered for their slot.
+   */
+  const { defineSets, defineFallbackSlots } = useMemo(() => {
+    const setToSlots: Partial<Record<ArtifactSetKey, ArtifactSlotKey[]>> = {}
+    allArtifactSlotKeys.forEach((slotKey) =>
+      upOptCalc?.defineSetKeys[slotKey]?.forEach((setKey) => {
+        const slots = setToSlots[setKey] ?? (setToSlots[setKey] = [])
+        slots.push(slotKey)
+      })
+    )
+    const defineFallbackSlots = upOptCalc?.defineFallbackSlots ?? []
+    const arbitrarySets = new Set(
+      defineFallbackSlots.flatMap(
+        (slotKey) => upOptCalc?.defineSetKeys[slotKey] ?? []
+      )
+    )
+    const defineSets = (
+      Object.entries(setToSlots) as [ArtifactSetKey, ArtifactSlotKey[]][]
+    )
+      .sort(
+        ([k1, slots1], [k2, slots2]) =>
+          slots2.length - slots1.length || k1.localeCompare(k2)
+      )
+      .map(([setKey, slotKeys]) => ({
+        setKey,
+        slotKeys,
+        arbitrary: arbitrarySets.has(setKey),
+      }))
+    return { defineSets, defineFallbackSlots }
+  }, [upOptCalc])
+
   // Paging logic
   const [pageIdex, setpageIdex] = useState(0)
 
@@ -713,6 +757,75 @@ export default function TabUpopt() {
                               )
                             })}
                           </Grid>
+                        </Box>
+                        <Box>
+                          <Typography variant="body2" color="text.secondary">
+                            {t('upOptDefine.sets')}
+                            <SqBadge color="info" sx={{ ml: 1 }}>
+                              {defineSets.length}
+                            </SqBadge>
+                          </Typography>
+                          {defineSets.length ? (
+                            <Box
+                              display="flex"
+                              flexWrap="wrap"
+                              gap={0.5}
+                              sx={{ mt: 0.5 }}
+                            >
+                              {defineSets.map(
+                                ({ setKey, slotKeys, arbitrary }) => (
+                                  <ArtifactSetTooltip
+                                    key={setKey}
+                                    setKey={setKey}
+                                  >
+                                    <SqBadge
+                                      color={arbitrary ? 'warning' : 'primary'}
+                                    >
+                                      <Typography>
+                                        <ImgIcon
+                                          size={1.5}
+                                          src={artifactDefIcon(setKey)}
+                                        />{' '}
+                                        <ArtifactSetName setKey={setKey} />
+                                        {slotKeys.length <
+                                          allArtifactSlotKeys.length && (
+                                          <>
+                                            {' '}
+                                            {slotKeys.map((slotKey) => (
+                                              <SlotIcon
+                                                key={slotKey}
+                                                slotKey={slotKey}
+                                                iconProps={iconInlineProps}
+                                              />
+                                            ))}
+                                          </>
+                                        )}
+                                      </Typography>
+                                    </SqBadge>
+                                  </ArtifactSetTooltip>
+                                )
+                              )}
+                            </Box>
+                          ) : (
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              {t('upOptDefine.setsEmpty')}
+                            </Typography>
+                          )}
+                          {!!defineFallbackSlots.length && (
+                            <Alert severity="warning" sx={{ mt: 1 }}>
+                              {t('upOptDefine.setsArbitrary')}{' '}
+                              {defineFallbackSlots.map((slotKey) => (
+                                <SlotIcon
+                                  key={slotKey}
+                                  slotKey={slotKey}
+                                  iconProps={iconInlineProps}
+                                />
+                              ))}
+                            </Alert>
+                          )}
                         </Box>
                       </Stack>
                     </CardContent>

--- a/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
+++ b/libs/gi/page-team/src/CharacterDisplay/Tabs/TabUpgradeOpt/upOpt.ts
@@ -107,6 +107,10 @@ export class UpOptCalculatorV2 {
   build: Build
   obj: Objective
   candidates: EvaluatedMarkovTree[] = []
+  /** Sets `tryDefine` generated candidates for, per slot. Empty when Define is off. */
+  defineSetKeys: Partial<Record<ArtifactSlotKey, ArtifactSetKey[]>> = {}
+  /** Slots where no set affects the target, so `tryDefine` picked an arbitrary one. */
+  defineFallbackSlots: ArtifactSlotKey[] = []
   fixedIx = 0
   cache: ElixirSimplifiedCache = new Map()
 
@@ -202,7 +206,9 @@ export class UpOptCalculatorV2 {
       if (!validSetKeys.length && setKeys.length > 0) {
         console.warn(`Picking ${setKeys[0]} b/c none of them matter.`)
         validSetKeys = [setKeys[0]] // Default to something so user sees some results
+        this.defineFallbackSlots.push(slotKey)
       }
+      this.defineSetKeys[slotKey] = [...validSetKeys]
       validSetKeys.forEach((setKey) => {
         mainStats.forEach((mainStatKey) => {
           const subOptions = allSubstatKeys


### PR DESCRIPTION
## Describe your changes

Make Define sets more explicit which sets are being considered. Now appears in the selector when it's turned on.

<img width="563" height="228" alt="image" src="https://github.com/user-attachments/assets/97d978bf-24ba-481b-97ec-41b824f2f4e1" />

UpOptCalculatorV2 now records defineSetKeys per slot and defineFallbackSlots, and the panel lists the sets with the slots they apply to. Fallback sets are badged warning rather than primary, with an alert explaining those candidates are set-agnostic. When nothing is being considered at all, the panel says so and names the preconditions instead of rendering an empty row.


<img width="612" height="298" alt="image" src="https://github.com/user-attachments/assets/3ae0cbe0-97c8-4b77-8311-c86f2e81fd4f" />


## Issue or discord link

- <!--- link relevant issues to this PR, or provide a link to a discord message/thread -->

## Testing/validation

<!--- Add screenshots if possible -->

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Define mode display showing generated artifact sets by slot.
  * Added artifact and slot icons to clarify applicable recommendations.
  * Added guidance when no set is configured and warnings when arbitrary sets are used.
  * Improved messaging for defining artifact substats and selecting sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->