### PR TITLE
feat: auto-focus newly added target in multi-opt

### DIFF
--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
@@ -67,6 +67,10 @@ export default function CustomMultiTargetCard({
     setTargetProp(target)
   }, [onHide, setTargetProp, target])
 
+  /**
+   * Appends a new custom target (optionally with `multi` variants) and
+   * selects it, so the newly added target is immediately shown for editing.
+   */
   const addTarget = useCallback(
     (t: string[], multi?: number) => {
       const target_ = { ...target }

--- a/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
+++ b/libs/gi/page-team/src/CharacterDisplay/CustomMultiTarget/CustomMultiTargetCard.tsx
@@ -72,6 +72,7 @@ export default function CustomMultiTargetCard({
       const target_ = { ...target }
       target_.targets = [...target_.targets, initCustomTarget(t, multi)]
       setTarget(target_)
+      setSelectedTarget(target_.targets.length - 1)
     },
     [target, setTarget]
   )


### PR DESCRIPTION
## Describe your changes

When a new target is added to a multi-target card in the optimize tab, the target editor below keeps showing the previously selected target (or nothing), so the user has to click the new target to start editing it. Newly added targets are now focused by default.

`addTarget` in `CustomMultiTargetCard` now selects the newly added target, which immediately shows it in the target editor below the list.

## Issue or discord link

- https://github.com/frzyc/genshin-optimizer/issues/2907

## Testing/validation

- Behavior verified by code inspection; the change mirrors the approach of the earlier draft PR #3244 (closed unmerged).
- No new UI strings were added, so no translation changes are needed.

## Checklist before requesting a review (leave this PR as draft if any part of this list is not done.)

- [x] I have commented my code in hard to understand areas.
- [ ] I have made corresponding changes to README or wiki.
- [x] For front-end changes, I have updated the corresponding English translations.
- [ ] I have run `yarn run mini-ci` locally to validate format and lint.
- [ ] If I have added a new library or app, I have updated the deployment scripts to ignore changes as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly added custom targets are now automatically selected and highlighted for immediate editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->