### PR TITLE
Sandrone fixes

### DIFF
--- a/libs/gi/sheets/src/Characters/Sandrone/index.tsx
+++ b/libs/gi/sheets/src/Characters/Sandrone/index.tsx
@@ -373,7 +373,8 @@ const dmgFormulas = {
           percent(dm.constellation6.dmg2),
           'atk',
           'stellarconduct',
-          'cryo'
+          'cryo',
+          beamAddl
         )
       )
     ),
@@ -387,7 +388,8 @@ const dmgFormulas = {
           percent(dm.constellation6.ssDmg),
           'atk',
           'stellarswirl',
-          'cryo'
+          'cryo',
+          beamAddl
         )
       )
     ),

--- a/libs/gi/sheets/src/Characters/Sandrone/index.tsx
+++ b/libs/gi/sheets/src/Characters/Sandrone/index.tsx
@@ -698,7 +698,7 @@ const sheet: TalentSheet = {
           }),
         },
         {
-          node: infoMut(dmgFormulas.constellation4.dmg, {
+          node: infoMut(dmgFormulas.constellation4.ssDmg, {
             name: ct.ch('c4StellarSwirlDmg'),
           }),
         },


### PR DESCRIPTION
## Describe your changes

Fix Sandrone C6 not benefiting from C2
Fix Sandrone C4 UI glitch

## Issue or discord link

https://github.com/frzyc/genshin-optimizer/issues/3299
https://github.com/frzyc/genshin-optimizer/issues/3304

## Testing/validation

[GO - Sandrone C4 UI glitch fixed - YouTube](https://www.youtube.com/watch?v=8OF3hrnjqf4)

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [ ] I have commented my code in hard-to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [ ] For front-end changes, I have updated the corresponding English translations.
- [x] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Sandrone’s C6 stellarconduct and stellarswirl damage calculations to include applicable bonus modifiers.
  * Corrected the Constellation 4 talent display to show the appropriate stellarswirl damage value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->