### PR TITLE
Toofless/opt lp bug

### DIFF
--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.test.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@genshin-optimizer/gi/wr'
 import type { ArtifactsBySlot, DynStat } from '../../common.js'
 import type { Linear } from './linearUB.js'
-import { linearUB as linearUpperBound } from './linearUB.js'
+import { linbound, linearUB } from './linearUB.js'
 
 function apply(value: DynStat, linear: Linear): number {
   return Object.entries(linear).reduce(
@@ -51,11 +51,11 @@ describe('linearUpperBound can transform', () => {
     }
 
   test('constant nodes', () => {
-    const bounds = linearUpperBound([constant(88)], arts)
+    const bounds = linearUB([constant(88)], arts)
     expect(bounds[0]).toEqual({ $c: 88 })
   })
   test('read nodes', () => {
-    const bounds = linearUpperBound([rx], arts)
+    const bounds = linearUB([rx], arts)
     expect(bounds[0]).toEqual({ x: 1, $c: 0 })
   })
 
@@ -65,7 +65,7 @@ describe('linearUpperBound can transform', () => {
    * all optimal bounds.
    */
   test('min/max nodes', () => {
-    const bounds = linearUpperBound([min(rx, 3), max(rx, 3)], arts)
+    const bounds = linearUB([min(rx, 3), max(rx, 3)], arts)
 
     // Checking min/c/max
     expect(apply({ x: 0 }, bounds[0])).toBeGreaterThanOrEqual(Math.min(0, 3))
@@ -78,7 +78,7 @@ describe('linearUpperBound can transform', () => {
   })
   test('res nodes', () => {
     const op = allOperations.res,
-      bounds = linearUpperBound(
+      bounds = linearUB(
         [res(rx), res(sum(rx, -4)), res(sum(rx, 20)), res(sum(rx, -20))],
         arts
       )
@@ -100,7 +100,7 @@ describe('linearUpperBound can transform', () => {
     const op = allOperations.sum_frac,
       c = 4,
       loc = Math.sqrt((0 + c) * (5 + c))
-    const bounds = linearUpperBound([frac(rx, c)], arts)
+    const bounds = linearUB([frac(rx, c)], arts)
 
     // Checking min/loc/max
     expect(apply({ x: 0 }, bounds[0])).toBeGreaterThan(op([0, c]))
@@ -109,7 +109,7 @@ describe('linearUpperBound can transform', () => {
   })
   test('threshold nodes', () => {
     // All pass >= fail, pass <= fail and upper/lower bounds combinations
-    const bounds = linearUpperBound(
+    const bounds = linearUB(
       [
         threshold(rx, 4, 5, 10),
         threshold(rx, 4, 10, 5),
@@ -164,12 +164,37 @@ describe('linearUpperBound can transform', () => {
         },
       }
 
-    const bounds = linearUpperBound([prod(rx, ry)], arts)
+    const bounds = linearUB([prod(rx, ry)], arts)
 
     // x + y === 5
     for (let x = 0; x <= 5; x++) {
       const y = 5 - x
       expect(apply({ x, y }, bounds[0])).toBeGreaterThanOrEqual(x * y)
     }
+  })
+  test('LP loop bug', () => {
+    const bounds = [
+      {
+        min: 1.932,
+        max: 2.4917,
+      },
+      {
+        min: 2.016924,
+        max: 2.685224,
+      },
+      {
+        min: -689,
+        max: -537.27,
+      },
+      {
+        min: 0.4582,
+        max: 0.6214999999999999,
+      },
+      {
+        min: 0,
+        max: 3,
+      },
+    ]
+    linbound(bounds, 'upper')
   })
 })

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.test.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/index.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@genshin-optimizer/gi/wr'
 import type { ArtifactsBySlot, DynStat } from '../../common.js'
 import type { Linear } from './linearUB.js'
-import { linbound, linearUB } from './linearUB.js'
+import { linearUB } from './linearUB.js'
 
 function apply(value: DynStat, linear: Linear): number {
   return Object.entries(linear).reduce(
@@ -171,30 +171,5 @@ describe('linearUpperBound can transform', () => {
       const y = 5 - x
       expect(apply({ x, y }, bounds[0])).toBeGreaterThanOrEqual(x * y)
     }
-  })
-  test('LP loop bug', () => {
-    const bounds = [
-      {
-        min: 1.932,
-        max: 2.4917,
-      },
-      {
-        min: 2.016924,
-        max: 2.685224,
-      },
-      {
-        min: -689,
-        max: -537.27,
-      },
-      {
-        min: 0.4582,
-        max: 0.6214999999999999,
-      },
-      {
-        min: 0,
-        max: 3,
-      },
-    ]
-    linbound(bounds, 'upper')
   })
 })

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/linearUB.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/linearUB.ts
@@ -49,7 +49,7 @@ export function linearUB(nodes: OptNode[], arts: ArtifactsBySlot): Linear[] {
  * @returns A linear function L(x) = w . x + $c
  *            satisfying      m(x) <= L(x) <= m(x) + err (resp. m(x) - err <= L(x) <= m(x))
  */
-function linbound(
+export function linbound(
   bounds: MinMax[],
   direction: 'upper' | 'lower' = 'upper'
 ): { w: number[]; $c: number; err: number } {

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.test.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.test.ts
@@ -1,0 +1,322 @@
+import { cartesian } from '@genshin-optimizer/common/util'
+import type { MinMax } from '../../common.js'
+import { isFeasible, solveLP } from './solveLP.js'
+
+/**
+ * Reference solver: enumerate every vertex of { Ax <= b, x >= 0 } by picking `n` tight
+ * constraints at a time, and return the smallest objective among the feasible ones.
+ * Exponential, so only usable for the tiny LPs below, but exact.
+ */
+function bruteForceMin(c: number[], Ab: number[][]): number {
+  const n = c.length
+  const rows = [...Ab]
+  for (let j = 0; j < n; j++) {
+    const row = Array(n + 1).fill(0)
+    row[j] = -1 // -x_j <= 0
+    rows.push(row)
+  }
+  const combos = (arr: number[], k: number): number[][] =>
+    k === 0
+      ? [[]]
+      : arr.flatMap((v, i) =>
+          combos(arr.slice(i + 1), k - 1).map((r) => [v, ...r])
+        )
+
+  let best = Number.POSITIVE_INFINITY
+  for (const tight of combos([...rows.keys()], n)) {
+    // Gauss-Jordan on the n x n system of tight constraints
+    const A = tight.map((i) => [...rows[i]])
+    let solvable = true
+    for (let col = 0; col < n; col++) {
+      let piv = -1
+      for (let r = col; r < n; r++)
+        if (Math.abs(A[r][col]) > 1e-9) {
+          piv = r
+          break
+        }
+      if (piv < 0) {
+        solvable = false
+        break
+      }
+      ;[A[col], A[piv]] = [A[piv], A[col]]
+      for (let r = 0; r < n; r++) {
+        if (r === col) continue
+        const f = A[r][col] / A[col][col]
+        for (let k = col; k <= n; k++) A[r][k] -= f * A[col][k]
+      }
+    }
+    if (!solvable) continue
+    const x = A.map((row, i) => row[n] / row[i])
+    if (!isFeasible(rows, x)) continue
+    const obj = objective(c, x)
+    if (obj < best) best = obj
+  }
+  return best
+}
+function objective(c: number[], x: number[]): number {
+  return x.reduce((tot, xi, i) => tot + xi * c[i], 0)
+}
+
+describe('solveLP', () => {
+  // `solveLP` minimizes c^T x subject to Ax <= b, x >= 0
+  const cases: {
+    name: string
+    c: number[]
+    Ab: number[][]
+    x?: number[]
+    obj: number
+  }[] = [
+    {
+      // Ferguson p3: maximize x1 + x2 === minimize -x1 - x2
+      name: 'a simple bounded LP',
+      c: [-1, -1],
+      Ab: [
+        [1, 2, 4],
+        [4, 2, 12],
+        [-1, 1, 1],
+      ],
+      x: [8 / 3, 2 / 3],
+      obj: -10 / 3,
+    },
+    {
+      // Ferguson p33: the textbook example that cycles under careless pivot choices
+      name: "Ferguson's cycling example",
+      c: [-3, 5, -1, 2],
+      Ab: [
+        [1, -2, -1, 2, 0],
+        [2, -3, -1, 1, 0],
+        [0, 0, 1, 0, 1],
+      ],
+      x: [0.5, 0, 1, 0],
+      obj: -2.5,
+    },
+    {
+      // b has a negative entry, so this needs phase 1 (`findPiv2`) pivots to get feasible
+      name: 'an LP requiring phase 1 pivots',
+      c: [1, 1],
+      Ab: [
+        [-1, -1, -3],
+        [1, 0, 5],
+        [0, 1, 5],
+      ],
+      obj: 3, // multiple optima along x1 + x2 === 3
+    },
+    {
+      // Four constraints meeting at (1, 1): the optimal vertex is degenerate
+      name: 'an LP with a degenerate optimal vertex',
+      c: [-1, -1],
+      Ab: [
+        [1, 1, 2],
+        [1, 0, 1],
+        [0, 1, 1],
+        [2, 1, 3],
+      ],
+      x: [1, 1],
+      obj: -2,
+    },
+    {
+      // x1 + x2 <= 4 and -x1 - x2 <= -4 pin the sum exactly, another degenerate case
+      name: 'an LP with opposing tight constraints',
+      c: [-2, -3],
+      Ab: [
+        [1, 1, 4],
+        [-1, -1, -4],
+        [1, 0, 3],
+      ],
+      x: [0, 4],
+      obj: -12,
+    },
+  ]
+
+  test.each(cases)('solves $name', ({ c, Ab, x, obj }) => {
+    const xOpt = solveLP(c, Ab)
+    expect(isFeasible(Ab, xOpt)).toBe(true)
+    expect(objective(c, xOpt)).toBeCloseTo(obj, 8)
+    expect(objective(c, xOpt)).toBeCloseTo(bruteForceMin(c, Ab), 8)
+    if (x) x.forEach((xi, i) => expect(xOpt[i]).toBeCloseTo(xi, 8))
+  })
+
+  test('detects infeasible problems', () => {
+    // x1 <= -1 with x >= 0
+    expect(() => solveLP([1, 1], [[1, 0, -1]])).toThrow(/INFEASIBLE/)
+  })
+  test('detects unbounded problems', () => {
+    // minimize -x1 with x1 unbounded above
+    expect(() => solveLP([-1, 0], [[-1, 0, 0]])).toThrow(/UNBOUNDED/)
+  })
+
+  test('matches brute force on random small LPs', () => {
+    let seed = 20240607 // Fixed seed; these tests must be deterministic
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    const randInt = (lo: number, hi: number) =>
+      lo + Math.floor(rand() * (hi - lo + 1))
+
+    let solved = 0
+    for (let trial = 0; trial < 200; trial++) {
+      const nVar = randInt(2, 3),
+        nCons = randInt(3, 5)
+      const c = Array.from({ length: nVar }, () => randInt(-10, 10))
+      const Ab = Array.from({ length: nCons }, () => [
+        ...Array.from({ length: nVar }, () => randInt(-10, 10)),
+        randInt(0, 10),
+      ])
+
+      let xOpt: number[]
+      try {
+        xOpt = solveLP(c, Ab)
+      } catch (e) {
+        // Random LPs are legitimately infeasible/unbounded ~1 time in 6
+        expect((e as Error).message).toMatch(/INFEASIBLE|UNBOUNDED/)
+        continue
+      }
+      solved++
+      expect(isFeasible(Ab, xOpt)).toBe(true)
+      expect(objective(c, xOpt)).toBeCloseTo(bruteForceMin(c, Ab), 6)
+    }
+    expect(solved).toBe(165)
+  })
+})
+
+/**
+ * Rebuilds the LP that `linbound` (linearUB.ts) solves to bound a monomial on a box.
+ * Kept in the same operation order as `linbound` because the pivot path — and the cycling
+ * bug below — depends on the exact floating point values this produces.
+ */
+function monomialLP(bounds: MinMax[], direction: 'upper' | 'lower') {
+  const nVar = bounds.length
+  const boundScale = bounds.map(({ min, max }) => Math.max(-min, max))
+  const scaled = bounds.map(({ min, max }, i) => ({
+    min: min / boundScale[i],
+    max: max / boundScale[i],
+  }))
+  const cons = cartesian(...scaled.map(({ min, max }) => [min, max])).flatMap(
+    (coords) => {
+      const prod = coords.reduce((prod, v) => prod * v, 1)
+      const sum = coords.reduce((sum, v) => sum + v, 0)
+      return direction === 'upper'
+        ? [
+            [...coords, -1, 0, sum - prod - nVar],
+            [...coords.map((v) => -v), 1, -1, nVar + prod - sum],
+          ]
+        : [
+            [...coords.map((v) => -v), -1, 0, prod - sum - nVar],
+            [...coords, 1, -1, nVar + sum - prod],
+          ]
+    }
+  )
+  return { cons, objective: [...bounds.map((_) => 0), 0, 1], nVar }
+}
+
+describe('monomial bound LPs', () => {
+  // The bounds that made `linbound(bounds, 'upper')` spin forever. `max: 0.6214999999999999`
+  // is load-bearing: 0.6215 is a different double and does not trigger the cycle.
+  const reported: MinMax[] = [
+    { min: 1.932, max: 2.4917 },
+    { min: 2.016924, max: 2.685224 },
+    { min: -689, max: -537.27 },
+    { min: 0.4582, max: 0.6214999999999999 },
+    { min: 0, max: 3 },
+  ]
+
+  test.each([
+    'upper',
+    'lower',
+  ] as const)('terminates on the reported %s bound', (direction) => {
+    const { cons, objective, nVar } = monomialLP(reported, direction)
+    const soln = solveLP(objective, cons)
+    // Feasibility here *is* the statement that the resulting linear bound is valid on
+    // every corner of the box; the objective only measures how tight it is.
+    expect(isFeasible(cons, soln)).toBe(true)
+    expect(soln[nVar + 1]).toBeGreaterThanOrEqual(0)
+    expect(Number.isFinite(soln[nVar + 1])).toBe(true)
+  })
+
+  test.each([
+    'upper',
+    'lower',
+  ] as const)('finds the optimal %s bound for the reported case', (direction) => {
+    const { cons, objective, nVar } = monomialLP(reported, direction)
+    // Optimum cross-checked with Dantzig's rule and Bland's rule, both directions.
+    // Loosen to `toBeLessThanOrEqual` if the solver ever settles for a feasible
+    // but suboptimal vertex — the bound is still correct, just less tight.
+    expect(solveLP(objective, cons)[nVar + 1]).toBeCloseTo(0.332591421396, 8)
+  })
+
+  const shapes: { name: string; bounds: MinMax[]; err: number }[] = [
+    { name: 'a single variable', bounds: [{ min: 2, max: 5 }], err: 0 },
+    {
+      name: 'a positive box',
+      bounds: [
+        { min: 1, max: 2 },
+        { min: 3, max: 4 },
+      ],
+      err: 0.0625,
+    },
+    {
+      name: 'a zero-width bound',
+      bounds: [
+        { min: 2, max: 2 },
+        { min: 0, max: 3 },
+      ],
+      err: 0,
+    },
+    {
+      name: 'a box straddling zero',
+      bounds: [
+        { min: -1, max: 2 },
+        { min: -3, max: 1 },
+      ],
+      err: 1,
+    },
+    {
+      name: 'an all-negative box',
+      bounds: [
+        { min: -5, max: -2 },
+        { min: -4, max: -1 },
+      ],
+      err: 0.225,
+    },
+    {
+      name: 'five mixed-sign variables',
+      bounds: [
+        { min: 0, max: 1 },
+        { min: 0, max: 2 },
+        { min: -1, max: 1 },
+        { min: 1, max: 1.5 },
+        { min: 0, max: 10 },
+      ],
+      err: 1,
+    },
+  ]
+
+  describe.each(shapes)('$name', ({ bounds, err }) => {
+    test.each(['upper', 'lower'] as const)('%s bound', (direction) => {
+      const { cons, objective, nVar } = monomialLP(bounds, direction)
+      const soln = solveLP(objective, cons)
+      expect(isFeasible(cons, soln)).toBe(true)
+      expect(soln[nVar + 1]).toBeCloseTo(err, 8)
+    })
+  })
+})
+
+describe('isFeasible', () => {
+  const Ab = [
+    [1, 1, 2],
+    [-1, 0, 0],
+  ]
+  test('accepts points satisfying every constraint', () => {
+    expect(isFeasible(Ab, [1, 1])).toBe(true)
+    expect(isFeasible(Ab, [0, 0])).toBe(true)
+  })
+  test('rejects points violating a constraint', () => {
+    expect(isFeasible(Ab, [2, 1])).toBe(false)
+    expect(isFeasible(Ab, [-1, 0])).toBe(false)
+  })
+  test('tolerates violations within `zero`', () => {
+    expect(isFeasible(Ab, [1, 1 + 1e-9])).toBe(true)
+    expect(isFeasible(Ab, [1, 1 + 1e-6])).toBe(false)
+  })
+})

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.test.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.test.ts
@@ -1,6 +1,7 @@
 import { cartesian } from '@genshin-optimizer/common/util'
 import type { MinMax } from '../../common.js'
 import { isFeasible, solveLP } from './solveLP.js'
+import { solveLPBland } from './solveLPBland.js'
 
 /**
  * Reference solver: enumerate every vertex of { Ax <= b, x >= 0 } by picking `n` tight
@@ -57,77 +58,77 @@ function objective(c: number[], x: number[]): number {
   return x.reduce((tot, xi, i) => tot + xi * c[i], 0)
 }
 
-describe('solveLP', () => {
-  // `solveLP` minimizes c^T x subject to Ax <= b, x >= 0
-  const cases: {
-    name: string
-    c: number[]
-    Ab: number[][]
-    x?: number[]
-    obj: number
-  }[] = [
-    {
-      // Ferguson p3: maximize x1 + x2 === minimize -x1 - x2
-      name: 'a simple bounded LP',
-      c: [-1, -1],
-      Ab: [
-        [1, 2, 4],
-        [4, 2, 12],
-        [-1, 1, 1],
-      ],
-      x: [8 / 3, 2 / 3],
-      obj: -10 / 3,
-    },
-    {
-      // Ferguson p33: the textbook example that cycles under careless pivot choices
-      name: "Ferguson's cycling example",
-      c: [-3, 5, -1, 2],
-      Ab: [
-        [1, -2, -1, 2, 0],
-        [2, -3, -1, 1, 0],
-        [0, 0, 1, 0, 1],
-      ],
-      x: [0.5, 0, 1, 0],
-      obj: -2.5,
-    },
-    {
-      // b has a negative entry, so this needs phase 1 (`findPiv2`) pivots to get feasible
-      name: 'an LP requiring phase 1 pivots',
-      c: [1, 1],
-      Ab: [
-        [-1, -1, -3],
-        [1, 0, 5],
-        [0, 1, 5],
-      ],
-      obj: 3, // multiple optima along x1 + x2 === 3
-    },
-    {
-      // Four constraints meeting at (1, 1): the optimal vertex is degenerate
-      name: 'an LP with a degenerate optimal vertex',
-      c: [-1, -1],
-      Ab: [
-        [1, 1, 2],
-        [1, 0, 1],
-        [0, 1, 1],
-        [2, 1, 3],
-      ],
-      x: [1, 1],
-      obj: -2,
-    },
-    {
-      // x1 + x2 <= 4 and -x1 - x2 <= -4 pin the sum exactly, another degenerate case
-      name: 'an LP with opposing tight constraints',
-      c: [-2, -3],
-      Ab: [
-        [1, 1, 4],
-        [-1, -1, -4],
-        [1, 0, 3],
-      ],
-      x: [0, 4],
-      obj: -12,
-    },
-  ]
+// `solveLP` minimizes c^T x subject to Ax <= b, x >= 0
+const cases: {
+  name: string
+  c: number[]
+  Ab: number[][]
+  x?: number[]
+  obj: number
+}[] = [
+  {
+    // Ferguson p3: maximize x1 + x2 === minimize -x1 - x2
+    name: 'a simple bounded LP',
+    c: [-1, -1],
+    Ab: [
+      [1, 2, 4],
+      [4, 2, 12],
+      [-1, 1, 1],
+    ],
+    x: [8 / 3, 2 / 3],
+    obj: -10 / 3,
+  },
+  {
+    // Ferguson p33: the textbook example that cycles under careless pivot choices
+    name: "Ferguson's cycling example",
+    c: [-3, 5, -1, 2],
+    Ab: [
+      [1, -2, -1, 2, 0],
+      [2, -3, -1, 1, 0],
+      [0, 0, 1, 0, 1],
+    ],
+    x: [0.5, 0, 1, 0],
+    obj: -2.5,
+  },
+  {
+    // b has a negative entry, so this needs phase 1 (`findPiv2`) pivots to get feasible
+    name: 'an LP requiring phase 1 pivots',
+    c: [1, 1],
+    Ab: [
+      [-1, -1, -3],
+      [1, 0, 5],
+      [0, 1, 5],
+    ],
+    obj: 3, // multiple optima along x1 + x2 === 3
+  },
+  {
+    // Four constraints meeting at (1, 1): the optimal vertex is degenerate
+    name: 'an LP with a degenerate optimal vertex',
+    c: [-1, -1],
+    Ab: [
+      [1, 1, 2],
+      [1, 0, 1],
+      [0, 1, 1],
+      [2, 1, 3],
+    ],
+    x: [1, 1],
+    obj: -2,
+  },
+  {
+    // x1 + x2 <= 4 and -x1 - x2 <= -4 pin the sum exactly, another degenerate case
+    name: 'an LP with opposing tight constraints',
+    c: [-2, -3],
+    Ab: [
+      [1, 1, 4],
+      [-1, -1, -4],
+      [1, 0, 3],
+    ],
+    x: [0, 4],
+    obj: -12,
+  },
+]
 
+describe('solveLP', () => {
   test.each(cases)('solves $name', ({ c, Ab, x, obj }) => {
     const xOpt = solveLP(c, Ab)
     expect(isFeasible(Ab, xOpt)).toBe(true)
@@ -210,17 +211,64 @@ function monomialLP(bounds: MinMax[], direction: 'upper' | 'lower') {
   return { cons, objective: [...bounds.map((_) => 0), 0, 1], nVar }
 }
 
-describe('monomial bound LPs', () => {
-  // The bounds that made `linbound(bounds, 'upper')` spin forever. `max: 0.6214999999999999`
-  // is load-bearing: 0.6215 is a different double and does not trigger the cycle.
-  const reported: MinMax[] = [
-    { min: 1.932, max: 2.4917 },
-    { min: 2.016924, max: 2.685224 },
-    { min: -689, max: -537.27 },
-    { min: 0.4582, max: 0.6214999999999999 },
-    { min: 0, max: 3 },
-  ]
+// The bounds that made `linbound(bounds, 'upper')` spin forever. `max: 0.6214999999999999`
+// is load-bearing: 0.6215 is a different double and does not trigger the cycle.
+const reported: MinMax[] = [
+  { min: 1.932, max: 2.4917 },
+  { min: 2.016924, max: 2.685224 },
+  { min: -689, max: -537.27 },
+  { min: 0.4582, max: 0.6214999999999999 },
+  { min: 0, max: 3 },
+]
 
+const shapes: { name: string; bounds: MinMax[]; err: number }[] = [
+  { name: 'a single variable', bounds: [{ min: 2, max: 5 }], err: 0 },
+  {
+    name: 'a positive box',
+    bounds: [
+      { min: 1, max: 2 },
+      { min: 3, max: 4 },
+    ],
+    err: 0.0625,
+  },
+  {
+    name: 'a zero-width bound',
+    bounds: [
+      { min: 2, max: 2 },
+      { min: 0, max: 3 },
+    ],
+    err: 0,
+  },
+  {
+    name: 'a box straddling zero',
+    bounds: [
+      { min: -1, max: 2 },
+      { min: -3, max: 1 },
+    ],
+    err: 1,
+  },
+  {
+    name: 'an all-negative box',
+    bounds: [
+      { min: -5, max: -2 },
+      { min: -4, max: -1 },
+    ],
+    err: 0.225,
+  },
+  {
+    name: 'five mixed-sign variables',
+    bounds: [
+      { min: 0, max: 1 },
+      { min: 0, max: 2 },
+      { min: -1, max: 1 },
+      { min: 1, max: 1.5 },
+      { min: 0, max: 10 },
+    ],
+    err: 1,
+  },
+]
+
+describe('monomial bound LPs', () => {
   test.each([
     'upper',
     'lower',
@@ -244,53 +292,6 @@ describe('monomial bound LPs', () => {
     // but suboptimal vertex — the bound is still correct, just less tight.
     expect(solveLP(objective, cons)[nVar + 1]).toBeCloseTo(0.332591421396, 8)
   })
-
-  const shapes: { name: string; bounds: MinMax[]; err: number }[] = [
-    { name: 'a single variable', bounds: [{ min: 2, max: 5 }], err: 0 },
-    {
-      name: 'a positive box',
-      bounds: [
-        { min: 1, max: 2 },
-        { min: 3, max: 4 },
-      ],
-      err: 0.0625,
-    },
-    {
-      name: 'a zero-width bound',
-      bounds: [
-        { min: 2, max: 2 },
-        { min: 0, max: 3 },
-      ],
-      err: 0,
-    },
-    {
-      name: 'a box straddling zero',
-      bounds: [
-        { min: -1, max: 2 },
-        { min: -3, max: 1 },
-      ],
-      err: 1,
-    },
-    {
-      name: 'an all-negative box',
-      bounds: [
-        { min: -5, max: -2 },
-        { min: -4, max: -1 },
-      ],
-      err: 0.225,
-    },
-    {
-      name: 'five mixed-sign variables',
-      bounds: [
-        { min: 0, max: 1 },
-        { min: 0, max: 2 },
-        { min: -1, max: 1 },
-        { min: 1, max: 1.5 },
-        { min: 0, max: 10 },
-      ],
-      err: 1,
-    },
-  ]
 
   describe.each(shapes)('$name', ({ bounds, err }) => {
     test.each(['upper', 'lower'] as const)('%s bound', (direction) => {
@@ -318,5 +319,76 @@ describe('isFeasible', () => {
   test('tolerates violations within `zero`', () => {
     expect(isFeasible(Ab, [1, 1 + 1e-9])).toBe(true)
     expect(isFeasible(Ab, [1, 1 + 1e-6])).toBe(false)
+  })
+})
+
+describe('solveLPBland', () => {
+  // Multiple optima are common in these fixtures, and Bland's rule may land on a different
+  //   vertex than `solveLP` does, so only the objective value is asserted.
+  test.each(cases)('solves $name', ({ c, Ab, obj }) => {
+    const xOpt = solveLPBland(c, Ab)
+    expect(isFeasible(Ab, xOpt)).toBe(true)
+    expect(objective(c, xOpt)).toBeCloseTo(obj, 8)
+    expect(objective(c, xOpt)).toBeCloseTo(bruteForceMin(c, Ab), 8)
+  })
+
+  test('detects infeasible problems', () => {
+    expect(() => solveLPBland([1, 1], [[1, 0, -1]])).toThrow(/INFEASIBLE/)
+  })
+  test('detects unbounded problems', () => {
+    expect(() => solveLPBland([-1, 0], [[-1, 0, 0]])).toThrow(/UNBOUNDED/)
+  })
+
+  // The case `solveLP` cycles on; this is the solver it hands off to
+  test.each([
+    'upper',
+    'lower',
+  ] as const)('solves the reported %s bound outright', (direction) => {
+    const { cons, objective, nVar } = monomialLP(reported, direction)
+    const soln = solveLPBland(objective, cons)
+    expect(isFeasible(cons, soln)).toBe(true)
+    expect(soln[nVar + 1]).toBeCloseTo(0.332591421396, 8)
+  })
+
+  describe.each(shapes)('$name', ({ bounds, err }) => {
+    test.each(['upper', 'lower'] as const)('%s bound', (direction) => {
+      const { cons, objective, nVar } = monomialLP(bounds, direction)
+      const soln = solveLPBland(objective, cons)
+      expect(isFeasible(cons, soln)).toBe(true)
+      expect(soln[nVar + 1]).toBeCloseTo(err, 8)
+    })
+  })
+
+  test('matches brute force on random small LPs', () => {
+    let seed = 20240607 // Same problems the `solveLP` fuzz test uses
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    const randInt = (lo: number, hi: number) =>
+      lo + Math.floor(rand() * (hi - lo + 1))
+
+    let solved = 0
+    for (let trial = 0; trial < 200; trial++) {
+      const nVar = randInt(2, 3),
+        nCons = randInt(3, 5)
+      const c = Array.from({ length: nVar }, () => randInt(-10, 10))
+      const Ab = Array.from({ length: nCons }, () => [
+        ...Array.from({ length: nVar }, () => randInt(-10, 10)),
+        randInt(0, 10),
+      ])
+
+      let xOpt: number[]
+      try {
+        xOpt = solveLPBland(c, Ab)
+      } catch (e) {
+        expect((e as Error).message).toMatch(/INFEASIBLE|UNBOUNDED/)
+        continue
+      }
+      solved++
+      expect(isFeasible(Ab, xOpt)).toBe(true)
+      expect(objective(c, xOpt)).toBeCloseTo(bruteForceMin(c, Ab), 6)
+    }
+    expect(solved).toBe(165) // Same count `solveLP` reaches on this seed
   })
 })

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.ts
@@ -1,7 +1,11 @@
+import { solveLPBland } from './solveLPBland.js'
+
 // Matrix convention is row-major, indexed A_{ij} = A[i][j]
 type Pivot = { i: number; j: number }
-type Cmp = { b: number[]; a: number } // Pivot rule on lexicographically smallest (b / a) vector
-const zero = 1e-8 // Small number equivalent to 0 for numerical instability
+export const zero = 1e-8 // Small number equivalent to 0 for numerical instability
+
+// Degenerate pivots leave the objective untouched, so a long enough run of them means we are cycling.
+const maxDegeneratePivots = 16
 
 /** Checks that all constraints are satisfied (Ax <= b) */
 export function isFeasible(Ab: number[][], x: number[]): boolean {
@@ -21,8 +25,8 @@ export function isFeasible(Ab: number[][], x: number[]): boolean {
  * Implemented according to the Simplex Method (Sec 4) of:
  *   Ferguson, https://www.math.ucla.edu/~tom/LP.pdf
  *
- * Does not implement any cycle detection, though that *shouldnt* be a problem for GO's use
- *   case. This algorithm will always return a feasible solution, though it may be suboptimal.
+ * The pivot rules here can cycle on degenerate problems. When that is detected, the problem is
+ *   handed to `solveLPBland`, whose rule is slower but provably terminates.
  *
  * @param c        Objective vector
  * @param Ab       Constraints matrix with thresholds. Inputted in block form [A, b]
@@ -34,12 +38,9 @@ export function solveLP(c: number[], Ab: number[][]) {
 
   const tableau = Array(rows)
     .fill(0)
-    .map((_) => Array(cols + Ab.length).fill(0))
+    .map((_) => Array(cols).fill(0))
   Ab.forEach((Ai, i) => Ai.forEach((Aij, j) => (tableau[i][j] = Aij)))
   c.forEach((cj, j) => (tableau[rows - 1][j] = cj))
-  Array(Ab.length)
-    .fill(0)
-    .forEach((_, i) => (tableau[i][cols + i] = 1)) // lexicographic tracking
 
   const pivotHistory: Pivot[] = [] // Keep track of all chosen pivots for backtracking later
 
@@ -49,8 +50,14 @@ export function solveLP(c: number[], Ab: number[][]) {
     pivotInplace(tableau, piv)
   }
 
+  let degenerate = 0
   while (tableau[rows - 1].some((t, j) => j < cols - 1 && t < -zero)) {
     const piv = findPiv1(tableau)
+    // The objective improves on every pivot except those in a row whose threshold is 0
+    //   (Ferguson p24), so an unbroken run of those means this is a cycle rather than progress.
+    if (Math.abs(tableau[piv.i][cols - 1]) <= zero) {
+      if (++degenerate > maxDegeneratePivots) return solveLPBland(c, Ab)
+    } else degenerate = 0
     pivotHistory.push(piv)
     pivotInplace(tableau, piv)
   }
@@ -61,7 +68,7 @@ export function solveLP(c: number[], Ab: number[][]) {
 }
 
 /** Standard `pivot` operation on LPs */
-function pivotInplace(A: number[][], { i, j }: Pivot) {
+export function pivotInplace(A: number[][], { i, j }: Pivot) {
   const Aij = A[i][j]
   for (let h = 0; h < A.length; h++) {
     if (h === i) continue
@@ -84,14 +91,14 @@ function pivotInplace(A: number[][], { i, j }: Pivot) {
 /** Find a pivot according to Case 1 (Ferguson p23) */
 function findPiv1(A: number[][]) {
   const r = A.length,
-    c = A[0].length - r + 1
-  let minloc = { i: -1, j: -1, cmp: { b: [Number.POSITIVE_INFINITY], a: 1 } }
+    c = A[0].length
+  let minloc = { i: -1, j: -1, cmp: Number.POSITIVE_INFINITY }
   for (let j = 0; j < c - 1; j++) {
     if (A[r - 1][j] >= -zero) continue
     for (let i = 0; i < r - 1; i++) {
       if (A[i][j] > zero) {
-        const cmp = { b: A[i].slice(c - 1), a: A[i][j] }
-        if (lt(cmp, minloc.cmp)) minloc = { i, j, cmp }
+        const cmp = A[i][c - 1] / A[i][j]
+        if (cmp < minloc.cmp) minloc = { i, j, cmp }
       }
     }
 
@@ -104,14 +111,14 @@ function findPiv1(A: number[][]) {
 /** Find a pivot according to Case 2 (Ferguson p24) */
 function findPiv2(A: number[][]) {
   const r = A.length,
-    c = A[0].length - r + 1
-  let minloc = { i: -1, j: -1, cmp: { b: [Number.POSITIVE_INFINITY], a: 1 } }
+    c = A[0].length
+  let minloc = { i: -1, j: -1, cmp: Number.POSITIVE_INFINITY }
   for (let i = 0; i < r - 1; i++) {
     if (A[i][c - 1] >= -zero) continue
     for (let j = 0; j < c - 1; j++) {
       if (A[i][j] < -zero) {
-        const cmp = { b: A[i].slice(c - 1), a: A[i][j] }
-        if (lt(cmp, minloc.cmp)) minloc = { i, j, cmp }
+        const cmp = A[i][c - 1] / A[i][j]
+        if (cmp < minloc.cmp) minloc = { i, j, cmp }
       }
     }
 
@@ -134,15 +141,6 @@ function backtrack(tableau: number[][], pivotHistory: Pivot[], targ: number) {
     }
   })
 
-  const bCol = tableau[0].length - tableau.length + 1
-  return side === 0 ? tableau[targ][bCol - 1] : 0
-}
-
-/** Lexicographic comparator (less than) */
-function lt(a: Cmp, b: Cmp) {
-  const len = Math.min(a.b.length, b.b.length)
-  for (let i = 0; i < len; i++) {
-    if (a.b[i] / a.a !== b.b[i] / b.a) return a.b[i] / a.a < b.b[i] / b.a
-  }
-  return false
+  const ncol = tableau[0].length
+  return side === 0 ? tableau[targ][ncol - 1] : 0
 }

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLP.ts
@@ -1,5 +1,6 @@
 // Matrix convention is row-major, indexed A_{ij} = A[i][j]
 type Pivot = { i: number; j: number }
+type Cmp = { b: number[]; a: number } // Pivot rule on lexicographically smallest (b / a) vector
 const zero = 1e-8 // Small number equivalent to 0 for numerical instability
 
 /** Checks that all constraints are satisfied (Ax <= b) */
@@ -33,9 +34,12 @@ export function solveLP(c: number[], Ab: number[][]) {
 
   const tableau = Array(rows)
     .fill(0)
-    .map((_) => Array(cols).fill(0))
+    .map((_) => Array(cols + Ab.length).fill(0))
   Ab.forEach((Ai, i) => Ai.forEach((Aij, j) => (tableau[i][j] = Aij)))
   c.forEach((cj, j) => (tableau[rows - 1][j] = cj))
+  Array(Ab.length)
+    .fill(0)
+    .forEach((_, i) => (tableau[i][cols + i] = 1)) // lexicographic tracking
 
   const pivotHistory: Pivot[] = [] // Keep track of all chosen pivots for backtracking later
 
@@ -80,14 +84,14 @@ function pivotInplace(A: number[][], { i, j }: Pivot) {
 /** Find a pivot according to Case 1 (Ferguson p23) */
 function findPiv1(A: number[][]) {
   const r = A.length,
-    c = A[0].length
-  let minloc = { i: -1, j: -1, cmp: Number.POSITIVE_INFINITY }
+    c = A[0].length - r + 1
+  let minloc = { i: -1, j: -1, cmp: { b: [Number.POSITIVE_INFINITY], a: 1 } }
   for (let j = 0; j < c - 1; j++) {
     if (A[r - 1][j] >= -zero) continue
     for (let i = 0; i < r - 1; i++) {
       if (A[i][j] > zero) {
-        const cmp = A[i][c - 1] / A[i][j]
-        if (cmp < minloc.cmp) minloc = { i, j, cmp }
+        const cmp = { b: A[i].slice(c - 1), a: A[i][j] }
+        if (lt(cmp, minloc.cmp)) minloc = { i, j, cmp }
       }
     }
 
@@ -100,14 +104,14 @@ function findPiv1(A: number[][]) {
 /** Find a pivot according to Case 2 (Ferguson p24) */
 function findPiv2(A: number[][]) {
   const r = A.length,
-    c = A[0].length
-  let minloc = { i: -1, j: -1, cmp: Number.POSITIVE_INFINITY }
+    c = A[0].length - r + 1
+  let minloc = { i: -1, j: -1, cmp: { b: [Number.POSITIVE_INFINITY], a: 1 } }
   for (let i = 0; i < r - 1; i++) {
     if (A[i][c - 1] >= -zero) continue
     for (let j = 0; j < c - 1; j++) {
       if (A[i][j] < -zero) {
-        const cmp = A[i][c - 1] / A[i][j]
-        if (cmp < minloc.cmp) minloc = { i, j, cmp }
+        const cmp = { b: A[i].slice(c - 1), a: A[i][j] }
+        if (lt(cmp, minloc.cmp)) minloc = { i, j, cmp }
       }
     }
 
@@ -130,6 +134,15 @@ function backtrack(tableau: number[][], pivotHistory: Pivot[], targ: number) {
     }
   })
 
-  const ncol = tableau[0].length
-  return side === 0 ? tableau[targ][ncol - 1] : 0
+  const bCol = tableau[0].length - tableau.length + 1
+  return side === 0 ? tableau[targ][bCol - 1] : 0
+}
+
+/** Lexicographic comparator (less than) */
+function lt(a: Cmp, b: Cmp) {
+  const len = Math.min(a.b.length, b.b.length)
+  for (let i = 0; i < len; i++) {
+    if (a.b[i] / a.a !== b.b[i] / b.a) return a.b[i] / a.a < b.b[i] / b.a
+  }
+  return false
 }

--- a/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLPBland.ts
+++ b/libs/gi/solver/src/GOSolver/BNBSplitWorker/solveLPBland.ts
@@ -1,0 +1,84 @@
+import { isFeasible, pivotInplace, zero } from './solveLP.js'
+
+/**
+ * Solve the same Linear Program as `solveLP`, using Bland's Smallest-Subscript Rule (Sec 6) of:
+ *   Ferguson, https://www.math.ucla.edu/~tom/LP.pdf
+ *
+ * Pivots are chosen by the *subscript of the variable* entering/leaving the basis rather than by
+ * ratio alone, which is slower than the usual rules but provably cannot cycle. `solveLP` falls
+ * back to this when it detects that it is cycling.
+ *
+ * @param c        Objective vector
+ * @param Ab       Constraints matrix with thresholds. Inputted in block form [A, b]
+ * @returns        the optimal solution x
+ */
+export function solveLPBland(c: number[], Ab: number[][]) {
+  const nCons = Ab.length,
+    nVar = Ab[0].length - 1 // Last column of `Ab` holds the thresholds `b`
+  const tableau = Array(nCons + 1)
+    .fill(0)
+    .map((_) => Array(nVar + 1).fill(0))
+  Ab.forEach((Ai, i) => Ai.forEach((Aij, j) => (tableau[i][j] = Aij)))
+  c.forEach((cj, j) => (tableau[nCons][j] = cj))
+
+  // Which variable currently sits in each column (nonbasic) and row (basic). Slack variables
+  // are numbered after the `nVar` problem variables. Pivoting swaps the two labels.
+  const colVar = Array(nVar)
+    .fill(0)
+    .map((_, j) => j)
+  const rowVar = Array(nCons)
+    .fill(0)
+    .map((_, i) => nVar + i)
+
+  const pivot = (i: number, j: number) => {
+    pivotInplace(tableau, { i, j })
+    const swap = rowVar[i]
+    rowVar[i] = colVar[j]
+    colVar[j] = swap
+  }
+
+  // Phase 1: pivot the first infeasible row feasible, entering the smallest-subscript variable
+  for (;;) {
+    const row = tableau.findIndex((t, i) => i < nCons && t[nVar] < -zero)
+    if (row < 0) break
+
+    let piv = -1
+    for (let j = 0; j < nVar; j++)
+      if (tableau[row][j] < -zero && (piv < 0 || colVar[j] < colVar[piv]))
+        piv = j
+    if (piv < 0) throw Error('INFEASIBLE')
+    pivot(row, piv)
+  }
+
+  // Phase 2: enter the smallest-subscript improving variable, leave by ratio test with
+  //   smallest-subscript tie-breaking. Both halves are what makes cycling impossible.
+  for (;;) {
+    let enter = -1
+    for (let j = 0; j < nVar; j++)
+      if (tableau[nCons][j] < -zero && (enter < 0 || colVar[j] < colVar[enter]))
+        enter = j
+    if (enter < 0) break
+
+    let leave = -1,
+      ratio = Number.POSITIVE_INFINITY
+    for (let i = 0; i < nCons; i++) {
+      if (tableau[i][enter] <= zero) continue
+      const cmp = tableau[i][nVar] / tableau[i][enter]
+      if (cmp < ratio - zero) {
+        ratio = cmp
+        leave = i
+      } else if (cmp < ratio + zero && leave >= 0 && rowVar[i] < rowVar[leave])
+        leave = i
+    }
+    if (leave < 0) throw Error('UNBOUNDED FEASIBLE')
+    pivot(leave, enter)
+  }
+
+  // The labels say where each variable ended up instead of backtracking
+  const xOpt = c.map((_) => 0)
+  rowVar.forEach((v, i) => {
+    if (v < c.length) xOpt[v] = tableau[i][nVar]
+  })
+  if (!isFeasible(Ab, xOpt)) throw Error('COMPUTED SOLUTION IS NOT FEASIBLE')
+  return xOpt
+}


### PR DESCRIPTION
## Describe your changes

Fix an old LP solver bug (we used to ignore cycles since they're rare). Added `solveLPBland()` which uses Bland's pivoting rules to avoid cycles, though it runs ~50-100% slower. When the original solver detects that it's stuck in a cycle, it switches to using Bland's method.

Added an AI-written `solveLP.test.ts` file including the reported hang/crash to ensure we actually caught it. In reality I expect solveLPBland() to be called 0% of the time.

## Issue or discord link

- [discord link](https://ptb.discord.com/channels/785153694478893126/1541055919356514415)

## Testing/validation

The stuck config now solves in PR.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linear programming reliability by detecting degenerate pivot sequences and using an alternate solving strategy to avoid cycling.
  - Added clearer handling for infeasible and unbounded optimization problems.
  - Preserved feasibility validation and numerical tolerance behavior for more dependable results.

- **Tests**
  - Expanded coverage for bounded, infeasible, unbounded, degenerate, randomized, and edge-case optimization scenarios.
  - Added regression tests for cycling and bound-generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->