### PR TITLE
fix: exclude filtered-out unactivated substats from max RV

### DIFF
--- a/libs/gi/util/src/artifact/artifact.test.ts
+++ b/libs/gi/util/src/artifact/artifact.test.ts
@@ -1,6 +1,12 @@
+import type { SubstatKey } from '@genshin-optimizer/gi/consts'
 import { artSubstatRollData } from '@genshin-optimizer/gi/consts'
+import type { IArtifact } from '@genshin-optimizer/gi/good'
 import { allStats } from '@genshin-optimizer/gi/stats'
-import { getSubstatEfficiency, getSubstatRolls } from './artifact'
+import {
+  getArtifactEfficiency,
+  getSubstatEfficiency,
+  getSubstatRolls,
+} from './artifact'
 
 const artifactSubstatRoll = allStats.art.subRoll
 describe('Substat Rolls/efficiency', () => {
@@ -96,6 +102,90 @@ describe('Substat Rolls/efficiency', () => {
       )
       expect(getSubstatEfficiency('def_', [-1])).toEqual(0)
       expect(getSubstatEfficiency('', [-1])).toEqual(0)
+    })
+  })
+
+  describe('getArtifactEfficiency()', () => {
+    const baseArtifact: IArtifact = {
+      setKey: 'GladiatorsFinale',
+      rarity: 5,
+      level: 0,
+      slotKey: 'flower',
+      mainStatKey: 'hp',
+      location: '',
+      lock: false,
+      substats: [],
+    }
+    const usefulFilter = new Set<SubstatKey>([
+      'critRate_',
+      'critDMG_',
+      'atk_',
+      'enerRech_',
+    ])
+
+    test('should not count substats that are excluded by the filter', () => {
+      // +0 artifact whose 4 known substats are all excluded by the filter.
+      // The unactivated 4th line has a known key, so no upgrade can roll into
+      // a useful stat: max efficiency should be 0.
+      // https://github.com/frzyc/genshin-optimizer/issues/3152
+      const artifact: IArtifact = {
+        ...baseArtifact,
+        substats: [
+          { key: 'def_', value: 0 },
+          { key: 'def', value: 0 },
+          { key: 'hp_', value: 0 },
+          { key: '', value: 0 },
+        ],
+        unactivatedSubstats: [{ key: 'eleMas', value: 21 }],
+      }
+      const { currentEfficiency, maxEfficiency } = getArtifactEfficiency(
+        artifact,
+        usefulFilter
+      )
+      expect(currentEfficiency).toBe(0)
+      expect(maxEfficiency).toBe(0)
+    })
+
+    test('should count an unactivated substat towards max efficiency when selected by the filter', () => {
+      const artifact: IArtifact = {
+        ...baseArtifact,
+        substats: [
+          { key: 'critRate_', value: 3.9 },
+          { key: 'critDMG_', value: 7.8 },
+          { key: 'atk_', value: 5.8 },
+          { key: '', value: 0 },
+        ],
+        unactivatedSubstats: [{ key: 'eleMas', value: 23 }],
+      }
+      const filter = new Set<SubstatKey>([...usefulFilter, 'eleMas'])
+      const { currentEfficiency, maxEfficiency } = getArtifactEfficiency(
+        artifact,
+        filter
+      )
+      // 3 current max rolls + the unactivated EM line (1 max roll) + the 4
+      // remaining upgrades at max roll value.
+      expect(currentEfficiency).toBeCloseTo(3)
+      expect(maxEfficiency).toBeCloseTo(8)
+    })
+
+    test('should count potential rolls into empty slots for a 3-liner', () => {
+      const artifact: IArtifact = {
+        ...baseArtifact,
+        substats: [
+          { key: 'critRate_', value: 3.9 },
+          { key: 'critDMG_', value: 7.8 },
+          { key: 'atk_', value: 5.8 },
+          { key: '', value: 0 },
+        ],
+      }
+      const { currentEfficiency, maxEfficiency } = getArtifactEfficiency(
+        artifact,
+        usefulFilter
+      )
+      // 3 current max rolls + 1 roll to unlock the 4th line + the 4 remaining
+      // upgrades at max roll value.
+      expect(currentEfficiency).toBeCloseTo(3)
+      expect(maxEfficiency).toBeCloseTo(8)
     })
   })
 })

--- a/libs/gi/util/src/artifact/artifact.ts
+++ b/libs/gi/util/src/artifact/artifact.ts
@@ -172,6 +172,15 @@ const maxSubstatRollEfficiency = objKeyMap(allArtifactRarityKeys, (rarity) =>
   )
 )
 
+/**
+ * Computes the current and maximum possible substat efficiency ("Roll Value")
+ * of an artifact, relative to the given `filter` of useful substat keys.
+ *
+ * `currentEfficiency` sums the efficiency of the substats that already match
+ * the filter. `maxEfficiency` additionally counts the remaining upgrades as
+ * if they all roll into matched (or unlockable, filter-matched) slots. An
+ * unactivated substat is only counted when its key is selected by the filter.
+ */
 export function getArtifactEfficiency(
   artifact: IArtifact,
   filter: Set<SubstatKey> = new Set(allSubstatKeys)

--- a/libs/gi/util/src/artifact/artifact.ts
+++ b/libs/gi/util/src/artifact/artifact.ts
@@ -188,11 +188,24 @@ export function getArtifactEfficiency(
   )
 
   const rollsRemaining = getRollsRemaining(level, rarity)
-  const emptySlotCount = substats.filter((s) => !s.key).length
+  // An unactivated substat (the dimmed 4th line of an artifact below +4) is
+  // stored outside of `substats`, but it still occupies the fourth substat
+  // slot: the slot is not empty, since the line already has a known key and
+  // can never be unlocked into a different stat.
+  const hasUnactivatedSubstat = !!unactivatedSubstats?.some(({ key }) => key)
+  const emptySlotCount = Math.max(
+    0,
+    substats.filter((s) => !s.key).length - (hasUnactivatedSubstat ? 1 : 0)
+  )
 
-  const matchedSlotCount = substats.filter(
-    (s) => s.key && filter.has(s.key)
-  ).length
+  const matchedUnactivatedSubstat =
+    hasUnactivatedSubstat &&
+    unactivatedSubstats!.some(({ key }) => key && filter.has(key))
+      ? 1
+      : 0
+  const matchedSlotCount =
+    substats.filter((s) => s.key && filter.has(s.key)).length +
+    matchedUnactivatedSubstat
   const unusedFilterCount =
     filter.size -
     matchedSlotCount -
@@ -200,8 +213,12 @@ export function getArtifactEfficiency(
   const unactivatedSubstatRoll =
     unactivatedSubstats?.filter((s) => s.key).length ?? 0
 
-  let maxEfficiency =
-    currentEfficiency + (artifactMeta.unactivatedSubstats[0]?.efficiency ?? 0)
+  let maxEfficiency = currentEfficiency
+  // The value of the unactivated substat only counts towards max efficiency
+  // when its stat is selected by the filter.
+  const unactivatedSubstatKey = unactivatedSubstats?.find(({ key }) => key)?.key
+  if (unactivatedSubstatKey && filter.has(unactivatedSubstatKey))
+    maxEfficiency += artifactMeta.unactivatedSubstats[0]?.efficiency ?? 0
   const maxRollEff = maxSubstatRollEfficiency[rarity]
   // Rolls into good empty slots, assuming max-level artifacts have no empty slots
   maxEfficiency += maxRollEff * Math.min(emptySlotCount, unusedFilterCount)


### PR DESCRIPTION
## Describe your changes

Fix the Max. Roll Value calculation for low-level artifacts whose unactivated substat (the dimmed 4th line of an artifact below +4) is not selected by the artifact filter.

`getArtifactEfficiency` previously:

- added the unactivated substat's value to `maxEfficiency` regardless of whether its stat is selected by the filter
- treated the unactivated line's slot as an empty slot that could unlock into a useful stat, even though it already has a known key
- allowed the "rolls into existing slots" term to fire when no existing slot matched the filter

This made a +0 artifact whose 4 known substats are all excluded by the filter report ~490% Max. RV instead of 0%.

## Issue or discord link

- https://github.com/frzyc/genshin-optimizer/issues/3152

## Testing/validation

- Added unit tests in `libs/gi/util/src/artifact/artifact.test.ts`:
  - regression test for the issue scenario (all known substats excluded by the filter -> current and max efficiency are 0), which fails on the previous implementation with ~4.9 max efficiency
  - an unactivated substat selected by the filter still counts towards max efficiency
  - a plain 3-liner still counts the unlock roll and the remaining upgrades
- `yarn nx test gi-util` passes locally.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact efficiency calculations to accurately account for unactivated substats.
  * Updated maximum efficiency and available-slot calculations for artifacts with unactivated stats.
  * Matching unactivated substats now count toward matched stats when included in the selected filter.
* **Tests**
  * Added coverage for filtered substats, unactivated substats, and potential rolls on three-line artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->